### PR TITLE
Establish FAQ section pattern and add FHIR Developers FAQ

### DIFF
--- a/Rules
+++ b/Rules
@@ -31,6 +31,14 @@ compile '/dstu1/*' do
   filter :relativize_paths, :type => :html
 end
 
+compile '/faq/*' do
+  filter :erb
+  filter :kramdown, :toc_levels => [2]
+  layout item[:layout] || 'faq'
+  filter :relativize_paths, :type => :css
+  filter :relativize_paths, :type => :html
+end
+
 compile '/may2015/*' do
   filter :erb
   filter :kramdown, :toc_levels => [2]

--- a/content/faq.md
+++ b/content/faq.md
@@ -1,0 +1,38 @@
+---
+title: FHIR FAQs
+---
+
+# Frequently Asked Questions
+
+* TOC
+{:toc}
+
+## FHIR Developer FAQs
+
+### What is Cerner's roadmap for FHIR implementation?
+
+Currently, resources published on [Cerner's FHIR Development](http://fhir.cerner.com/) web site use May2015 and are available to partners. Part of the roadmap is moving the May2015 resources forward to general availability, migrating to the recently released final Draft Standard for Trial Use 2, and helping provide feedback to the current draft of FHIR. Additionally, our roadmap is prioritized depending on maturity of the resources in FHIR (in other words, how stable they are considered), as well as the needs of our business partners. Some external forces, like Meaningful Use, also help determine the priorities and order for the FHIR resources we implement. If you would like to create a business partnership with us and help guide our roadmap, please complete the [SMART on FHIR Collaboration Request form](http://www.cerner.com/Smart_on_FHIR_Collaboration_Request_Form/?LangType=1033).
+
+### What is Cerner's Millennium Web Services toolkit?
+
+Millennium Web Services is an application programming interface (API) that exposes a set of Cerner Millennium business and application logic through person-centric web interfaces. Cerner's Millennium Web Services toolkit includes web services that provide access to a range of the clinical services that are available on the Cerner Millennium platform. These services include concepts around patient demographics, clinical results, clinical documentation, reporting, and scheduling. The Millennium Web Services are exposed using standard protocols (for example, SOAP, REST, and HTTPS).
+
+### What is the future of Millennium Web Services?
+
+With the emergence of the FHIR (Fast HealthCare Interoperability Resources) standard, we expect to migrate Millennium Web Services to the FHIR standard for all services that have a FHIR resource equivalent. Cerner expects that some of the services may never have FHIR equivalents, and so we will maintain those services in addition to the FHIR suite.
+
+### How will Cerner implement FHIR?
+
+Cerner is currently in the process of implementing FHIR to expose Cerner Millennium data to our clients and third-party developers. Cerner believes FHIR will become the public API that the JASON report and the JASON Task Force have called for. We believe FHIR, along with SMART and OAuth2, will enable Cerner Millennium to become an open electronic healthe record (EHR) platform that supports innovative developers.
+
+### With the FHIR implementation, what service and protocol is supported?
+
+The current FHIR implementation supports the REST API through the HTTPS protocol. Any application capable of making an HTTPS call can consume Cerner's FHIR resource suite. In testing, we have desktop, web, and mobile applications that consume our FHIR resource suite. We will support the SMART platform, OAuth2 authentication, and authorization profiles.
+
+### What are SMART apps and what is Cerner's position on usage with FHIR?
+
+The SMART (Substitutable Medical Apps & Reusable Technology) platform defines a specification for an EHR to safely and securely open other applications with context. These SMART applications are commonly web applications but may also be native mobile applications and will use FHIR to read and write data from the EHR. With SMART, Cerner can embed a SMART app in the EHR. Cerner believes that SMART applications will be a major user of FHIR resources. We will also support FHIR access through mobile SMART applications, as those specifications emerge from the [SMART](http://smartplatforms.org/) web site.
+
+### Where can I ask a question?
+
+A developer can post a question to the community using the [Cerner FHIR Developers](https://groups.google.com/forum/#!forum/cerner-fhir-developers) group.

--- a/content/index.md
+++ b/content/index.md
@@ -16,6 +16,6 @@ layout: overview
 <div class="full-width dev-program-callout">
   <div class="wrapper">
     <h2>Build a business relationship with Cerner around SMART on FHIR.</h2>
-    <p>Interested in collaborating? <a href="http://www.cerner.com/Smart_on_FHIR_Collaboration_Request_Form/?LangType=1033">Learn more.</a></p>
+    <p>Interested in collaborating? <a href="http://www.cerner.com/Smart_on_FHIR_Collaboration_Request_Form/?LangType=1033">Learn more</a>.</p>
   </div>
 </div>

--- a/layouts/faq.html
+++ b/layouts/faq.html
@@ -1,0 +1,20 @@
+<%= render 'head' %>
+
+<body class="faq">
+  <%= render 'header' %>
+
+  <div class="sub-nav">
+    <h2><a href="/faq/">FAQ</a></h2>
+  </div>
+
+  <div id="wrapper">
+    <div class="content">
+      <%= yield %>
+    </div>
+
+    <%= render 'faq_sidebar' %>
+  </div><!-- #wrapper -->
+
+  <%= render 'footer' %>
+</body>
+</html>

--- a/layouts/faq_sidebar.html
+++ b/layouts/faq_sidebar.html
@@ -1,0 +1,12 @@
+<div id="js-sidebar" class="sidebar-shell">
+    <div class="js-toggle-list sidebar-module expandable">
+        <ul>
+            <li class="js-topic">
+                <h3><a href="#" class="js-expand-btn collapsed arrow-btn" data-proofer-ignore></a><a href="/faq/#fhir-developer-faqs">FHIR Developer FAQs</a></h3>
+            </li>
+        </ul>
+    </div> <!-- /sidebar-module -->
+    <div class="sidebar-module notice">
+        <p>This website is a <a href="https://github.com/cerner/fhir.cerner.com" target="_blank">public GitHub repository</a>. Please help us by forking the project and adding to it.</p>
+    </div>
+</div><!-- /sidebar-shell -->

--- a/layouts/header.html
+++ b/layouts/header.html
@@ -5,6 +5,7 @@
       <ul class="nav">
         <li><a href="/may2015/" class="nav-may2015-api">DSTU 2 (MAY BALLOT) API</a></li>
         <li><a href="/dstu1/" class="nav-dstu1-api">DSTU 1 API</a></li>
+        <li><a href="/faq/" class="nav-faq">FAQ</a></li>
         <li><a href="https://groups.google.com/d/forum/cerner-fhir-developers">Support</a></li>
       </ul>
     </div>

--- a/layouts/highlights.html
+++ b/layouts/highlights.html
@@ -12,6 +12,11 @@
             <p>Check out a number of <a href="http://wiki.hl7.org/index.php?title=Open_Source_FHIR_implementations">Open Source FHIR Implementations</a>.</p>
         </li>
         <li class="highlight-module">
+            <a href="/faq/"><span class="mega-octicon octicon-question"></span></a>
+            <h2><a href="/faq/">FAQ</a></h2>
+            <p>Browse frequently asked questions to learn more about SMART on FHIR.</p>
+        </li>
+        <li class="highlight-module">
             <a href="https://groups.google.com/d/forum/cerner-fhir-developers"><span class="mega-octicon octicon-mail-read"></span></a>
             <h2><a href="https://groups.google.com/d/forum/cerner-fhir-developers">Support</a></h2>
             <p>Are you stuck? Talk to <a href="https://groups.google.com/d/forum/cerner-fhir-developers">Cerner support</a>.</p>

--- a/static/css/documentation.css
+++ b/static/css/documentation.css
@@ -257,6 +257,7 @@ a img {
 
 .overview #header .nav-overview,
 .dstu1_api #header .nav-dstu1-api,
+.faq #header .nav-faq,
 .may2015_api #header .nav-may2015-api,
 .blog #header .nav-blog,
 .developers #header .nav-developers {


### PR DESCRIPTION
Did this in a way that matches what is set up for the may2015 and dstu1 sections of the site.  We will be able to add new FAQ sections by adding new faq/*.md files and adding links in faq_sidebar.html

I added links to the FAQ in the header and in the 'highlights' section.