### PR TITLE
Use FHIR parameter types and link to FHIR documentation.

### DIFF
--- a/content/dstu1/allergy-intolerance.md
+++ b/content/dstu1/allergy-intolerance.md
@@ -15,9 +15,9 @@ Search for AllergyIntolerances that meet supplied query parameters:
 
 ### Parameters
 
-Name | Type | Description
------|------|--------------
-`subject:Patient`|`string`| The patient who has the allergy or intolerance. Example: `12345`
+ Name            | Type                                                                           | Description
+-----------------|--------------------------------------------------------------------------------|-----------------------------------------------------------------
+`subject:Patient`|[`reference`](http://www.hl7.org/implement/standards/fhir/search.html#reference)| The patient who has the allergy or intolerance. Example: `12345`
 
 ### Response
 

--- a/content/dstu1/condition.md
+++ b/content/dstu1/condition.md
@@ -15,9 +15,9 @@ Search for Conditions that meet supplied query parameters:
 
 ### Parameters
 
-Name | Type | Description
------|------|--------------
-`subject:Patient`|`string`| The patient who has the condition. Example: `12345`
+ Name            | Type                                                                           | Description
+-----------------|--------------------------------------------------------------------------------|----------------------------------------------------
+`subject:Patient`|[`reference`](http://www.hl7.org/implement/standards/fhir/search.html#reference)| The patient who has the condition. Example: `12345`
 
 ### Response
 

--- a/content/dstu1/diagnostic-report.md
+++ b/content/dstu1/diagnostic-report.md
@@ -15,9 +15,9 @@ Search for DiagnosticReports that meet supplied query parameters:
 
 ### Parameters
 
-Name | Type | Description
------|------|--------------
-`subject:Patient`|`string`| The subject of the report. Example: `12345`
+ Name            | Type                                                                           | Description
+-----------------|--------------------------------------------------------------------------------|--------------------------------------------
+`subject:Patient`|[`reference`](http://www.hl7.org/implement/standards/fhir/search.html#reference)| The subject of the report. Example: `12345`
 
 ### Response
 

--- a/content/dstu1/encounter.md
+++ b/content/dstu1/encounter.md
@@ -15,9 +15,9 @@ Search for Encounters that meet supplied query parameters:
 
 ### Parameters
 
-Name | Type | Description
------|------|--------------
-`subject:Patient`|`string`| The patient present at the encounter. Example: `12345`
+ Name            | Type                                                                           | Description
+-----------------|--------------------------------------------------------------------------------|-------------------------------------------------------
+`subject:Patient`|[`reference`](http://www.hl7.org/implement/standards/fhir/search.html#reference)| The patient present at the encounter. Example: `12345`
 
 ### Response
 

--- a/content/dstu1/immunization.md
+++ b/content/dstu1/immunization.md
@@ -15,9 +15,9 @@ Search for Immunizations that meet supplied query parameters:
 
 ### Parameters
 
-Name | Type | Description
------|------|--------------
-`subject:Patient`|`string`| The subject of the vaccination event / refusal. Example: `12345`
+ Name            | Type                                                                           | Description
+-----------------|--------------------------------------------------------------------------------|-----------------------------------------------------------------
+`subject:Patient`|[`reference`](http://www.hl7.org/implement/standards/fhir/search.html#reference)| The subject of the vaccination event / refusal. Example: `12345`
 
 ### Response
 

--- a/content/dstu1/medication-prescription.md
+++ b/content/dstu1/medication-prescription.md
@@ -15,9 +15,9 @@ Search for active MedicationPrescriptions that meet supplied query parameters:
 
 ### Parameters
 
-Name | Type | Description
------|------|--------------
-`patient`|`string`| The identity of a patient to list dispenses for. Example: `12345`
+ Name    | Type                                                                           | Description
+---------|--------------------------------------------------------------------------------|------------------------------------------------------------------
+`patient`|[`reference`](http://www.hl7.org/implement/standards/fhir/search.html#reference)| The identity of a patient to list dispenses for. Example: `12345`
 
 ### Response
 

--- a/content/dstu1/observation.md
+++ b/content/dstu1/observation.md
@@ -15,10 +15,9 @@ Search for labs, vitals, and alcohol/tobacco use Observations that meet supplied
 
 ### Parameters
 
-Name | Type | Description
------|------|--------------
-`subject:Patient`|`string`| The subject that the observation is about. Example: `12345`
-`name`|`string`| The name of the observation type. Example: `http://loinc.org|55284-4`
+ Name            | Type                                                                           | Description
+-----------------|--------------------------------------------------------------------------------|------------------------------------------------------------
+`subject:Patient`|[`reference`](http://www.hl7.org/implement/standards/fhir/search.html#reference)| The subject that the observation is about. Example: `12345`
 
 
 ### Response

--- a/content/dstu1/patient.md
+++ b/content/dstu1/patient.md
@@ -15,13 +15,13 @@ Search for Patients that meet supplied query parameters:
 
 ### Parameters
 
-Name | Type | Description
------|------|--------------
-`_id`|`string`| The logical resource id associated with the resource.
-`birthdate`|`date`| The patient's date of birth.  Example: `1961-01-16`
-`identifier`|`string`| A patient identifier.  Example: `01022228`
-`name`|`string`|  A portion of either family or given name of the patient. Example: `Peters`
-`telecom`|`string`| The value in any kind of telecom details of the patient. Example: `(816) 475-2374`
+ Name       | Type                                                                     | Description
+------------|--------------------------------------------------------------------------|-----------------------------------------------------------------------------------
+`_id`       |[`token`](http://www.hl7.org/implement/standards/fhir/search.html#token)  | The logical resource id associated with the resource.
+`birthdate` |[`date`](http://www.hl7.org/implement/standards/fhir/search.html#date)    | The patient's date of birth.  Example: `1961-01-16`
+`identifier`|[`token`](http://www.hl7.org/implement/standards/fhir/search.html#token)  | A patient identifier.  Example: `01022228`
+`name`      |[`string`](http://www.hl7.org/implement/standards/fhir/search.html#string)| A portion of either family or given name of the patient. Example: `Peters`
+`telecom`   |[`token`](http://www.hl7.org/implement/standards/fhir/search.html#token)  | The value in any kind of telecom details of the patient. Example: `(816) 475-2374`
 
 ### Response
 

--- a/content/dstu2/allergy-intolerance.md
+++ b/content/dstu2/allergy-intolerance.md
@@ -15,9 +15,9 @@ Search for AllergyIntolerances that meet supplied query parameters:
 
 ### Parameters
 
-Name | Type | Description
------|------|--------------
-`patient`|`string`| Who the sensitivity is for. Example: `12345`
+ Name    | Type                                                           | Description
+---------|----------------------------------------------------------------|---------------------------------------------
+`patient`|[`reference`](http://hl7.org/fhir/2015May/search.html#reference)| Who the sensitivity is for. Example: `12345`
 
 ### Response
 

--- a/content/dstu2/immunization.md
+++ b/content/dstu2/immunization.md
@@ -15,10 +15,10 @@ Search for Immunizations that meet supplied query parameters:
 
 ### Parameters
 
-Name | Type | Description
------|------|--------------
-`patient`|`string`| The patient for the vaccination record. Example: `12345`
-`subject`|`string`| The patient for the vaccination record. Example: `12345`
+ Name    | Type                                                           | Description
+---------|----------------------------------------------------------------|---------------------------------------------------------
+`patient`|[`reference`](http://hl7.org/fhir/2015May/search.html#reference)| The patient for the vaccination record. Example: `12345`
+`subject`|[`reference`](http://hl7.org/fhir/2015May/search.html#reference)| The patient for the vaccination record. Example: `12345`
 
 ### Response
 

--- a/content/dstu2/medication-prescription.md
+++ b/content/dstu2/medication-prescription.md
@@ -15,9 +15,9 @@ Search for active MedicationPrescriptions that meet supplied query parameters:
 
 ### Parameters
 
-Name | Type | Description
------|------|--------------
-`patient`|`string`| The identity of a patient to list dispenses for. Example: `12345`
+ Name    | Type                                                           | Description
+---------|----------------------------------------------------------------|------------------------------------------------------------------
+`patient`|[`reference`](http://hl7.org/fhir/2015May/search.html#reference)| The identity of a patient to list dispenses for. Example: `12345`
 
 ### Response
 

--- a/content/dstu2/patient.md
+++ b/content/dstu2/patient.md
@@ -15,15 +15,15 @@ Search for Patients that meet supplied query parameters:
 
 ### Parameters
 
-Name | Type | Description
------|------|--------------
-`_id`|`string`| The logical resource id associated with the resource.
-`birthdate`|`date`| The patient's date of birth.  Example: `1961-01-16`
-`identifier`|`string`| A patient identifier.  Example: `01022228`
-`name`|`string`|  A portion of either family or given name of the patient. Example: `Peters`
-`telecom`|`string`| The value in any kind of telecom details of the patient. Example: `(816) 475-2374`
-`start`|`numeric`| The offset to use when returning results. Defaults to `0`.
-`_count`|`numeric`| The maximum number of results to return. Defaults to `20`.
+ Name                                                    | Type                                                     | Description
+---------------------------------------------------------|----------------------------------------------------------|-----------------------------------------------------------------------------------
+`_id`                                                    |[`token`](http://hl7.org/fhir/2015May/search.html#token)  | The logical resource id associated with the resource.
+`birthdate`                                              |[`date`](http://hl7.org/fhir/2015May/search.html#date)    | The patient's date of birth.  Example: `1961-01-16`
+`identifier`                                             |[`token`](http://hl7.org/fhir/2015May/search.html#token)  | A patient identifier.  Example: `01022228`
+`name`                                                   |[`string`](http://hl7.org/fhir/2015May/search.html#string)| A portion of either family or given name of the patient. Example: `Peters`
+`telecom`                                                |[`token`](http://hl7.org/fhir/2015May/search.html#token)  | The value in any kind of telecom details of the patient. Example: `(816) 475-2374`
+`start`                                                  |[`number`](http://hl7.org/fhir/2015May/search.html#number)| The offset to use when returning results. Defaults to `0`.
+[`_count`](http://hl7.org/fhir/2015May/search.html#count)|[`number`](http://hl7.org/fhir/2015May/search.html#number)| The maximum number of results to return. Defaults to `20`.
 
 ### Response
 


### PR DESCRIPTION
Updated search parameter types across all existing pages to directly reflect FHIR types.  Also, removed 'name' from Observation DSTU 1 search parameters.