### PR TITLE
Adding DocumentReference implementation notes

### DIFF
--- a/content/dstu2/document-reference.md
+++ b/content/dstu2/document-reference.md
@@ -28,6 +28,10 @@ To successfully POST a document, the following headers must be provided. Documen
 
 <%= definition_table(:document_reference, :create, :dstu2) %>
 
+### Implementation Notes
+
+* The [relatesTo](http://hl7.org/fhir/DSTU2/documentreference-definitions.html#DocumentReference.relatesTo) Is-Modifier field is not supported and will be ignored if present.
+
 #### Example Body
 
     {

--- a/content/dstu2/document-reference.md
+++ b/content/dstu2/document-reference.md
@@ -26,11 +26,11 @@ To successfully POST a document, the following headers must be provided. Documen
 
 ### Body fields
 
-<%= definition_table(:document_reference, :create, :dstu2) %>
-
-### Implementation Notes
+_Implementation Notes_   
 
 * The [relatesTo](http://hl7.org/fhir/DSTU2/documentreference-definitions.html#DocumentReference.relatesTo) Is-Modifier field is not supported and will be ignored if present.
+
+<%= definition_table(:document_reference, :create, :dstu2) %>
 
 #### Example Body
 

--- a/content/may2015/document-reference.md
+++ b/content/may2015/document-reference.md
@@ -28,6 +28,10 @@ To successfully POST a document, the following headers must be provided. Documen
 
 <%= definition_table(:document_reference, :create, :may2015) %>
 
+### Implementation Notes
+
+* The [relatesTo](http://hl7.org/fhir/2015May/documentreference-definitions.html#DocumentReference.relatesTo) Is-Modifier field is not supported and will be ignored if present.
+
 #### Example Body
 
     {

--- a/content/may2015/document-reference.md
+++ b/content/may2015/document-reference.md
@@ -26,11 +26,11 @@ To successfully POST a document, the following headers must be provided. Documen
 
 ### Body fields
 
-<%= definition_table(:document_reference, :create, :may2015) %>
-
-### Implementation Notes
+_Implementation Notes_
 
 * The [relatesTo](http://hl7.org/fhir/2015May/documentreference-definitions.html#DocumentReference.relatesTo) Is-Modifier field is not supported and will be ignored if present.
+
+<%= definition_table(:document_reference, :create, :may2015) %>
 
 #### Example Body
 

--- a/lib/resources/dstu2/document_reference.yaml
+++ b/lib/resources/dstu2/document_reference.yaml
@@ -143,7 +143,7 @@ fields:
     example: |
               {"context": {
                 "period" : {
-                  "end": "2015-08-20T091014Z"}}}
+                  "end": "2015-08-20T09:10:14Z"}}}
     note: >
             If provided, the service time must be set to `context.period.end`. If not provided, the document will be
             stored with the indexed dateTime.

--- a/lib/resources/may2015/document_reference.yaml
+++ b/lib/resources/may2015/document_reference.yaml
@@ -120,7 +120,7 @@ fields:
     example: |
               {"context": {
                 "period" : {
-                  "end": "2015-08-20T091014Z"}}}
+                  "end": "2015-08-20T09:10:14Z"}}}
     note: >
             If provided, the service time must be set to `context.period.end`. If not provided, the document will be
             stored with the indexed dateTime.


### PR DESCRIPTION
- Adding "Implementation Notes" section to DocumentReference (may2015 and dstu2) to indicate that we do not support and ignore the relatesTo modifier
- Colonizing the DocumentReference.context.period.end example