### PR TITLE
Add DSTU2 documentation for CarePlan

### DIFF
--- a/content/dstu2/care-plan.md
+++ b/content/dstu2/care-plan.md
@@ -1,0 +1,68 @@
+---
+title: CarePlan | DSTU 2 API
+---
+
+# CarePlan
+
+* TOC
+{:toc}
+
+## Terminology Bindings
+
+<%= terminology_table(:care_plan, :dstu2) %>
+
+## Search
+
+Search for CarePlans that meet supplied query parameters:
+
+    GET /CarePlan?:parameters
+
+_Implementation Notes_
+
+* The [CarePlan.activity] element is not supported and will not be returned. This means that the [CarePlan.activity.detail.status] and [CarePlan.activity.detail.prohibited] modifier elements will not be returned.
+
+* The description of the CarePlan is included in the [CarePlan.text.div] element as escaped XHTML. We will be making changes to increase the usability of the description.
+
+### Parameters
+
+ Name         | Required?                              | Type          | Description
+--------------|----------------------------------------|---------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------
+ `_id`        | This, or one of `patient` or `subject` | [`token`]     | The logical resource id associated with the resource.
+ `date`       | N                                      | [`date`]      | Time period plan covers. Example: `date=ge2016-08` or `date=le2017-01-24T12:00:00.000Z`
+ `patient`    | This, or one of `_id` or `subject`     | [`reference`] | Who care plan is for. Example: `patient=1316024`
+ `subject`    | This, or one of `_id` or `patient`     | [`reference`] | Who care plan is for. Must represent a Patient resource. May use the `:Patient` modifier. Example: `subject=Patient/1316024` or `subject:Patient=1316024`
+ [`_count`]   | N                                      | [`number`]    | Number of results per page. Defaults to `10`. Capped at `10`.
+
+Notes:
+
+- The `_id` parameter may not be provided at the same time as the `date`, `patient`, or `subject` parameters. When `_id` is provided, `_count` is ignored.
+
+- The `patient` parameter is preferred when set simultaneously with `subject`.
+
+- The `date` parameter may be provided up to two times, and must use the `ge` or `le` prefixes. When provided twice, the lower value must have the `ge` prefix and the higher value must have the `le` prefix.
+
+### Response
+
+<%= headers 200 %>
+<%= json(:dstu2_care_plan_bundle) %>
+
+## Retrieve by id
+
+List an individual CarePlan by its id:
+
+    GET /CarePlan/:id
+
+### Response
+
+<%= headers 200 %>
+<%= json(:dstu2_care_plan_entry) %>
+
+[CarePlan.activity]: https://www.hl7.org/fhir/careplan-definitions.html#CarePlan.activity
+[CarePlan.activity.detail.status]: https://www.hl7.org/fhir/careplan-definitions.html#CarePlan.activity.detail.status
+[CarePlan.activity.detail.prohibited]: https://www.hl7.org/fhir/careplan-definitions.html#CarePlan.activity.detail.prohibited
+[CarePlan.text.div]: https://www.hl7.org/fhir/careplan-definitions.html#CarePlan.text.div
+[`token`]: http://hl7.org/fhir/DSTU2/search.html#token
+[`date`]: http://hl7.org/fhir/DSTU2/search.html#date
+[`reference`]: http://hl7.org/fhir/DSTU2/search.html#reference
+[`_count`]: http://hl7.org/fhir/DSTU2/search.html#count
+[`number`]: http://hl7.org/fhir/DSTU2/search.html#number

--- a/layouts/dstu2_sidebar.html
+++ b/layouts/dstu2_sidebar.html
@@ -8,17 +8,20 @@
         <h3><a href="/dstu2/authorization">Authorization</a></h3>
       </li>
       <li class="js-topic">
-        <h3><a href="/dstu2/binary">Binary</a></h3>
-      </li>
-      <li class="js-topic">
         <h3><a href="/dstu2/conformance/">Conformance Metadata</a></h3>
