### PR TITLE
Update DSTU2 documentation for Observation

### DIFF
--- a/content/dstu2/observation.md
+++ b/content/dstu2/observation.md
@@ -7,6 +7,10 @@ title: Observation | DSTU 2 API
 * TOC
 {:toc}
 
+## Terminology Bindings
+
+<%= terminology_table(:observation, :dstu2) %>
+
 ## Search
 
 Search for labs, vitals, and alcohol/tobacco use Observations that meet supplied query parameters:

--- a/lib/dstu2_resources.rb
+++ b/lib/dstu2_resources.rb
@@ -2280,112 +2280,19 @@ module Cerner
         "link": [
           {
             "relation": "self",
-            "url": "https://fhir.sandboxcernerpowerchart.com/dstu2/d075cf8b-3261-481d-97e5-ba6c48d3b41f/Observation?subject%3APatient=3998008&_count=50"
+            "url": "https://fhir-open.sandboxcernerpowerchart.com/dstu2/d075cf8b-3261-481d-97e5-ba6c48d3b41f/Observation?subject%3APatient=3998008&_count=50"
           }
         ],
         "entry": [
           {
-            "fullUrl": "https://fhir.sandboxcernerpowerchart.com/dstu2/d075cf8b-3261-481d-97e5-ba6c48d3b41f/Observation/5525867",
+            "fullUrl": "https://fhir-open.sandboxcernerpowerchart.com/dstu2/d075cf8b-3261-481d-97e5-ba6c48d3b41f/Observation/93-5525867",
             "resource": {
               "resourceType": "Observation",
-              "id": "5525867",
+              "id": "93-5525867",
               "meta": {
                 "versionId": "1252402",
                 "lastUpdated": "2016-01-26T21:58:41.000Z"
               },
-              "contained": [
-                {
-                  "resourceType": "Observation",
-                  "id": "5525867-q6930400",
-                  "status": "final",
-                  "code": {
-                    "text": "SHX Tobacco use"
-                  },
-                  "subject": {
-                    "reference": "Patient/3998008"
-                  },
-                  "issued": "2016-01-26T21:58:41.000Z",
-                  "valueString": "Current some day smoker"
-                },
-                {
-                  "resourceType": "Observation",
-                  "id": "5525867-q6930404",
-                  "status": "final",
-                  "code": {
-                    "text": "SHX Tobacco type"
-                  },
-                  "subject": {
-                    "reference": "Patient/3998008"
-                  },
-                  "issued": "2016-01-26T21:58:41.000Z",
-                  "valueString": "Cigarettes, Chewing tobacco"
-                },
-                {
-                  "resourceType": "Observation",
-                  "id": "5525867-q6930316",
-                  "status": "final",
-                  "code": {
-                    "text": "SHX Tobacco number of years"
-                  },
-                  "subject": {
-                    "reference": "Patient/3998008"
-                  },
-                  "issued": "2016-01-26T21:58:41.000Z",
-                  "valueString": "10"
-                },
-                {
-                  "resourceType": "Observation",
-                  "id": "5525867-q6930360",
-                  "status": "final",
-                  "code": {
-                    "text": "SHX Tobacco started at age"
-                  },
-                  "subject": {
-                    "reference": "Patient/3998008"
-                  },
-                  "issued": "2016-01-26T21:58:41.000Z",
-                  "valueString": "22 Years"
-                },
-                {
-                  "resourceType": "Observation",
-                  "id": "5525867-q6930372",
-                  "status": "final",
-                  "code": {
-                    "text": "SHX Tobacco readiness to change"
-                  },
-                  "subject": {
-                    "reference": "Patient/3998008"
-                  },
-                  "issued": "2016-01-26T21:58:41.000Z",
-                  "valueString": "No"
-                },
-                {
-                  "resourceType": "Observation",
-                  "id": "5525867-q6930368",
-                  "status": "final",
-                  "code": {
-                    "text": "SHX Tobacco previous treatment"
-                  },
-                  "subject": {
-                    "reference": "Patient/3998008"
-                  },
-                  "issued": "2016-01-26T21:58:41.000Z",
-                  "valueString": "None"
-                },
-                {
-                  "resourceType": "Observation",
-                  "id": "5525867-q6930376",
-                  "status": "final",
-                  "code": {
-                    "text": "SHX Tobacco household concerns"
-                  },
-                  "subject": {
-                    "reference": "Patient/3998008"
-                  },
-                  "issued": "2016-01-26T21:58:41.000Z",
-                  "valueString": "Yes"
-                }
-              ],
               "status": "final",
               "code": {
                 "coding": [
@@ -2404,50 +2311,184 @@ module Cerner
                 {
                   "type": "has-member",
                   "target": {
-                    "reference": "#5525867-q6930400"
-                  }
-                },
-                {
-                  "type": "has-member",
-                  "target": {
-                    "reference": "#5525867-q6930404"
-                  }
-                },
-                {
-                  "type": "has-member",
-                  "target": {
-                    "reference": "#5525867-q6930316"
-                  }
-                },
-                {
-                  "type": "has-member",
-                  "target": {
-                    "reference": "#5525867-q6930360"
-                  }
-                },
-                {
-                  "type": "has-member",
-                  "target": {
-                    "reference": "#5525867-q6930372"
-                  }
-                },
-                {
-                  "type": "has-member",
-                  "target": {
-                    "reference": "#5525867-q6930368"
-                  }
-                },
-                {
-                  "type": "has-member",
-                  "target": {
-                    "reference": "#5525867-q6930376"
+                    "reference": "Observation/5525867"
                   }
                 }
               ]
             }
           },
           {
-            "fullUrl": "https://fhir.sandboxcernerpowerchart.com/dstu2/d075cf8b-3261-481d-97e5-ba6c48d3b41f/Observation/M5853272",
+            "fullUrl": "https://fhir-open.sandboxcernerpowerchart.com/dstu2/d075cf8b-3261-481d-97e5-ba6c48d3b41f/Observation/5525867",
+            "resource": {
+              "resourceType": "Observation",
+              "id": "5525867",
+              "meta": {
+                "versionId": "1252402",
+                "lastUpdated": "2016-01-26T21:58:41.000Z"
+              },
+              "status": "final",
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://snomed.info/sct",
+                    "code": "229819007",
+                    "display": "Tobacco use and exposure (observable entity)"
+                  }
+                ],
+                "text": "Tobacco"
+              },
+              "subject": {
+                "reference": "Patient/3998008"
+              },
+              "related": [
+                {
+                  "type": "has-member",
+                  "target": {
+                    "reference": "Observation/5525867-q6930400"
+                  }
+                },
+                {
+                  "type": "has-member",
+                  "target": {
+                    "reference": "Observation/5525867-q6930404-0"
+                  }
+                },
+                {
+                  "type": "has-member",
+                  "target": {
+                    "reference": "Observation/5525867-q6930404-1"
+                  }
+                },
+                {
+                  "type": "has-member",
+                  "target": {
+                    "reference": "Observation/5525867-q6930316"
+                  }
+                },
+                {
+                  "type": "has-member",
+                  "target": {
+                    "reference": "Observation/5525867-q6930360"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "fullUrl": "https://fhir-open.sandboxcernerpowerchart.com/dstu2/d075cf8b-3261-481d-97e5-ba6c48d3b41f/Observation/5525867-q6930400",
+            "resource": {
+              "resourceType": "Observation",
+              "id": "5525867-q6930400",
+              "meta": {
+                "versionId": "1252402",
+                "lastUpdated": "2016-01-26T21:58:41.000Z"
+              },
+              "status": "final",
+              "code": {
+                "text": "SHX Tobacco use"
+              },
+              "subject": {
+                "reference": "Patient/3998008"
+              },
+              "issued": "2016-01-26T21:58:41.000Z",
+              "valueCodeableConcept": {
+                "coding": [
+                  {
+                    "system": "http://snomed.info/sct",
+                    "code": "8517006",
+                    "display": "Ex-smoker (finding)"
+                  }
+                ],
+                "text": "Former smoker"
+              }
+            }
+          },
+          {
+            "fullUrl": "https://fhir-open.sandboxcernerpowerchart.com/dstu2/d075cf8b-3261-481d-97e5-ba6c48d3b41f/Observation/5525867-q6930404-0",
+            "resource": {
+              "resourceType": "Observation",
+              "id": "5525867-q6930404-0",
+              "meta": {
+                "versionId": "1252402",
+                "lastUpdated": "2016-01-26T21:58:41.000Z"
+              },
+              "status": "final",
+              "code": {
+                "text": "SHX Tobacco type"
+              },
+              "subject": {
+                "reference": "Patient/3998008"
+              },
+              "issued": "2016-01-26T21:58:41.000Z",
+              "valueCodeableConcept": {
+                "text": "Cigarettes"
+              }
+            }
+          },
+          {
+            "fullUrl": "https://fhir-open.sandboxcernerpowerchart.com/dstu2/d075cf8b-3261-481d-97e5-ba6c48d3b41f/Observation/5525867-q6930404-1",
+            "resource": {
+              "resourceType": "Observation",
+              "id": "5525867-q6930404-1",
+              "meta": {
+                "versionId": "1252402",
+                "lastUpdated": "2016-01-26T21:58:41.000Z"
+              },
+              "status": "final",
+              "code": {
+                "text": "SHX Tobacco type"
+              },
+              "subject": {
+                "reference": "Patient/3998008"
+              },
+              "issued": "2016-01-26T21:58:41.000Z",
+              "valueCodeableConcept": {
+                "text": "Chewing tobacco"
+              }
+            }
+          },
+          {
+            "fullUrl": "https://fhir-open.sandboxcernerpowerchart.com/dstu2/d075cf8b-3261-481d-97e5-ba6c48d3b41f/Observation/5525867-q6930316",
+            "resource": {
+              "resourceType": "Observation",
+              "id": "5525867-q6930316",
+              "meta": {
+                "versionId": "1252402",
+                "lastUpdated": "2016-01-26T21:58:41.000Z"
+              },
+              "status": "final",
+              "code": {
+                "text": "SHX Tobacco number of years"
+              },
+              "subject": {
+                "reference": "Patient/3998008"
+              },
+              "issued": "2016-01-26T21:58:41.000Z",
+              "valueString": "10"
+            }
+          },
+          {
+            "fullUrl": "https://fhir-open.sandboxcernerpowerchart.com/dstu2/d075cf8b-3261-481d-97e5-ba6c48d3b41f/Observation/5525867-q6930360",
+            "resource": {
+              "resourceType": "Observation",
+              "id": "5525867-q6930360",
+              "meta": {
+                "versionId": "1252402",
+                "lastUpdated": "2016-01-26T21:58:41.000Z"
+              },
+              "status": "final",
+              "code": {
+                "text": "SHX Tobacco started at age"
+              },
+              "subject": {
+                "reference": "Patient/3998008"
+              },
+              "issued": "2016-01-26T21:58:41.000Z",
+              "valueString": "22 Years"
+            }
+          },
+          {
+            "fullUrl": "https://fhir-open.sandboxcernerpowerchart.com/dstu2/d075cf8b-3261-481d-97e5-ba6c48d3b41f/Observation/M5853272",
             "resource": {
               "resourceType": "Observation",
               "id": "M5853272",
@@ -2516,7 +2557,7 @@ module Cerner
             }
           },
           {
-            "fullUrl": "https://fhir.sandboxcernerpowerchart.com/dstu2/d075cf8b-3261-481d-97e5-ba6c48d3b41f/Observation/M5851292",
+            "fullUrl": "https://fhir-open.sandboxcernerpowerchart.com/dstu2/d075cf8b-3261-481d-97e5-ba6c48d3b41f/Observation/M5851292",
             "resource": {
               "resourceType": "Observation",
               "id": "M5851292",
@@ -2576,7 +2617,7 @@ module Cerner
             }
           },
           {
-            "fullUrl": "https://fhir.sandboxcernerpowerchart.com/dstu2/d075cf8b-3261-481d-97e5-ba6c48d3b41f/Observation/BP-5851294-5851296",
+            "fullUrl": "https://fhir-open.sandboxcernerpowerchart.com/dstu2/d075cf8b-3261-481d-97e5-ba6c48d3b41f/Observation/BP-5851294-5851296",
             "resource": {
               "resourceType": "Observation",
               "id": "BP-5851294-5851296",

--- a/lib/resources/dstu2/observation.yaml
+++ b/lib/resources/dstu2/observation.yaml
@@ -1,0 +1,67 @@
+---
+name: Observation
+field_name_base_url: http://hl7.org/fhir/DSTU2/observation-definitions.html#Observation
+fields:
+
+- name: category
+  required: 'No'
+  cardinality: 0..1
+  type: CodeableConcept
+  description: >
+    A code that classifies the general type of observation being made. This is used for searching, sorting and display
+    purposes.
+  binding:
+    description: Codes for high level observation categories.
+    terminology:
+    - display: Observation Category Codes
+      system: http://hl7.org/fhir/observation-category
+
+- name: code
+  required: 'Yes'
+  cardinality: 1..1
+  type: CodeableConcept
+  description: Describes what was observed. Sometimes this is called the observation "name".
+  binding:
+    description: Codes identifying names of simple observations.
+    terminology:
+    - display: LOINC
+      system: http://loinc.org
+    - display: SNOMED CT
+      system: http://snomed.info/sct
+
+- name: interpretation
+  required: 'No'
+  cardinality: 0..1
+  type: CodeableConcept
+  description: >
+    The assessment made based on the result of the observation. Intended as a simple compact code often placed adjacent
+    to the result value in reports and flow sheets to signal the meaning/normalcy status of the result. Otherwise known
+    as abnormal flag.
+  binding:
+    description: Codes identifying interpretations of observations.
+    terminology:
+    - display: v2 Interpretation Codes
+      system: http://hl7.org/fhir/DSTU2/v2/0078
+
+- name: component
+  required: 'No'
+  cardinality: 0..*
+  type: BackboneElement
+  description: >
+    Some observations have multiple component observations. These component observations are expressed as separate code
+    value pairs that share the same attributes. Examples include systolic and diastolic component observations for
+    blood pressure measurement and multiple component observations for genetics observations.
+  children:
+
+  - name: code
+    required: 'Yes'
+    cardinality: 1..1
+    type: CodeableConcept
+    description: Describes what was observed. Sometimes this is called the observation "code".
+    binding:
+      description: Codes identifying names of simple observations.
+      terminology:
+      - display: LOINC
+        system: http://loinc.org
+      - display: SNOMED CT
+        system: http://snomed.info/sct


### PR DESCRIPTION
* Switch all example urls for Observations to fhir-open to match other examples
* Update tobacco Observation to show the category, form, and question answer Observations