### PR TITLE
Add bad_route page as redirect for invalid routes to Cerner's FHIR Serve...

### DIFF
--- a/content/bad_route.md
+++ b/content/bad_route.md
@@ -1,0 +1,14 @@
+---
+title: Cerner | Bad Route
+layout: overview
+---
+
+<div class="wrapper feature">
+  <h1>
+    We notice you're trying to call our FHIR<br/>
+    server but your request is to a bad route.
+  </h1>
+  <p class="intro">Please read our documentation here to see how to make a valid request.</p>
+  <a href="/dstu1/" class="button">Browse the documentation</a>
+  <img src="/images/fhir.png" class="fhirlogo" alt="FHIR" />
+</div>

--- a/content/index.md
+++ b/content/index.md
@@ -12,24 +12,3 @@ layout: overview
   <a href="/dstu1/" class="button">Browse the documentation</a>
   <img src="/images/fhir.png" class="fhirlogo" alt="FHIR" />
 </div>
-
-<div class="full-width-divider">
-  <ul class="wrapper highlights">
-    <li class="highlight-module">
-      <a href="http://www.hl7.org/implement/standards/fhir/summary.html"><span class="mega-octicon octicon-file-text"></span></a>
-      <h2><a href="http://www.hl7.org/implement/standards/fhir/summary.html">Get Started</a></h2>
-      <p>New to the FHIR API? Have a look at HL7's <a href="http://www.hl7.org/implement/standards/fhir/summary.html">Summary</a>
-       and <a href="http://www.hl7.org/implement/standards/fhir/overview.html">Overview</a>.</p>
-    </li>
-    <li class="highlight-module">
-      <a href="http://wiki.hl7.org/index.php?title=Open_Source_FHIR_implementations"><span class="mega-octicon octicon-code"></span></a>
-      <h2><a href="http://wiki.hl7.org/index.php?title=Open_Source_FHIR_implementations">Libraries</a></h2>
-      <p>Check out a number of <a href="http://wiki.hl7.org/index.php?title=Open_Source_FHIR_implementations">Open Source FHIR Implementations</a>.</p>
-    </li>
-    <li class="highlight-module">
-      <a href="https://groups.google.com/d/forum/cerner-fhir-developers"><span class="mega-octicon octicon-mail-read"></span></a>
-      <h2><a href="https://groups.google.com/d/forum/cerner-fhir-developers">Support</a></h2>
-      <p>Are you stuck? Talk to <a href="https://groups.google.com/d/forum/cerner-fhir-developers">Cerner support</a>.</p>
-    </li>
-  </ul>
-</div>

--- a/layouts/highlights.html
+++ b/layouts/highlights.html
@@ -1,0 +1,20 @@
+<div class="full-width-divider">
+    <ul class="wrapper highlights">
+        <li class="highlight-module">
+            <a href="http://www.hl7.org/implement/standards/fhir/summary.html"><span class="mega-octicon octicon-file-text"></span></a>
+            <h2><a href="http://www.hl7.org/implement/standards/fhir/summary.html">Get Started</a></h2>
+            <p>New to the FHIR API? Have a look at HL7's <a href="http://www.hl7.org/implement/standards/fhir/summary.html">Summary</a>
+                and <a href="http://www.hl7.org/implement/standards/fhir/overview.html">Overview</a>.</p>
+        </li>
+        <li class="highlight-module">
+            <a href="http://wiki.hl7.org/index.php?title=Open_Source_FHIR_implementations"><span class="mega-octicon octicon-code"></span></a>
+            <h2><a href="http://wiki.hl7.org/index.php?title=Open_Source_FHIR_implementations">Libraries</a></h2>
+            <p>Check out a number of <a href="http://wiki.hl7.org/index.php?title=Open_Source_FHIR_implementations">Open Source FHIR Implementations</a>.</p>
+        </li>
+        <li class="highlight-module">
+            <a href="https://groups.google.com/d/forum/cerner-fhir-developers"><span class="mega-octicon octicon-mail-read"></span></a>
+            <h2><a href="https://groups.google.com/d/forum/cerner-fhir-developers">Support</a></h2>
+            <p>Are you stuck? Talk to <a href="https://groups.google.com/d/forum/cerner-fhir-developers">Cerner support</a>.</p>
+        </li>
+    </ul>
+</div>

--- a/layouts/overview.html
+++ b/layouts/overview.html
@@ -5,6 +5,8 @@
 
   <%= yield %>
 
+  <%= render 'highlights' %>
+
   <%= render 'footer' %>
 </body>
 </html>


### PR DESCRIPTION
...r.

When new users are trying Cerner's FHIR server url and may navigate to the tenant/application root in their browsers, this bad_route page serves as a redirect location.  The change under review migrates the highlights div to its own layout so that the homepage and the bad_route page are essentially the same, but with a different message.

To view:
1. Checkout the ServerRedirectPage branch
2. bundle install
3. run nanoc to generate static content
4. run 'nanoc view' and hit http://localhost:3000/bad_route/ to view page

Separate pull request will be sent for generated changes to gh-pages branch.