-      </li>     
+      </li>
       <li class="js-topic">
         <h3><a href="/dstu2/allergy-intolerance/">AllergyIntolerance</a></h3>
       </li>
       <li class="js-topic">
           <h3><a href="/dstu2/appointment/">Appointment</a></h3>
-      </li>          
+      </li>
+      <li class="js-topic">
+        <h3><a href="/dstu2/binary">Binary</a></h3>
+      </li>
+      <li class="js-topic">
+        <h3><a href="/dstu2/care-plan/">CarePlan</a></h3>
+      </li>
       <li class="js-topic">
         <h3><a href="/dstu2/condition/">Condition</a></h3>
       </li>
@@ -33,7 +36,7 @@
       </li>
       <li class="js-topic">
         <h3><a href="/dstu2/document-reference/">DocumentReference</a></h3>
-      </li>            
+      </li>
       <li class="js-topic">
         <h3><a href="/dstu2/encounter/">Encounter</a></h3>
       </li>

--- a/lib/resources/dstu2/care_plan.yaml
+++ b/lib/resources/dstu2/care_plan.yaml
@@ -1,0 +1,14 @@
+---
+name: CarePlan
+field_name_base_url: http://hl7.org/fhir/DSTU2/careplan-definitions.html#CarePlan
+fields:
+- name: category
+  required: 'No'
+  cardinality: 0..*
+  type: CodeableConcept
+  binding:
+    description: >
+      Identifies what kind of plan this is. The code will be "assess-plan" from the linked value set.
+    terminology:
+    - display: Argonaut Extension Codes
+      system: http://www.fhir.org/guides/argonaut/r2/ValueSet-argo-codesystem.html

