### PR TITLE
Adding AllergyIntolerance DSTU2 documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,95 @@
+# fhir.cerner.com
+
+The public facing API documentation for Cerner's FHIR implementation.
+
+## Usage
+
+### Generating a field table
+
+Create and Update operations typically require JSON bodies which can be tedious to document manually through markdown. To simplify this process and to improve consistency we have added the `definition_table` helper to generate a table from a yaml content file.
+
+The `definition_table` helper requires 3 parameters: content, action, and version.  
+- `content` indicates which content file to load.  
+- `version` indicates the version of the content file.   
+- `action` indicates which action specific variations defined in the content file to reflect in the generated table. Typically the action will be :create or :update. The available actions are defined in the content files themselves.     
+
+Generating a field table is done by invoking the `definition_table` method through an ERB call in whichever documentation file needs the table.
+
+For example, the DSTU2 version of DocumentReference Create can be generated using
+
+    <%= definition_table(:document_reference, :create, :dstu2) %>
+
+Whereas the May 2015 version of AllergyIntolerance Update can be generated using
+
+    <%= definition_table(:allergy_intolerance, :update, :may2015) %>
+
+In actuality, the `version` parameter is reference a subfolder in `lib/resources` where the content files for that version are stored. Thus `definition_table(:document_reference, :create, :dstu2)` is referencing `lib/resources/dstu2/document_reference.yaml`. Adding new versions or new content files is simply a matter of creating an appropriately named folder and content file.
+
+#### Content YAML
+
+The content is defined in YAML files and most fields are optional. If they are not provided the resulting table cell will just be empty.
+
+- field_name_base_url: `definition_table` will generate nested links for each field prepended with this url
+- fields: The list of defined fields
+    - name: The name of the field. This will be generated as a link based of `field_name_base_url`
+    - required: Whether or not the field is required. This is not necessarily whether the field is required by FHIR, but rather whether it is required by our server implementation.
+    - cardinality: The is the FHIR defined cardinality for the field
+    - type: The type of the field. If found in `lib/resources/<version>/types.yaml` this field will be linked to the specified resource.
+    - description: The description of the field.
+    - example: An example of how the field should be populated. The generated examples will be enclosed in &lt;pre&gt; tags to preserve formatting.
+    - note: Additional implementation notes.
+    - children: A list of nested fields. Each nested field item has the same structure as this `fields` list.
+    - url: Overrides the `field_name_base_url` generated URL if defined. 
+
+Standard YAML formatting rules apply 
+
+##### Action
+
+In addition to the fields above, each field can have an `action` field which indicates to which action or actions the field applies. When defined, the field will only be included when generating a table with the specified action. Multiple actions are supported as well and can be defined as a list
+
+    Make the field apply to a single action
+    - name: subject
+      ...
+      action: create
+
+    Make the field apply to multiple actions
+    - name: subject
+      ...
+      action: 
+      - create
+      - update
+
+Similarly field values can be flexed per action as well
+ 
+    Alter the required and note values for update and create
+    - name: id
+      required:
+      - update: 'Yes'
+      - create: 'No'
+      cardinality: 0..1
+      type: id
+      description: The logical id of the resource to update.
+      example: '{"id": "123412"}'
+      note:
+      - update: The id value must match the AllergyIntolerance/&lt;id> value.
+      - create: The id field <b>must not</b> be set when performing an update operation.
+
+The name of the action isn't limited to create and update, but only one action can be used at a time when generating a field table.
+
+#### Linking
+
+Linking is supported in a few forms
+
+##### Field names
+
+The field names will be automatically linked based on the `base_field_name_url` unless overridden by a field's `url` value.
+
+##### Type names
+
+The Type table cell will generate links based on URLs key-value pairs defined in `lib/resources/<version>/types.yaml`. Any word found in a `type` field will be replaced with the specified URL.
+
+##### Formatting Tags
+
+The `description` and `note` fields also support linking via the use of \`\` and `[]` tags. Words enclosed in \`\` tags will be linked according to the `types.yaml` file, if possible, or just formatted as `<code>` tags if not. Words enclosed in `[]` will be assumed to be references to other fields in the same table.
+
+In generally it is best to not use \`\` tags in the `type` field, although it is possible. There can be conflicts which may result in duplicate replacements and unintended results. 

--- a/content/dstu2.md
+++ b/content/dstu2.md
@@ -85,31 +85,42 @@ while `patient` and `status` are passed in the query string.
 
 ## Client Errors
 
-There are four possible types of client errors on API calls that
+There are seven possible types of client errors on API calls that
 receive request bodies:
 
-1. Requested a media type other than JSON will result in a `406 Not Acceptable` response.
-
-        HTTP/1.1 406 Not Acceptable
-        Content-Length: 0
-
-2. Failing to send a required query parameter will result in a `400 Bad
-   Request` response.
+1. Failing to send a required query parameter will result in a `400 Bad Request` response.
 
         HTTP/1.1 400 Bad Request
 
         no supported search parameters provided
 
-3. Requesting the authenticated endpoint (non-`open`) without valid credentials will result in a `401 Unauthorized`
+2. Requesting the authenticated endpoint (non-`open`) without valid credentials will result in a `401 Unauthorized`
    response.
 
         HTTP/1.1 401 Unauthorized
 
-4. Requesting an invalid or unauthorized `:ehr_source_id` will result in a `403 Forbidden` response.
+3. Requesting an invalid or unauthorized `:ehr_source_id` will result in a `403 Forbidden` response.
 
         HTTP/1.1 403 Forbidden
 
         Tenant [:ehr_source_id] not valid or accessible
+
+4. Requesting a resource which does not exist will resule in a `404 Not Found` response.
+
+        HTTP/1.1 404 Not Found
+
+5. Requested a media type other than JSON will result in a `406 Not Acceptable` response.
+
+        HTTP/1.1 406 Not Acceptable
+        Content-Length: 0
+
+6. Performing an update with an out-of-date version id will result in a `409 Conflict Error` response.
+
+        HTTP/1.1 409 Conflict Error
+
+7. Performing an add or update with syntactically correct JSON body which is invalid according to business rules will result in a `422 Unprocessable Entity` response.
+
+        HTTP/1.1 422 Unprocessable Entity
 
 ## HTTP Verbs
 
@@ -118,7 +129,8 @@ Where possible, FHIR strives to use appropriate HTTP verbs for each action.
 Verb | Description
 -----|-----------
 `GET` | Used for retrieving resources.
-`POST` | Coming soon!
+`POST` | Used for creating resources.
+`PUT` | Used for updating resources.
 
 ## Authorization
 

--- a/content/dstu2/allergy-intolerance.md
+++ b/content/dstu2/allergy-intolerance.md
@@ -1,0 +1,130 @@
+---
+title: AllergyIntolerance | FHIR DSTU 2 API
+---
+
+# AllergyIntolerance
+
+* TOC
+{:toc}
+
+## Search
+
+Search for AllergyIntolerances that meet supplied query parameters:
+
+    GET /AllergyIntolerance?:parameters
+
+### Parameters
+
+ Name    | Required? | Type                                                           | Description
+---------|-----------|----------------------------------------------------------------|---------------------------------------------
+`patient`|     Y     |[`reference`](http://hl7.org/fhir/DSTU2/search.html#reference)| Who the sensitivity is for. Example: `12345`
+`status` |     N     |[`token`](http://hl7.org/fhir/DSTU2/search.html#token)        | [Certainty of the allergy or intolerance](http://hl7.org/fhir/DSTU2/valueset-allergy-intolerance-status.html). Example: `confirmed`
+
+### Response
+
+<%= headers 200 %>
+<%= json(:dstu2_allergy_intolerance_bundle) %>
+
+## Create
+
+Create new allergies.
+
+    POST /AllergyIntolerance
+
+### Headers
+
+To successfully POST an allergy, the following headers must be provided. Allergy creation is supported from the closed endpoint only.
+
+    Content-Type: application/json+fhir
+    Authorization: <OAuth2 Bearer Token>
+
+### Body fields
+
+<%= definition_table(:allergy_intolerance, :create, :dstu2) %>
+
+### Example Body
+
+<%= json(:dstu2_allergy_intolerance_create) %>
+
+### Response
+
+<%= headers 201 %>
+<pre class="terminal">
+    Connection → Keep-Alive
+    Content-Encoding → gzip
+    Content-Length → 20
+    Content-Type → text/html; charset=UTF-8
+    Date → Wed, 13 Jan 2016 21:45:47 GMT
+    Keep-Alive → timeout=15, max=100
+    Last-Modified → Tue, 15 Dec 2015 19:13:20 GMT
+    Status → 201 Created
+    access-control-allow-methods → DELETE, GET, POST, PUT, OPTIONS, HEAD
+    access-control-allow-origin → *
+    access-control-expose-headers → ETag, Content-Location, Location, X-Request-Id, WWW-Authenticate, Date
+    access-control-max-age → 0
+    cache-control → no-cache
+    etag → W/"35502191"
+    location → https://fhir.sandboxcernerpowerchart.com/dstu2/9e2aaa6d-3811-4d84-b5f9-93ccf529eefa/AllergyIntolerance/35502191
+    server-response-time → 1260.984596
+    strict-transport-security → max-age=631152000
+    vary → Origin,User-Agent,Accept-Encoding
+    x-content-type-options → nosniff
+    x-frame-options → SAMEORIGIN
+    x-request-id → edad5615-1f19-4ff0-9999-46f46a52368e
+    x-runtime → 1.260940
+    x-xss-protection → 1; mode=block
+</pre>
+
+The `etag` response header indicates the current `If-Match` version to use on subsequent updates.
+
+## Update
+
+Update an existing allergy.
+
+    PUT /AllergyIntolerance
+
+Note that any field which is missing will be interpreted as nulling out or removing data from the resource. See [FHIR Update](http://hl7.org/fhir/DSTU2/http.html#update) for additional details about update operations.
+
+### Headers
+
+To successfully PUT an allergy, the following headers must be provided. Allergy updates are supported from the closed endpoint only.
+
+    Content-Type: application/json+fhir
+    Authorization: <OAuth2 Bearer Token>
+    If-Match: W/"<Current allergy id>"
+
+### Body fields
+
+<%= definition_table(:allergy_intolerance, :update, :dstu2) %>
+
+### Example Body
+
+<%= json(:dstu2_allergy_intolerance_update) %>
+
+### Response
+
+<%= headers 200 %>
+<pre class="terminal">
+    Connection → Keep-Alive
+    Content-Encoding → gzip
+    Content-Length → 20
+    Content-Type → text/html; charset=UTF-8
+    Date → Wed, 13 Jan 2016 21:50:53 GMT
+    Keep-Alive → timeout=15, max=100
+    Last-Modified → Tue, 15 Dec 2015 19:13:20 GMT
+    Status → 200 OK
+    access-control-allow-methods → DELETE, GET, POST, PUT, OPTIONS, HEAD
+    access-control-allow-origin → *
+    access-control-expose-headers → ETag, Content-Location, Location, X-Request-Id, WWW-Authenticate, Date
+    access-control-max-age → 0
+    cache-control → no-cache
+    etag → W/"35504311"
+    server-response-time → 653.7616069999999
+    strict-transport-security → max-age=631152000
+    vary → Origin,User-Agent,Accept-Encoding
+    x-content-type-options → nosniff
+    x-frame-options → SAMEORIGIN
+    x-request-id → 9dba8326-899a-406f-a125-3fc3d6605dad
+    x-runtime → 0.653722
+    x-xss-protection → 1; mode=block
+</pre>

--- a/content/dstu2/document-reference.md
+++ b/content/dstu2/document-reference.md
@@ -22,7 +22,7 @@ To successfully POST a document, the following headers must be provided. Documen
 
 ### Body fields
 
-<%= definition_table(:document_reference_create, :dstu2) %>
+<%= definition_table(:document_reference, :create, :dstu2) %>
 
 #### Example Body
 

--- a/content/may2015.md
+++ b/content/may2015.md
@@ -84,31 +84,42 @@ while `patient` and `status` are passed in the query string.
 
 ## Client Errors
 
-There are four possible types of client errors on API calls that
+There are seven possible types of client errors on API calls that
 receive request bodies:
 
-1. Requested a media type other than JSON will result in a `406 Not Acceptable` response.
-
-        HTTP/1.1 406 Not Acceptable
-        Content-Length: 0
-
-2. Failing to send a required query parameter will result in a `400 Bad
-   Request` response.
+1. Failing to send a required query parameter will result in a `400 Bad Request` response.
 
         HTTP/1.1 400 Bad Request
 
         no supported search parameters provided
 
-3. Requesting the authenticated endpoint (non-`open`) without valid credentials will result in a `401 Unauthorized`
+2. Requesting the authenticated endpoint (non-`open`) without valid credentials will result in a `401 Unauthorized`
    response.
 
         HTTP/1.1 401 Unauthorized
 
-4. Requesting an invalid or unauthorized `:ehr_source_id` will result in a `403 Forbidden` response.
+3. Requesting an invalid or unauthorized `:ehr_source_id` will result in a `403 Forbidden` response.
 
         HTTP/1.1 403 Forbidden
 
         Tenant [:ehr_source_id] not valid or accessible
+
+4. Requesting a resource which does not exist will resule in a `404 Not Found` response.
+
+        HTTP/1.1 404 Not Found
+
+5. Requested a media type other than JSON will result in a `406 Not Acceptable` response.
+
+        HTTP/1.1 406 Not Acceptable
+        Content-Length: 0
+
+6. Performing an update with an out-of-date version id will result in a `409 Conflict Error` response.
+
+        HTTP/1.1 409 Conflict Error
+
+7. Performing an add or update with syntactically correct JSON body which is invalid according to business rules will result in a `422 Unprocessable Entity` response.
+
+        HTTP/1.1 422 Unprocessable Entity
 
 ## HTTP Verbs
 
@@ -117,7 +128,8 @@ Where possible, FHIR strives to use appropriate HTTP verbs for each action.
 Verb | Description
 -----|-----------
 `GET` | Used for retrieving resources.
-`POST` | Coming soon!
+`POST` | Used for creating resources.
+`PUT` | Used for updating resources.
 
 ## Authorization
 

--- a/content/may2015/document-reference.md
+++ b/content/may2015/document-reference.md
@@ -22,7 +22,7 @@ To successfully POST a document, the following headers must be provided. Documen
 
 ### Body fields
 
-<%= definition_table(:document_reference_create, :may2015) %>
+<%= definition_table(:document_reference, :create, :may2015) %>
 
 #### Example Body
 

--- a/layouts/dstu2_sidebar.html
+++ b/layouts/dstu2_sidebar.html
@@ -10,9 +10,9 @@
             <li class="js-topic">
                 <h3><a href="#" class="js-expand-btn collapsed arrow-btn" data-proofer-ignore></a><a href="/dstu2/conformance/">Conformance Metadata</a></h3>
             </li>
-            <!-- <li class="js-topic">
+            <li class="js-topic">
                 <h3><a href="#" class="js-expand-btn collapsed arrow-btn" data-proofer-ignore></a><a href="/dstu2/allergy-intolerance/">AllergyIntolerance</a></h3>
-            </li> -->
+            </li>
             <!-- <li class="js-topic">
                 <h3><a href="#" class="js-expand-btn collapsed arrow-btn" data-proofer-ignore></a><a href="/dstu2/condition/">Condition</a></h3>
             </li> -->

--- a/lib/dstu2_resources.rb
+++ b/lib/dstu2_resources.rb
@@ -1,6 +1,211 @@
 module Cerner
   module Resources
 
+    DSTU2_ALLERGY_INTOLERANCE_BUNDLE ||= {
+      "resourceType": "Bundle",
+      "id": "84a45b50-f11b-4c0a-9411-756156cbd49f",
+      "type": "searchset",
+      "total": 3,
+      "link": [
+        {
+          "relation": "self",
+          "url": "https://fhir-open.sandboxcernerpowerchart.com/dstu2/d075cf8b-3261-481d-97e5-ba6c48d3b41f/AllergyIntolerance?patient=2744010"
+        }
+      ],
+      "entry": [
+        {
+          "fullUrl": "https://fhir-open.sandboxcernerpowerchart.com/dstu2/d075cf8b-3261-481d-97e5-ba6c48d3b41f/AllergyIntolerance/2759741",
+          "resource": {
+            "resourceType": "AllergyIntolerance",
+            "id": "2759741",
+            "meta": {
+              "versionId": "2759741",
+              "lastUpdated": "2014-09-24T23:16:54.000Z"
+            },
+            "text": {
+              "status": "generated",
+              "div": "&lt;div&gt;&lt;p&gt;&lt;b&gt;Allergy Intolerance&lt;/b&gt;&lt;/p&gt;&lt;p&gt;&lt;b&gt;Patient&lt;/b&gt;: RHEUM, TEST ONE&lt;/p&gt;&lt;p&gt;&lt;b&gt;Allergy&lt;/b&gt;: Peanuts&lt;/p&gt;&lt;p&gt;&lt;b&gt;Status&lt;/b&gt;: Active&lt;/p&gt;&lt;p&gt;&lt;b&gt;Criticality&lt;/b&gt;: &lt;/p&gt;&lt;p&gt;&lt;b&gt;Category&lt;/b&gt;: Food&lt;/p&gt;&lt;p&gt;&lt;b&gt;Reactions&lt;/b&gt;: &lt;/p&gt;&lt;p&gt;&lt;b&gt;Onset&lt;/b&gt;: &lt;/p&gt;&lt;p&gt;&lt;b&gt;Note&lt;/b&gt;: &lt;/p&gt;&lt;/div&gt;"
+            },
+            "recordedDate": "2014-09-24T18:16:54.000",
+            "recorder": {
+              "reference": "Practitioner/2770007",
+              "display": "Song, River"
+            },
+            "patient": {
+              "reference": "Patient/2744010",
+              "display": "RHEUM, TEST ONE"
+            },
+            "substance": {
+              "text": "Peanuts"
+            },
+            "status": "active",
+            "type": "allergy",
+            "category": "food"
+          }
+        },
+        {
+          "fullUrl": "https://fhir-open.sandboxcernerpowerchart.com/dstu2/d075cf8b-3261-481d-97e5-ba6c48d3b41f/AllergyIntolerance/3643739",
+          "resource": {
+            "resourceType": "AllergyIntolerance",
+            "id": "3643739",
+            "meta": {
+              "versionId": "3643739",
+              "lastUpdated": "2015-03-11T20:36:08.000Z"
+            },
+            "text": {
+              "status": "generated",
+              "div": "&lt;div&gt;&lt;p&gt;&lt;b&gt;Allergy Intolerance&lt;/b&gt;&lt;/p&gt;&lt;p&gt;&lt;b&gt;Patient&lt;/b&gt;: RHEUM, TEST ONE&lt;/p&gt;&lt;p&gt;&lt;b&gt;Allergy&lt;/b&gt;: Dust allergy&lt;/p&gt;&lt;p&gt;&lt;b&gt;Status&lt;/b&gt;: Active&lt;/p&gt;&lt;p&gt;&lt;b&gt;Criticality&lt;/b&gt;: &lt;/p&gt;&lt;p&gt;&lt;b&gt;Category&lt;/b&gt;: Environment&lt;/p&gt;&lt;p&gt;&lt;b&gt;Reactions&lt;/b&gt;: &lt;/p&gt;&lt;p&gt;&lt;b&gt;Onset&lt;/b&gt;: &lt;/p&gt;&lt;p&gt;&lt;b&gt;Note&lt;/b&gt;: &lt;/p&gt;&lt;/div&gt;"
+            },
+            "recordedDate": "2015-03-11T15:36:08.000",
+            "recorder": {
+              "reference": "Practitioner/3270007",
+              "display": "Who, Doctor"
+            },
+            "patient": {
+              "reference": "Patient/2744010",
+              "display": "RHEUM, TEST ONE"
+            },
+            "substance": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "390952000",
+                  "display": "Dust allergy (disorder)",
+                  "userSelected": true
+                }
+              ],
+              "text": "Dust allergy"
+            },
+            "status": "active",
+            "type": "allergy",
+            "category": "environment"
+          }
+        },
+        {
+          "fullUrl": "https://fhir-open.sandboxcernerpowerchart.com/dstu2/d075cf8b-3261-481d-97e5-ba6c48d3b41f/AllergyIntolerance/3643731",
+          "resource": {
+            "resourceType": "AllergyIntolerance",
+            "id": "3643731",
+            "meta": {
+              "versionId": "3643735",
+              "lastUpdated": "2015-03-11T20:34:59.000Z"
+            },
+            "text": {
+              "status": "generated",
+              "div": "&lt;div&gt;&lt;p&gt;&lt;b&gt;Allergy Intolerance&lt;/b&gt;&lt;/p&gt;&lt;p&gt;&lt;b&gt;Patient&lt;/b&gt;: RHEUM, TEST ONE&lt;/p&gt;&lt;p&gt;&lt;b&gt;Allergy&lt;/b&gt;: Penicillin&lt;/p&gt;&lt;p&gt;&lt;b&gt;Status&lt;/b&gt;: Entered In Error&lt;/p&gt;&lt;p&gt;&lt;b&gt;Criticality&lt;/b&gt;: &lt;/p&gt;&lt;p&gt;&lt;b&gt;Category&lt;/b&gt;: Medication&lt;/p&gt;&lt;p&gt;&lt;b&gt;Reactions&lt;/b&gt;: &lt;/p&gt;&lt;p&gt;&lt;b&gt;Onset&lt;/b&gt;: &lt;/p&gt;&lt;p&gt;&lt;b&gt;Note&lt;/b&gt;: &lt;/p&gt;&lt;/div&gt;"
+            },
+            "recordedDate": "2015-03-11T15:34:59.000",
+            "recorder": {
+              "reference": "Practitioner/3270007",
+              "display": "Who, Doctor"
+            },
+            "patient": {
+              "reference": "Patient/2744010",
+              "display": "RHEUM, TEST ONE"
+            },
+            "substance": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "373270004",
+                  "display": "Penicillin -class of antibiotic- (substance)",
+                  "userSelected": true
+                }
+              ],
+              "text": "Penicillin"
+            },
+            "status": "entered-in-error",
+            "type": "allergy",
+            "category": "medication"
+          }
+        }
+      ]
+    }
+
+    DSTU2_ALLERGY_INTOLERANCE_CREATE ||= {
+        "resourceType": "AllergyIntolerance",
+        "category": "medication",
+        "criticality": "CRITL",
+        "recordedDate": "2015-12-15T13:13:20-06:00",
+        "status": "active",
+        "type": "allergy",
+        "onset": "2012-12-15T00:00:00Z",
+        "patient": {
+            "reference": "Patient/41563419"
+        },
+        "reporter": {
+            "reference": "Patient/41563419"
+        },
+        "recorder": {
+            "reference": "Practitioner/41562141"
+        },
+        "reaction": [
+            {
+                "manifestation": [
+                    {
+                        "text": "Hives"
+                    }
+                ]
+            }
+        ],
+        "note": {
+            "authorReference": {"reference": "Practitioner/41562141"},
+            "time": "2012-12-15T00:00:00Z",
+            "text": "Note 1"
+        },
+        "substance": {
+            "coding": [
+                {
+                    "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+                    "code": "3498"
+                }
+            ]
+        }
+    }
+
+    DSTU2_ALLERGY_INTOLERANCE_UPDATE ||= {
+        "resourceType": "AllergyIntolerance",
+        "id": "35502191",
+        "category": "medication",
+        "criticality": "CRITU",
+        "recordedDate": "2015-12-15T13:13:20-06:00",
+        "status": "active",
+        "type": "allergy",
+        "onset": "2012-12-15T00:00:00Z",
+        "patient": {
+            "reference": "Patient/41563419"
+        },
+        "reporter": {
+            "reference": "Patient/41563419"
+        },
+        "recorder": {
+            "reference": "Practitioner/41562141"
+        },
+        "reaction": [
+            {
+                "id": "35502191",
+                "manifestation": [
+                    {
+                        "text": "Hives"
+                    }
+                ]
+            }
+        ],
+        "note": {
+            "authorReference": {"reference": "Practitioner/41562141"},
+            "time": "2012-12-15T00:00:00Z",
+            "text": "Note 1"
+        },
+        "substance": {
+            "coding": [
+                {
+                    "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+                    "code": "3498"
+                }
+            ]
+        }
+    }
+
     DSTU2_MEDICATION_STATEMENT_BUNDLE ||= {
       "resourceType"=> "Bundle",
       "id"=> "b8ea9905-29fe-4d40-9d71-475ca2ebb209",

--- a/lib/field_definition_table.erb
+++ b/lib/field_definition_table.erb
@@ -9,44 +9,39 @@
   </thead>
   <tbody>
     <% for item in data[:fields] %>
-
-      <!-- TODO: Externalize the styling in this erb so that it is consistent with the rest of the site. Keeping in
-                 mind that the table as a whole needs to not scroll. Individual examples should, but the entire table
-                 should not. It looks tacky -->
-      <tr>
-        <td>
-          <!-- Render the field name as a link, if a url is provided.-->
-          <% if !item[:url].nil? %>
-            <a target="_blank" href="<%= item[:url]%>"><code><%= item[:name]%></code></a>
-          <% else %>
-            <code><%= item[:name]%></code>
-          <% end %>
-        </td>
-        <td><%= item[:required] %> </td>
-        <td><%= item[:cardinality] %> </td>
-        <td><%= item[:type] %> </td>
-      </tr>
-
-      <tr>
-        <td colspan="4">
-        <ul style="list-style-type: none; margin: 1.2em">
-          <% unless item[:description].nil? %>
-              <li><i>Description</i></li>
-              <ul style="list-style-type: none"><li><%= item[:description] %></li></ul>
-          <%end%>
-
-          <% unless item[:example].nil? %>
-              <li><i>Example</i></li>
-              <ul style="list-style-type: none"><li><pre><%= item[:example] %></pre></li></ul>
-          <%end%>
-
-          <% unless item[:note].nil? %>
-              <li><i>Notes</i></li>
-              <ul style="list-style-type: none"><li><%= item[:note] %></li></ul>
-          <%end%>
-        </ul>
-        </td>
-      </tr>
+    <tr>
+      <td>
+        <a name="<%= "#{data[:table_name]}-#{item[:name]}" %>">
+        <% if !item[:url].nil? %>
+          <a target="_blank" href="<%= item[:url]%>"><code><%= item[:name]%></code></a>
+        <% else %>
+          <code><%= item[:name]%></code>
+        <% end %>
+        </a>
+      </td>
+      <td><%= item[:required] %> </td>
+      <td><%= item[:cardinality] %> </td>
+      <td><%= item[:type] %> </td>
+    </tr>
+    <tr>
+      <td colspan="4">
+      <ul style="list-style-type: none; margin: 1.2em">
+      <% unless item[:description].nil? %>
+        <li><i>Description</i></li>
+        <ul style="list-style-type: none"><li><%= item[:description] %></li></ul>
+      <%end%>
+      <% unless item[:example].nil? %>
+        <li><i>Example</i></li>
+        <ul style="list-style-type: none"><li><pre><%= item[:example] %></pre></li></ul>
+      <%end%>
+      <% unless item[:note].nil? %>
+        <li><i>Notes</i></li>
+        <ul style="list-style-type: none"><li><%= item[:note] %></li></ul>
+      <%end%>
+      </ul>
+      <div style="float: right"><a href="#<%=data[:table_name]%>">top of section</a></div>
+      </td>
+    </tr>
     <% end %>
   </tbody>
 </table>

--- a/lib/resources/dstu2/allergy_intolerance.yaml
+++ b/lib/resources/dstu2/allergy_intolerance.yaml
@@ -1,0 +1,223 @@
+---
+field_name_base_url: http://hl7.org/fhir/DSTU2/allergyintolerance-definitions.html#AllergyIntolerance
+fields:
+- name: resourceType
+  required: 'Yes'
+  cardinality: 1..1
+  type: string
+  description: The type of the FHIR resource.
+  example: AllergyIntolerance
+  note: resourceType must be AllergyIntolerance
+  url: http://hl7.org/fhir/DSTU2/json.html#resources
+
+- name: id
+  required: 'Yes'
+  cardinality: 0..1
+  type: id
+  description: The logical id of the resource to update.
+  example: '{"id": "123412"}'
+  note: The id value must match the AllergyIntolerance/&lt;id> value.
+  url: http://hl7.org/fhir/DSTU2/resource-definitions.html#Resource.id
+  action: update
+
+- name: contained
+  required: 'No'
+  cardinality: 0..*
+  type: Resource
+  description: Contained, inline Resources.
+  example: |
+             Contained RelatedPerson
+               {"contained": [
+                  {"resourceType": "RelatedPerson",
+                   "id": "5366328",
+                   "relationship": {
+                      "coding": [
+                        {"system": "http://hl7.org/fhir/v3/RoleCode",
+                         "code": "SIGOTHR"}]}}]}
+
+             Contained Practitioner
+               {"contained": [
+                  {"resourceType": "Practitioner",
+                   "id": "123",
+                   "practitionerRole": [
+                     {"role": {
+                        "coding": [
+                          {"system": "http://hl7.org/fhir/v2/0286",
+                            "code": "RP"}]}}]}]
+  note: >
+          These should be either `Practitioner` or `RelatedPerson` resources that are referenced with the
+          [reporter] field.
+  url: http://hl7.org/fhir/DSTU2/domainresource-definitions.html#DomainResource.contained
+
+- name: onset
+  required: 'No'
+  cardinality: 0..1
+  type: dateTime
+  description: Date(/time) when manifestations showed.
+  example: '{"onset: "2012-07-13T00:00:00Z"}'
+
+- name: recordedDate
+  required: 'Yes'
+  cardinality: 0..1
+  type: dateTime
+  description: When the sensitivity was recorded.
+  example: '{"recordedDate": "2015-10-14T13:13:20-06:00"}'
+
+- name: recorder
+  required: 'No'
+  cardinality: 0..1
+  type: Reference (Practitioner)
+  description: Who recorded the sensitivity.
+  note: Recorder must be a `Practitioner` reference.
+  example: |
+             {"recorder": {
+                "reference": "Practitioner/21500971"}}
+
+- name: patient
+  required: 'Yes'
+  cardinality: 1..1
+  type: Reference (Patient)
+  description: Who the sensitivity is for.
+  example: |
+             {"patient": {
+                "reference": "Patient/5366327"}}
+
+- name: reporter
+  required: 'Yes'
+  cardinality: 0..1
+  type: Reference (Patient) | contained Reference (Practitioner | RelatedPerson)
+  description: Source of the information about the allergy.
+  example: |
+             Reporter as a Patient Reference
+               {"reporter": {
+                  "reference": "Patient/5366327"}}
+
+             Reporter as a contained reference
+               {"reporter": "#5366328"}
+  note: >
+          If [reporter] is a contained reference, a matching `RelatedPerson` or `Practitioner` reference must be
+          provided in the [contained] field.
+
+- name: substance
+  required: 'Yes'
+  cardinality: 1..1
+  type: CodeableConcept
+  description: Substance, (or class) considered to be responsible for risk
+  example: |
+             {"substance": {
+                "coding": [
+                  {"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+                   "code": "4125",
+                   "display": "Ethiodized oil"}]}}
+
+- name: status
+  required: 'Yes'
+  cardinality: 0..1
+  type: code
+  description: >
+                 Assertion about certainty associated with the propensity, or potential risk, of a reaction to the
+                 identified [substance].
+  example: '{"status": "resolved"}'
+
+- name: criticality
+  required: 'Yes'
+  cardinality: 0..1
+  type: code
+  description: Estimate of the potential clinical harm, or seriousness, of the reaction to the identified [substance].
+  example: '{"criticality": "CRITU"}'
+
+- name: type
+  required: 'No'
+  cardinality: 0..1
+  type: code
+  description: Identification of the underlying physiological mechanism for the reaction risk.
+  example: '{"type": "allergy"}'
+
+- name: category
+  required: 'Yes'
+  cardinality: 0..1
+  type: code
+  description: Category of the identified [substance].
+  example: '{"type": "food"}'
+
+- name: note
+  required: 'No'
+  cardinality: 0..1
+  type: Annotation
+  description: Additional text not captured in other fields.
+  example: |
+             {"note": {
+                "authorReference": {"reference": "Practitioner/21500971"},
+                "time": "2015-10-14T13:13:20-06:00",
+                "text": "Patient complains of discomfort"}}
+  children:
+
+  - name: authorReference
+    required: 'No'
+    cardinality: 0..1
+    type: Reference (Practitioner)
+    description: Individual responsible for the annotation.
+    url: http://hl7.org/fhir/DSTU2/datatypes-definitions.html#Annotation.author_x_
+    example: |
+               {"note": {
+                  "authorReference": {"reference": "Practitioner/21500971"}}
+  - name: time
+    required: 'No'
+    cardinality: 0..1
+    type: dateTime
+    description: When the annotation was made.
+    url: http://hl7.org/fhir/DSTU2/datatypes-definitions.html#Annotation.time
+    example: |
+               {"note": {
+                  "time": "2015-10-14T13:13:20-06:00"}}
+
+  - name: text
+    required: 'Yes'
+    cardinality: 1..1
+    type: string
+    description: The text content.
+    url: http://hl7.org/fhir/DSTU2/datatypes-definitions.html#Annotation.text
+    example: |
+               {"note": {
+                  "text": "Patient complains of discomfort"}}
+- name: reaction
+  required: 'No'
+  cardinality: 0..*
+  type: BackboneElement
+  description: Adverse reaction events linked to exposure to [substance].
+  example: |
+             {"reaction": [
+                {"manifestation": [
+                  {"coding": [
+                    {"system": "http://snomed.info/sct",
+                     "code": "39579001",
+                     "display": "Anaphylactic reaction"}]}]}}
+  children:
+
+  - name: id
+    required: 'Yes'
+    cardinality: 0..1
+    type: id
+    description: Logical id of the reaction event.
+    example: '{"id": "543123"}'
+    url: http://hl7.org/fhir/DSTU2/resource-definitions.html#Resource.id
+    action: update
+
+  - name: manifestation
+    required: 'Yes'
+    cardinality: 1..*
+    type: CodeableConcept
+    description: Clinical symptoms/signs associated with the event.
+    example: |
+               Manifestation with a coding:
+                 {"reaction": [
+                    {"manifestation": [
+                      {"coding": [
+                        {"system": "http://snomed.info/sct",
+                         "code": "39579001",
+                         "display": "Anaphylactic reaction"}]}]}}
+
+               Manifestation with a freetext value:
+                 {"reaction": [
+                    {"manifestation": [
+                      {"text": "Anaphylactic reaction"}]}]}

--- a/lib/resources/dstu2/document_reference.yaml
+++ b/lib/resources/dstu2/document_reference.yaml
@@ -13,7 +13,7 @@ fields:
 - name: subject
   required: 'Yes'
   cardinality: 0..1
-  type: PatientReference
+  type: Reference (Patient)
   description: Who or what is the subject of the document.
   example: '{"reference": "Patient/1234"}'
 
@@ -31,7 +31,7 @@ fields:
 - name: author
   required: 'Yes'
   cardinality: 0..1
-  type: PractitionerReference
+  type: Reference (Practitioner)
   description: Who and/or what authored the document
   example: |
             {"author": [
@@ -50,7 +50,7 @@ fields:
   type: code
   description: The status of this document reference
   example: '{"status": "current"}'
-  note: Currently support 'current' only
+  note: Currently support `current` only
 
 - name: docStatus
   required: 'No'
@@ -58,7 +58,7 @@ fields:
   type: CodeableConcept
   description: The status of underlying document
   example: '{"status": "final"}'
-  note: Currently support 'final' and 'preliminary'
+  note: Currently support `final` and `preliminary`
 
 - name: description
   required: 'No'
@@ -119,7 +119,7 @@ fields:
   - name: encounter
     required: 'Yes'
     cardinality: 0..1
-    type: EncounterReference
+    type: Reference (Encounter)
     description: Context of the document content
     example: |
               {"context": {
@@ -136,5 +136,5 @@ fields:
                 "period" : {
                   "end": "2015-08-20T091014Z"}}}
     note: >
-            If provided, the service time must be set to context.period.end. If not provided, the document will be
+            If provided, the service time must be set to `context.period.end`. If not provided, the document will be
             stored with the indexed dateTime.

--- a/lib/resources/dstu2/types.yaml
+++ b/lib/resources/dstu2/types.yaml
@@ -1,12 +1,17 @@
 ---
-Attachment: <a target="_blank" href="http://hl7.org/fhir/DSTU2/datatypes.html#Attachment"><code>Attachment</code></a>
-BackboneElement: <a target="_blank" href="http://hl7.org/fhir/DSTU2/backboneelement.html"><code>BackboneElement</code></a>
-code: <a target="_blank" href="http://hl7.org/fhir/DSTU2/datatypes.html#code"><code>code</code></a>
-dateTime: <a target="_blank" href="http://hl7.org/fhir/DSTU2/datatypes.html#dateTime"><code>dateTime</code></a>
-EncounterReference: <a target="_blank" href="http://hl7.org/fhir/DSTU2/search.html#reference"><code>Reference</code></a> (<a target="_blank" href="http://hl7.org/fhir/DSTU2/encounter.html"><code>Encounter</code></a>)
-instant: <a target="_blank" href="http://hl7.org/fhir/DSTU2/datatypes.html#instant"><code>instant</code></a>
-PatientReference: <a target="_blank" href="http://hl7.org/fhir/DSTU2/search.html#reference"><code>Reference</code></a> (<a target="_blank" href="http://hl7.org/fhir/DSTU2/patient.html"><code>Patient</code></a>)
-PractitionerReference: <a target="_blank" href="http://hl7.org/fhir/DSTU2/search.html#reference"><code>Reference</code></a> (<a target="_blank" href="http://hl7.org/fhir/DSTU2/practitioner.html"><code>Practitioner</code></a>)
-Period: <a target="_blank" href="http://hl7.org/fhir/DSTU2/datatypes.html#Period"><code>Period</code></a>
-string: <a target="_blank" href="http://hl7.org/fhir/DSTU2/datatypes.html#string"><code>string</code></a>
-CodeableConcept: <a target="_blank" href="http://hl7.org/fhir/DSTU2/datatypes.html#CodeableConcept"><code>CodeableConcept</code></a>
+Annotation: http://hl7.org/fhir/DSTU2/datatypes.html#Annotation
+Attachment: http://hl7.org/fhir/DSTU2/datatypes.html#Attachment
+BackboneElement: http://hl7.org/fhir/DSTU2/backboneelement.html
+code: http://hl7.org/fhir/DSTU2/datatypes.html#code
+CodeableConcept: http://hl7.org/fhir/DSTU2/datatypes.html#CodeableConcept
+dateTime: http://hl7.org/fhir/DSTU2/datatypes.html#dateTime
+Encounter: http://hl7.org/fhir/DSTU2/encounter.html
+id: http://hl7.org/fhir/DSTU2/datatypes.html#id
+instant: http://hl7.org/fhir/DSTU2/datatypes.html#instant
+Reference: http://hl7.org/fhir/DSTU2/references.html
+Patient: http://hl7.org/fhir/DSTU2/patient.html
+Practitioner: http://hl7.org/fhir/DSTU2/practitioner.html
+Period: http://hl7.org/fhir/DSTU2/datatypes.html#Period
+RelatedPerson: http://hl7.org/fhir/DSTU2/relatedperson.html
+Resource: http://hl7.org/fhir/DSTU2/resource.html
+string: http://hl7.org/fhir/DSTU2/datatypes.html#string

--- a/lib/resources/may2015/document_reference.yaml
+++ b/lib/resources/may2015/document_reference.yaml
@@ -13,7 +13,7 @@ fields:
 - name: subject
   required: 'Yes'
   cardinality: 0..1
-  type: PatientReference
+  type: Reference (Patient)
   description: Who or what is the subject of the document.
   example: '{"reference": "Patient/1234"}'
 
@@ -31,7 +31,7 @@ fields:
 - name: author
   required: 'Yes'
   cardinality: 0..1
-  type: PractitionerReference
+  type: Reference (Practitioner)
   description: Who and/or what authored the document
   example: |
             {"author": [
@@ -50,7 +50,7 @@ fields:
   type: code
   description: The status of this document reference
   example: '{"status": "current"}'
-  note: Currently support 'current' only
+  note: Currently support `current` only
 
 - name: docStatus
   required: 'No'
@@ -58,7 +58,7 @@ fields:
   type: CodeableConcept
   description: The status of underlying document
   example: '{"status": "final"}'
-  note: Currently support 'final' and 'preliminary'
+  note: Currently support `final` and `preliminary`
 
 - name: description
   required: 'No'
@@ -78,11 +78,12 @@ fields:
     required: 'Yes'
     cardinality: 0..1
     type: string
-    description: Mime type of the content, with charset etc.
+    description: Mime type of the [content], with charset etc.
     example: |
               {"content": [
                 {"contentType": "application/xhtml+xml;charset=utf-8"}]}
-    note: contentType must be 'application/xhtml+xml;charset=utf-8'
+    note: >
+            contentType must be `application/xhtml+xml;charset=utf-8`
     url: http://hl7.org/fhir/2015May/datatypes-definitions.html#Attachment.contentType
 
   - name: data
@@ -112,7 +113,7 @@ fields:
                 "period" : {
                   "end": "2015-08-20T091014Z"}}}
     note: >
-            If provided, the service time must be set to context.period.end. If not provided, the document will be
+            If provided, the service time must be set to `context.period.end`. If not provided, the document will be
             stored with the indexed dateTime.
 
   - name: related
@@ -132,4 +133,5 @@ fields:
                     "related": [
                       {"ref": {
                         "reference": "Encounter/31419016"}}]}
-        note: context.related.ref must be an Encounter reference
+        note: >
+                `context.related.ref` must be an Encounter reference

--- a/lib/resources/may2015/types.yaml
+++ b/lib/resources/may2015/types.yaml
@@ -1,13 +1,14 @@
 ---
-Any:  <a target="_blank" href="http://hl7.org/fhir/2015May/resourcelist.html"><code>Any</code></a>
-Attachment: <a target="_blank" href="http://hl7.org/fhir/2015May/datatypes.html#Attachment"><code>Attachment</code></a>
-Element: <a target="_blank" href="http://hl7.org/fhir/2015May/element.html"><code>Element</code></a>
-code: <a target="_blank" href="http://hl7.org/fhir/2015May/datatypes.html#code"><code>code</code></a>
-dateTime: <a target="_blank" href="http://hl7.org/fhir/2015May/datatypes.html#dateTime"><code>dateTime</code></a>
-EncounterReference: <a target="_blank" href="http://hl7.org/fhir/2015May/search.html#reference"><code>Reference</code></a> (<a target="_blank" href="http://hl7.org/fhir/2015May/encounter.html"><code>Encounter</code></a>)
-instant: <a target="_blank" href="http://hl7.org/fhir/2015May/datatypes.html#instant"><code>instant</code></a>
-PatientReference: <a target="_blank" href="http://hl7.org/fhir/2015May/search.html#reference"><code>Reference</code></a> (<a target="_blank" href="http://hl7.org/fhir/2015May/patient.html"><code>Patient</code></a>)
-PractitionerReference: <a target="_blank" href="http://hl7.org/fhir/2015May/search.html#reference"><code>Reference</code></a> (<a target="_blank" href="http://hl7.org/fhir/2015May/practitioner.html"><code>Practitioner</code></a>)
-Period: <a target="_blank" href="http://hl7.org/fhir/2015May/datatypes.html#Period"><code>Period</code></a>
-string: <a target="_blank" href="http://hl7.org/fhir/2015May/datatypes.html#string"><code>string</code></a>
-CodeableConcept: <a target="_blank" href="http://hl7.org/fhir/2015May/datatypes.html#CodeableConcept"><code>CodeableConcept</code></a>
+Any: http://hl7.org/fhir/2015May/resourcelist.html
+Attachment: http://hl7.org/fhir/2015May/datatypes.html#Attachment
+code: http://hl7.org/fhir/2015May/datatypes.html#code
+CodeableConcept: http://hl7.org/fhir/2015May/datatypes.html#CodeableConcept
+dateTime: http://hl7.org/fhir/2015May/datatypes.html#dateTime
+Element: http://hl7.org/fhir/2015May/element.html
+Encounter: http://hl7.org/fhir/2015May/encounter.html
+instant: http://hl7.org/fhir/2015May/datatypes.html#instant
+Patient: http://hl7.org/fhir/2015May/patient.html
+Period: http://hl7.org/fhir/2015May/datatypes.html#Period
+Practitioner: http://hl7.org/fhir/2015May/practitioner.html
+Reference: http://hl7.org/fhir/2015May/references.html
+string: http://hl7.org/fhir/2015May/datatypes.html#string


### PR DESCRIPTION
Changes:
- Adding AllergyIntolerance DSTU2 documentation for Search, Create, and Update
- Enhancing the definition_table logic
    - Adding support for flagging fields and values for different action types
    - Adding support for simple embedding linking in notes and description fields
    - Refactoring type field definition and linking logic to be more straightforward and flexible
    - Adding 'top' link to each entry to return to the top of the action
- Updating README.md with documentation on how to use and config the definition_table method

Things to look at when running locally:
- Verify that AllergyIntolerance documentation looks accurate
- Because the type linking was reworked the field names and type links should be looked at again in may2015 and DSTU2. It shouldn't be necessary to verify DocReference AND AllergyIntolerance since they share the same system. Spot checks should be good.
- In AllergyIntolerance Update table:
  - Verify that Practitioner in the recorder field links to the FHIR Practitioner documentation
  - Verify that 'contained' in the reporter notes links to the contained field in the Update table. 
  - Verify that any of the 'top' links take you to the top of the Update section. Any of the 'top' links in the Create section should likewise take you to the top of Create.