### PR TITLE
Pointing nested Reference links to more specific version url

### DIFF
--- a/lib/resources/dstu2/types.yaml
+++ b/lib/resources/dstu2/types.yaml
@@ -3,10 +3,10 @@ Attachment: <a target="_blank" href="http://hl7.org/fhir/DSTU2/datatypes.html#At
 BackboneElement: <a target="_blank" href="http://hl7.org/fhir/DSTU2/backboneelement.html"><code>BackboneElement</code></a>
 code: <a target="_blank" href="http://hl7.org/fhir/DSTU2/datatypes.html#code"><code>code</code></a>
 dateTime: <a target="_blank" href="http://hl7.org/fhir/DSTU2/datatypes.html#dateTime"><code>dateTime</code></a>
-EncounterReference: <a target="_blank" href="http://hl7.org/fhir/DSTU2/search.html#reference"><code>Reference</code></a> (<a target="_blank" href="http://hl7.org/fhir/encounter.html"><code>Encounter</code></a>)
+EncounterReference: <a target="_blank" href="http://hl7.org/fhir/DSTU2/search.html#reference"><code>Reference</code></a> (<a target="_blank" href="http://hl7.org/fhir/DSTU2/encounter.html"><code>Encounter</code></a>)
 instant: <a target="_blank" href="http://hl7.org/fhir/DSTU2/datatypes.html#instant"><code>instant</code></a>
-PatientReference: <a target="_blank" href="http://hl7.org/fhir/DSTU2/search.html#reference"><code>Reference</code></a> (<a target="_blank" href="http://hl7.org/fhir/patient.html"><code>Patient</code></a>)
-PractitionerReference: <a target="_blank" href="http://hl7.org/fhir/DSTU2/search.html#reference"><code>Reference</code></a> (<a target="_blank" href="http://hl7.org/fhir/practitioner.html"><code>Practitioner</code></a>)
+PatientReference: <a target="_blank" href="http://hl7.org/fhir/DSTU2/search.html#reference"><code>Reference</code></a> (<a target="_blank" href="http://hl7.org/fhir/DSTU2/patient.html"><code>Patient</code></a>)
+PractitionerReference: <a target="_blank" href="http://hl7.org/fhir/DSTU2/search.html#reference"><code>Reference</code></a> (<a target="_blank" href="http://hl7.org/fhir/DSTU2/practitioner.html"><code>Practitioner</code></a>)
 Period: <a target="_blank" href="http://hl7.org/fhir/DSTU2/datatypes.html#Period"><code>Period</code></a>
 string: <a target="_blank" href="http://hl7.org/fhir/DSTU2/datatypes.html#string"><code>string</code></a>
 CodeableConcept: <a target="_blank" href="http://hl7.org/fhir/DSTU2/datatypes.html#CodeableConcept"><code>CodeableConcept</code></a>

--- a/lib/resources/may2015/types.yaml
+++ b/lib/resources/may2015/types.yaml
@@ -4,10 +4,10 @@ Attachment: <a target="_blank" href="http://hl7.org/fhir/2015May/datatypes.html#
 Element: <a target="_blank" href="http://hl7.org/fhir/2015May/element.html"><code>Element</code></a>
 code: <a target="_blank" href="http://hl7.org/fhir/2015May/datatypes.html#code"><code>code</code></a>
 dateTime: <a target="_blank" href="http://hl7.org/fhir/2015May/datatypes.html#dateTime"><code>dateTime</code></a>
-EncounterReference: <a target="_blank" href="http://hl7.org/fhir/2015May/search.html#reference"><code>Reference</code></a> (<a target="_blank" href="http://hl7.org/fhir/encounter.html"><code>Encounter</code></a>)
+EncounterReference: <a target="_blank" href="http://hl7.org/fhir/2015May/search.html#reference"><code>Reference</code></a> (<a target="_blank" href="http://hl7.org/fhir/2015May/encounter.html"><code>Encounter</code></a>)
 instant: <a target="_blank" href="http://hl7.org/fhir/2015May/datatypes.html#instant"><code>instant</code></a>
-PatientReference: <a target="_blank" href="http://hl7.org/fhir/2015May/search.html#reference"><code>Reference</code></a> (<a target="_blank" href="http://hl7.org/fhir/patient.html"><code>Patient</code></a>)
-PractitionerReference: <a target="_blank" href="http://hl7.org/fhir/2015May/search.html#reference"><code>Reference</code></a> (<a target="_blank" href="http://hl7.org/fhir/practitioner.html"><code>Practitioner</code></a>)
+PatientReference: <a target="_blank" href="http://hl7.org/fhir/2015May/search.html#reference"><code>Reference</code></a> (<a target="_blank" href="http://hl7.org/fhir/2015May/patient.html"><code>Patient</code></a>)
+PractitionerReference: <a target="_blank" href="http://hl7.org/fhir/2015May/search.html#reference"><code>Reference</code></a> (<a target="_blank" href="http://hl7.org/fhir/2015May/practitioner.html"><code>Practitioner</code></a>)
 Period: <a target="_blank" href="http://hl7.org/fhir/2015May/datatypes.html#Period"><code>Period</code></a>
 string: <a target="_blank" href="http://hl7.org/fhir/2015May/datatypes.html#string"><code>string</code></a>
 CodeableConcept: <a target="_blank" href="http://hl7.org/fhir/2015May/datatypes.html#CodeableConcept"><code>CodeableConcept</code></a>


### PR DESCRIPTION
Verification Steps (running locally):
- On DSTU2 1.0.2 DocumentReference page, ensure the nested Patient, Practitioner, and Encounter links in Reference(Patient, Practitioner, and Encounter) link to http://hl7.org/fhir/DSTU2/(patient/practitioner/encounter).html

- On DSTU2 0.5.0 DocumentReference page, ensure the nested Patient, Practitioner, and Encounter links in Reference(Patient, Practitioner, and Encounter) link to http://hl7.org/fhir/2015May/(patient/practitioner/encounter).html