--- a/lib/resources/example_json/dstu2_examples_care_plan.rb
+++ b/lib/resources/example_json/dstu2_examples_care_plan.rb
@@ -1,0 +1,150 @@
+module Cerner
+  module Resources
+
+    DSTU2_CARE_PLAN_ENTRY ||= {
+      "resourceType": "CarePlan",
+      "id": "7499295",
+      "meta": {
+        "versionId": "1",
+        "lastUpdated": "2017-01-27T16:32:54-06:00"
+      },
+      "text": {
+        "status": "additional",
+        "div": "&lt;div>&lt;p>&lt;b>Care Plan&lt;/b>&lt;/p>&lt;p>&lt;b>Patient&lt;/b>: PETERS, TIMOTHY&lt;/p>&lt;p>&lt;b>Description&lt;/b>: &amp;lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;&amp;lt;!DOCTYPE html PUBLIC &quot;-//W3C//DTD XHTML 1.0 Strict//EN&quot; &quot;http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd&quot;&gt;&amp;lt;html xmlns=&quot;http://www.w3.org/1999/xhtml&quot;&gt;&amp;lt;head&gt;&amp;lt;meta http-equiv=&quot;Content-Type&quot; content=&quot;text/html; charset=utf-8&quot; /&gt;&amp;lt;title&gt;XSL FO Document&amp;lt;/title&gt;&amp;lt;/head&gt;&amp;lt;body bgcolor=&quot;white&quot; marginwidth=&quot;6&quot; marginheight=&quot;6&quot; leftmargin=&quot;6&quot; topmargin=&quot;6&quot;&gt;&amp;lt;div valign=&quot;top&quot;&gt;&#10;&amp;lt;div style=&quot;font-family: Helvetica,sans-serif,Lucida Sans Unicode; font-size: 12pt; font-weight: normal; font-style: normal; text-decoration: none; color: rgb(0,0,0); background-color: transparent; margin-top: 0.0pt; margin-bottom: 0.0pt; text-indent: 0.0in; margin-left: 0.0in; margin-right: 0.0in; text-align: left; border-style: none; border-width: 0.0pt; border-color: rgb(0,0,0); padding: 0.0pt; white-space: pre-wrap;&quot;&gt;&amp;lt;div style=&quot;font-family: sans-serif,Lucida Sans Unicode; font-size: 24pt; font-weight: bold; margin-top: 16.05pt; margin-bottom: 16.05pt;&quot;&gt;PETERS, TIMOTHY (55 yrs.)&amp;lt;/div&gt;&amp;lt;div style=&quot;font-family: sans-serif,Lucida Sans Unicode; font-size: 18pt; font-weight: bold; margin-top: 14.9pt; margin-bottom: 14.9pt;&quot;&gt;HEAR Score: 2&amp;lt;/div&gt;&amp;lt;div style=&quot;font-family: sans-serif,Lucida Sans Unicode; margin-top: 12.0pt; margin-bottom: 12.0pt;&quot;&gt;Your patient has a LOW RISK HEAR score. Please obtain serial troponin at 0 and 3 hours. If serial troponins are negative, the HEART Pathway recommend discharge from the ED without stress testing or angiography.&amp;lt;/div&gt;&amp;lt;/div&gt;  &amp;lt;/div&gt;&amp;lt;/body&gt;&amp;lt;/html&gt;&lt;/p>&lt;p>&lt;b>Author&lt;/b>: Argonaut, Test&lt;/p>&lt;p>&lt;b>Effective Date/Time&lt;/b>: 2017-01-27T16:32:53-06:00&lt;/p>&lt;/div>"
+      },
+      "subject": {
+        "reference": "Patient/1316024",
+        "display": "PETERS, TIMOTHY"
+      },
+      "status": "completed",
+      "context": {
+        "reference": "Encounter/2675906"
+      },
+      "period": {
+        "end": "2017-01-27T16:32:53-06:00"
+      },
+      "author": [
+        {
+          "reference": "Practitioner/3622007",
+          "display": "Argonaut, Test"
+        }
+      ],
+      "modified": "2017-01-27T16:32:54-06:00",
+      "category": [
+        {
+          "coding": [
+            {
+              "system": "http://argonaut.hl7.org",
+              "code": "assess-plan"
+            }
+          ]
+        }
+      ]
+    }
+
+    DSTU2_CARE_PLAN_BUNDLE ||= {
+      "resourceType": "Bundle",
+      "id": "66a6d608-8d77-47c8-b210-2fd3f56d2c68",
+      "type": "searchset",
+      "link": [
+        {
+          "relation": "self",
+          "url": "https://fhir-open.sandboxcerner.com/dstu2/d075cf8b-3261-481d-97e5-ba6c48d3b41f/CarePlan?patient=1316024&_count=10"
+        },
+        {
+          "relation": "next",
+          "url": "https://fhir-open.sandboxcerner.com/dstu2/d075cf8b-3261-481d-97e5-ba6c48d3b41f/CarePlan?patient=1316024&-pageContext=eNqVUttq4zAQ_ZWW7KMjdHNtCwp1HBUM3TrYSujuizGKGgS2FGSn7JZ-fOUmodsNNC0IRqM5R3M70nZAKmeUA13_JIFstdGyadWTMgNouubZGrBtNtpsQPrmLZqNyqwZ1J9hcnMpP-Wvrdx140U6PSinG1CqwWkfnP3lI6JSQ3YIXd5Mds6w_Wes02umXAe2yvXWsN6sldkwRNAVxNRDURLBKUT-CAjZ2wEQwt8-hCGKphBPIREoZvCKIQpIgsYQgqdZpHUKONuqrbOPulXHXOL6Lsjn18gzzK5tvZmlVZ7VqRBlPlsKXvknfnvLM5GveD1PBfcPj03bq2_Y7DCvi_lhVP3468-F-FXf5ZX4WK60a7-HY4HeU4yEwecAnJwBEHgOQM8B0LkaQt9H6udU3NeLsljlc17-3-YHZ3C7cThf19dBqKfqKryAmkFb82Ov3lPEqOf3lPf8QdTZsqyKsUJCIhrSKIhokuA4ChCNwzDEFCdeawH8Z4-Lkq_yYlm9c3GMYRiTIAoRInjPTWJMSXzk-vZeJi_wFSyNJmU%3D&-pageDirection=NEXT"
+        }
+      ],
+      "entry": [
+        {
+          "fullUrl": "https://fhir-open.sandboxcerner.com/dstu2/d075cf8b-3261-481d-97e5-ba6c48d3b41f/CarePlan/7499295",
+          "resource": {
+            "resourceType": "CarePlan",
+            "id": "7499295",
+            "meta": {
+              "versionId": "1",
+              "lastUpdated": "2017-01-27T16:32:54-06:00"
+            },
+            "text": {
+              "status": "additional",
+              "div": "&lt;div>&lt;p>&lt;b>Care Plan&lt;/b>&lt;/p>&lt;p>&lt;b>Patient&lt;/b>: PETERS, TIMOTHY&lt;/p>&lt;p>&lt;b>Description&lt;/b>: &amp;lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;&amp;lt;!DOCTYPE html PUBLIC &quot;-//W3C//DTD XHTML 1.0 Strict//EN&quot; &quot;http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd&quot;&gt;&amp;lt;html xmlns=&quot;http://www.w3.org/1999/xhtml&quot;&gt;&amp;lt;head&gt;&amp;lt;meta http-equiv=&quot;Content-Type&quot; content=&quot;text/html; charset=utf-8&quot; /&gt;&amp;lt;title&gt;XSL FO Document&amp;lt;/title&gt;&amp;lt;/head&gt;&amp;lt;body bgcolor=&quot;white&quot; marginwidth=&quot;6&quot; marginheight=&quot;6&quot; leftmargin=&quot;6&quot; topmargin=&quot;6&quot;&gt;&amp;lt;div valign=&quot;top&quot;&gt;&#10;&amp;lt;div style=&quot;font-family: Helvetica,sans-serif,Lucida Sans Unicode; font-size: 12pt; font-weight: normal; font-style: normal; text-decoration: none; color: rgb(0,0,0); background-color: transparent; margin-top: 0.0pt; margin-bottom: 0.0pt; text-indent: 0.0in; margin-left: 0.0in; margin-right: 0.0in; text-align: left; border-style: none; border-width: 0.0pt; border-color: rgb(0,0,0); padding: 0.0pt; white-space: pre-wrap;&quot;&gt;&amp;lt;div style=&quot;font-family: sans-serif,Lucida Sans Unicode; font-size: 24pt; font-weight: bold; margin-top: 16.05pt; margin-bottom: 16.05pt;&quot;&gt;PETERS, TIMOTHY (55 yrs.)&amp;lt;/div&gt;&amp;lt;div style=&quot;font-family: sans-serif,Lucida Sans Unicode; font-size: 18pt; font-weight: bold; margin-top: 14.9pt; margin-bottom: 14.9pt;&quot;&gt;HEAR Score: 2&amp;lt;/div&gt;&amp;lt;div style=&quot;font-family: sans-serif,Lucida Sans Unicode; margin-top: 12.0pt; margin-bottom: 12.0pt;&quot;&gt;Your patient has a LOW RISK HEAR score. Please obtain serial troponin at 0 and 3 hours. If serial troponins are negative, the HEART Pathway recommend discharge from the ED without stress testing or angiography.&amp;lt;/div&gt;&amp;lt;/div&gt;  &amp;lt;/div&gt;&amp;lt;/body&gt;&amp;lt;/html&gt;&lt;/p>&lt;p>&lt;b>Author&lt;/b>: Argonaut, Test&lt;/p>&lt;p>&lt;b>Effective Date/Time&lt;/b>: 2017-01-27T16:32:53-06:00&lt;/p>&lt;/div>"
+            },
+            "subject": {
+              "reference": "Patient/1316024",
+              "display": "PETERS, TIMOTHY"
+            },
+            "status": "completed",
+            "context": {
+              "reference": "Encounter/2675906"
+            },
+            "period": {
+              "end": "2017-01-27T16:32:53-06:00"
+            },
+            "author": [
+              {
+                "reference": "Practitioner/3622007",
+                "display": "Argonaut, Test"
+              }
+            ],
+            "modified": "2017-01-27T16:32:54-06:00",
+            "category": [
+              {
+                "coding": [
+                  {
+                    "system": "http://argonaut.hl7.org",
+                    "code": "assess-plan"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "fullUrl": "https://fhir-open.sandboxcerner.com/dstu2/d075cf8b-3261-481d-97e5-ba6c48d3b41f/CarePlan/7499291",
+          "resource": {
+            "resourceType": "CarePlan",
+            "id": "7499291",
+            "meta": {
+              "versionId": "1",
+              "lastUpdated": "2017-01-27T15:27:34-06:00"
+            },
+            "text": {
+              "status": "additional",
+              "div": "&lt;div>&lt;p>&lt;b>Care Plan&lt;/b>&lt;/p>&lt;p>&lt;b>Patient&lt;/b>: PETERS, TIMOTHY&lt;/p>&lt;p>&lt;b>Description&lt;/b>: &amp;lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;&amp;lt;!DOCTYPE html PUBLIC &quot;-//W3C//DTD XHTML 1.0 Strict//EN&quot; &quot;http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd&quot;&gt;&amp;lt;html xmlns=&quot;http://www.w3.org/1999/xhtml&quot;&gt;&amp;lt;head&gt;&amp;lt;meta http-equiv=&quot;Content-Type&quot; content=&quot;text/html; charset=utf-8&quot; /&gt;&amp;lt;title&gt;XSL FO Document&amp;lt;/title&gt;&amp;lt;/head&gt;&amp;lt;body bgcolor=&quot;white&quot; marginwidth=&quot;6&quot; marginheight=&quot;6&quot; leftmargin=&quot;6&quot; topmargin=&quot;6&quot;&gt;&amp;lt;div valign=&quot;top&quot;&gt;&#10;&amp;lt;div style=&quot;font-family: Helvetica,sans-serif,Lucida Sans Unicode; font-size: 12pt; font-weight: normal; font-style: normal; text-decoration: none; color: rgb(0,0,0); background-color: transparent; margin-top: 0.0pt; margin-bottom: 0.0pt; text-indent: 0.0in; margin-left: 0.0in; margin-right: 0.0in; text-align: left; border-style: none; border-width: 0.0pt; border-color: rgb(0,0,0); padding: 0.0pt; white-space: pre-wrap;&quot;&gt;&amp;lt;div style=&quot;font-family: sans-serif,Lucida Sans Unicode; font-size: 24pt; font-weight: bold; margin-top: 16.05pt; margin-bottom: 16.05pt;&quot;&gt;PETERS, TIMOTHY (55 yrs.)&amp;lt;/div&gt;&amp;lt;div style=&quot;font-family: sans-serif,Lucida Sans Unicode; font-size: 18pt; font-weight: bold; margin-top: 14.9pt; margin-bottom: 14.9pt;&quot;&gt;HEAR Score: 4&amp;lt;/div&gt;&amp;lt;div style=&quot;font-family: sans-serif,Lucida Sans Unicode; margin-top: 12.0pt; margin-bottom: 12.0pt;&quot;&gt;Your patient is at risk for ACS! Further cardiac evaluation including serial troponins and stress testing or angiography is recommended.&amp;lt;/div&gt;&amp;lt;/div&gt;  &amp;lt;/div&gt;&amp;lt;/body&gt;&amp;lt;/html&gt;&lt;/p>&lt;p>&lt;b>Author&lt;/b>: Argonaut, Test&lt;/p>&lt;p>&lt;b>Effective Date/Time&lt;/b>: 2017-01-27T15:27:10-06:00&lt;/p>&lt;/div>"
+            },
+            "subject": {
+              "reference": "Patient/1316024",
+              "display": "PETERS, TIMOTHY"
+            },
+            "status": "completed",
+            "context": {
+              "reference": "Encounter/2675906"
+            },
+            "period": {
+              "end": "2017-01-27T15:27:10-06:00"
+            },
+            "author": [
+              {
+                "reference": "Practitioner/3622007",
+                "display": "Argonaut, Test"
+              }
+            ],
+            "modified": "2017-01-27T15:27:34-06:00",
+            "category": [
+              {
+                "coding": [
+                  {
+                    "system": "http://argonaut.hl7.org",
+                    "code": "assess-plan"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    }
+
+  end
+end

--- a/lib/resources/example_json/dstu2_examples_conformance.rb
+++ b/lib/resources/example_json/dstu2_examples_conformance.rb
@@ -11,7 +11,7 @@ module Cerner
       "name": "Cerner Conformance Statement",
       "status": "draft",
       "publisher": "Cerner",
-      "date": "2016-11-28",
+      "date": "2017-01-23",
       "description": "Describes capabilities of this server",
       "kind": "instance",
       "fhirVersion": "1.0.2",
@@ -68,6 +68,39 @@ module Cerner
               "interaction": [
                 {
                   "code": "read"
+                }
+              ]
+            },
+            {
+              "type": "CarePlan",
+              "interaction": [
+                {
+                  "code": "read"
+                },
+                {
+                  "code": "search-type"
+                }
+              ],
+              "searchParam": [
+                {
+                  "name": "patient",
+                  "type": "reference",
+                  "documentation": "Who care plan is for. It is a required field if _id field is not given"
+                },
+                {
+                  "name": "_id",
+                  "type": "token",
+                  "documentation": "A single or comma separated list of CarePlan ids. It is a required field if patient field is not given"
+                },
+                {
+                  "name": "date",
+                  "type": "date",
+                  "documentation": "Time period plan covers. The prefixes 'ge' and 'le' are supported for this parameter. Date may be provided once to imply a date range or twice to specify a range. When two dates are provided they must create a closed range."
+                },
+                {
+                  "name": "_count",
+                  "type": "number",
+                  "documentation": "The maximum number of results to return in a page."
                 }
               ]
             },
@@ -393,7 +426,7 @@ module Cerner
       "name": "Cerner Conformance Statement",
       "status": "draft",
       "publisher": "Cerner",
-      "date": "2016-11-28",
+      "date": "2017-01-23",
       "description": "Describes capabilities of this server",
       "kind": "instance",
       "fhirVersion": "1.0.2",
@@ -484,6 +517,39 @@ module Cerner
               "interaction": [
                 {
                   "code": "read"
+                }
+              ]
+            },
+            {
+              "type": "CarePlan",
+              "interaction": [
+                {
+                  "code": "read"
+                },
+                {
+                  "code": "search-type"
+                }
+              ],
+              "searchParam": [
+                {
+                  "name": "patient",
+                  "type": "reference",
+                  "documentation": "Who care plan is for. It is a required field if _id field is not given"
+                },
+                {
+                  "name": "_id",
+                  "type": "token",
+                  "documentation": "A single or comma separated list of CarePlan ids. It is a required field if patient field is not given"
+                },
+                {
+                  "name": "date",
+                  "type": "date",
+                  "documentation": "Time period plan covers. The prefixes 'ge' and 'le' are supported for this parameter. Date may be provided once to imply a date range or twice to specify a range. When two dates are provided they must create a closed range."
+                },
+                {
+                  "name": "_count",
+                  "type": "number",
+                  "documentation": "The maximum number of results to return in a page."
                 }
               ]
             },

--- a/lib/resources/example_json/dstu2_examples_relatedperson.rb
+++ b/lib/resources/example_json/dstu2_examples_relatedperson.rb
@@ -184,7 +184,7 @@ module Cerner
             ],
             "patient": {
               "reference": "Patient/3838011",
-              "display": "Peters, Timothy"
+              "display": "Peters, Jennifer"
             },
             "name": {
               "use": "official",


### PR DESCRIPTION
Do we need to do anything special for the category terminology binding since we are using the argonaut extension?  Should I just include an example for http://argonaut.hl7.org|assess-plan ?