### PR TITLE
Update to document reference create description.

### DIFF
--- a/content/dstu2/document-reference.md
+++ b/content/dstu2/document-reference.md
@@ -13,7 +13,7 @@ title: DocumentReference | DSTU 2 API
 
 ## Create
 
-Create new documents. Currently only XHTML formatted documents are supported. Only documents that need to be associated to the patient's chart should be written. Please validate your document is valid XHTML using any available validator like the one linked [here]. 
+Create new documents. Currently limited to unstructured clinical notes or documentation. For example, a document with display formatting or styling can be written, but a CCD cannot. 
 
     POST /DocumentReference
 
@@ -29,6 +29,7 @@ To successfully POST a document, the following headers must be provided. Documen
 _Implementation Notes_   
 
 * The [relatesTo] modifier element is not supported and will be ignored if present.
+* Currently only XHTML formatted documents are supported. You can validate your document using any available XHTML validator like the one linked [here].
 
 <%= definition_table(:document_reference, :create, :dstu2) %>
 

--- a/content/dstu2/document-reference.md
+++ b/content/dstu2/document-reference.md
@@ -13,7 +13,7 @@ title: DocumentReference | DSTU 2 API
 
 ## Create
 
-Create new documents. Only documents that would be classified as notes are currently supported.
+Create new documents. Currently only XHTML formatted documents are supported. Only documents that need to be associated to the patient's chart should be written. Please validate your document is valid XHTML using any available validator like the one linked [here]. 
 
     POST /DocumentReference
 
@@ -109,3 +109,4 @@ _Implementation Notes_
 </pre>
 
 [relatesTo]: http://hl7.org/fhir/DSTU2/documentreference-definitions.html#DocumentReference.relatesTo
+[here]: https://html5.validator.nu/

--- a/content/may2015/document-reference.md
+++ b/content/may2015/document-reference.md
@@ -13,7 +13,7 @@ title: DocumentReference | MAY 2015 BALLOT API
 
 ## Create
 
-Create new documents. Only documents that would be classified as notes are currently supported.
+Create new documents. Currently limited to unstructured clinical notes or documentation. For example, a document with display formatting or styling can be written, but a CCD cannot.
 
     POST /DocumentReference
 
@@ -29,6 +29,7 @@ To successfully POST a document, the following headers must be provided. Documen
 _Implementation Notes_
 
 * The [relatesTo](http://hl7.org/fhir/2015May/documentreference-definitions.html#DocumentReference.relatesTo) modifier element is not supported and will be ignored if present.
+* Currently only XHTML formatted documents are supported. You can validate your document using any available XHTML validator like the one linked [here].
 
 <%= definition_table(:document_reference, :create, :may2015) %>
 
@@ -106,3 +107,5 @@ _Implementation Notes_
    x-runtime → 3.751004
    x-xss-protection → 1; mode=block
 </pre>
+
+[here]: https://html5.validator.nu/

--- a/lib/resources/dstu2/document_reference.yaml
+++ b/lib/resources/dstu2/document_reference.yaml
@@ -148,7 +148,7 @@ fields:
       required: 'Yes'
       cardinality: 0..1
       type: string
-      description: Data inline, base64-ed
+      description: Data inline, base64 encoded XHTML.
       example: |
         {
           "content": [
@@ -159,6 +159,12 @@ fields:
             }
           ]
         }
+      note: >
+        You can validate your document using any available XHTML validator like the one linked
+        <a href="https://html5.validator.nu/">here</a>.
+        Some sanitization is run on provided XHMTL. For example: Applet, iframe, link, script, and style tags will be
+        removed completely. Other tags (a, button, form, frame, frameset, input, object, option, select, textarea) may be
+        removed but the text within will remain.
       url: http://hl7.org/fhir/DSTU2/datatypes-definitions.html#Attachment.data
 
 - name: context

--- a/lib/resources/may2015/document_reference.yaml
+++ b/lib/resources/may2015/document_reference.yaml
@@ -129,7 +129,7 @@ fields:
     required: 'Yes'
     cardinality: 0..1
     type: string
-    description: Data inline, base64-ed
+    description: Data inline, base64 encoded XHTML.
     example: |
       {
         "content": [
@@ -138,6 +138,12 @@ fields:
           }
         ]
       }
+    note: >
+      You can validate your document using any available XHTML validator like the one linked
+      <a href="https://html5.validator.nu/">here</a>.
+      Some sanitization is run on provided XHMTL. For example: Applet, iframe, link, script, and style tags will be
+      removed completely. Other tags (a, button, form, frame, frameset, input, object, option, select, textarea) may be
+      removed but the text within will remain.
     url: http://hl7.org/fhir/2015May/datatypes-definitions.html#Attachment.data
 
 - name: context


### PR DESCRIPTION
Added more information to eh create description to explain that the document being created must be valid XHTML.