### PR TITLE
Updating Patient documentation for Patient.link, extensions, and other changes

### DIFF
--- a/content/dstu2/patient.md
+++ b/content/dstu2/patient.md
@@ -8,24 +8,21 @@ title: Patient | DSTU 2 API
 {:toc}
 
 ## Overview
-The Patient resource provides general demographic information about the person receiving health care services from a specific organization. Common demographic fields or
-values include the patient id, patient names, gender, date of birth, address, phone, and marital status. A person receiving care from multiple organizations may have data
-available in multiple Patient resources in multiple FHIR servers. The Patient resource is commonly referenced by many of the other resources.
+The Patient Resource provides general demographic information about a person receiving health care services from a specific organization. Common demographic fields include patient id, patient name, gender, date of birth, address, phone, primary language and marital status. Cerner Millennium is a patient centric application: thus, many of the other resources will include the patient id in their queries. A person receiving care from multiple organizations may have data available in multiple patient resources in multiple FHIR servers.
 
 The following fields are returned if valued:
 
-   * Patient name
-   * Patient id
-   * Medical Record number (MRN)
-   * Phone (email is not supported at this time)
-   * Contact person (guardian, parent or emergency)
-   * Gender (administrative)
-   * Date of Birth
-   * Deceased
-   * Address
-   * Communication (preferred language)
-   * Link (if the patient record has been combined into another record)
-   * Marital status
+   * [Patient name](http://hl7.org/fhir/DSTU2/patient-definitions.html#Patient.name){:target="_blank"}
+   * [Patient id](http://hl7.org/fhir/DSTU2/resource-definitions.html#Resource.id){:target="_blank"}
+   * [Medical Record number (MRN)](http://hl7.org/fhir/DSTU2/patient-definitions.html#Patient.identifier){:target="_blank"}
+   * [Phone (email is not supported at this time)](http://hl7.org/fhir/DSTU2/patient-definitions.html#Patient.telecom){:target="_blank"}
+   * [Contact person (guardian, parent or emergency)](http://hl7.org/fhir/DSTU2/patient-definitions.html#Patient.contact){:target="_blank"}
+   * [Gender (administrative)](http://hl7.org/fhir/DSTU2/patient-definitions.html#Patient.gender){:target="_blank"}
+   * [Date of Birth](http://hl7.org/fhir/DSTU2/patient-definitions.html#Patient.birthDate){:target="_blank"}
+   * [Deceased](http://hl7.org/fhir/DSTU2/patient-definitions.html#Patient.deceased_x_){:target="_blank"}
+   * [Address](http://hl7.org/fhir/DSTU2/patient-definitions.html#Patient.address){:target="_blank"}
+   * [Communication (preferred language)](http://hl7.org/fhir/DSTU2/patient-definitions.html#Patient.communication.language){:target="_blank"}
+   * [Marital status](http://hl7.org/fhir/DSTU2/patient-definitions.html#Patient.maritalStatus){:target="_blank"}
 
 ## Terminology Bindings
 

--- a/content/dstu2/patient.md
+++ b/content/dstu2/patient.md
@@ -7,6 +7,26 @@ title: Patient | DSTU 2 API
 * TOC
 {:toc}
 
+## Overview
+The Patient resource provides general demographic information about the person receiving health care services from a specific organization. Common demographic fields or
+values include the patient id, patient names, gender, date of birth, address, phone, and marital status. A person receiving care from multiple organizations may have data
+available in multiple Patient resources in multiple FHIR servers. The Patient resource is commonly referenced by many of the other resources.
+
+The following fields are returned if valued:
+
+   * Patient name
+   * Patient id
+   * Medical Record number (MRN)
+   * Phone (email is not supported at this time)
+   * Contact person (guardian, parent or emergency)
+   * Gender (administrative)
+   * Date of Birth
+   * Deceased
+   * Address
+   * Communication (preferred language)
+   * Link (if the patient record has been combined into another record)
+   * Marital status
+
 ## Terminology Bindings
 
 <%= terminology_table(:patient, :dstu2) %>
@@ -22,7 +42,7 @@ Search for Patients that meet supplied query parameters:
 
 _Implementation Notes_
 
-* The [Patient.animal] and [Patient.link] modifier elements are not supported and will not be returned.
+* The [Patient.animal] modifier element is not supported and will not be returned.
 
 ### Parameters
 
@@ -58,12 +78,21 @@ List an individual Patient by its id:
 
 _Implementation Notes_
 
-* The [Patient.animal] and [Patient.link] modifier elements are not supported and will not be returned.
+* The [Patient.animal] modifier element is not supported and will not be returned.
 
 ### Response
 
 <%= headers 200 %>
 <%= json(:dstu2_patient_entry) %>
+
+### Patient Combines
+
+If the requested patient record has been combined into another patient record, an inactive Patient entry will be
+returned which has a link to the Patient entry it has been combined into. Combined patient results will only be
+returned when retrieving by id values. They will not be returned when searching with other parameters.
+
+<%= headers 200 %>
+<%= json(:dstu2_combined_patient_entry) %>
 
 [Time of day of birth]: http://hl7.org/fhir/DSTU2/extension-patient-birthtime.html
 [`token`]: http://hl7.org/fhir/DSTU2/search.html#token
@@ -72,4 +101,3 @@ _Implementation Notes_
 [`_count`]: http://hl7.org/fhir/DSTU2/search.html#count
 [`number`]: http://hl7.org/fhir/DSTU2/search.html#number
 [Patient.animal]: http://hl7.org/fhir/DSTU2/patient-definitions.html#Patient.animal
-[Patient.link]: http://hl7.org/fhir/DSTU2/patient-definitions.html#Patient.link

--- a/content/dstu2/patient.md
+++ b/content/dstu2/patient.md
@@ -14,6 +14,7 @@ The following fields are returned if valued:
 
    * [Patient name](http://hl7.org/fhir/DSTU2/patient-definitions.html#Patient.name){:target="_blank"}
    * [Patient id](http://hl7.org/fhir/DSTU2/resource-definitions.html#Resource.id){:target="_blank"}
+   * [Extensions including birth time, birth sex, ethnicity, and race](#extensions)
    * [Medical Record number (MRN)](http://hl7.org/fhir/DSTU2/patient-definitions.html#Patient.identifier){:target="_blank"}
    * [Phone (email is not supported at this time)](http://hl7.org/fhir/DSTU2/patient-definitions.html#Patient.telecom){:target="_blank"}
    * [Contact person (guardian, parent or emergency)](http://hl7.org/fhir/DSTU2/patient-definitions.html#Patient.contact){:target="_blank"}
@@ -43,7 +44,7 @@ Search for Patients that meet supplied query parameters:
 _Implementation Notes_
 
 * The [Patient.animal] modifier element is not supported and will not be returned.
-* When using an OAuth 2 patient access token to call GET /Patient without parameters, a bundle will be returned which contains the patients listed in the access token.
+* If the current user is a patient or patient proxy, a search may be performed without providing any parameters. The search will return all patients the current user has been granted access to view.
 
 ### Parameters
 

--- a/content/dstu2/patient.md
+++ b/content/dstu2/patient.md
@@ -30,6 +30,9 @@ The following fields are returned if valued:
 
 ## Extensions
 * [Time of day of birth]
+* [US Core Ethnicity]
+* [US Core Patient Birth Sex]
+* [US Core Race]
 
 ## Search
 
@@ -40,6 +43,7 @@ Search for Patients that meet supplied query parameters:
 _Implementation Notes_
 
 * The [Patient.animal] modifier element is not supported and will not be returned.
+* When using an OAuth 2 patient access token to call GET /Patient without parameters, a bundle will be returned which contains the patients listed in the access token.
 
 ### Parameters
 
@@ -95,6 +99,9 @@ The ability to perform patient combine or uncombine operations is not available 
 <%= json(:dstu2_combined_patient_entry) %>
 
 [Time of day of birth]: http://hl7.org/fhir/DSTU2/extension-patient-birthtime.html
+[US Core Race]: http://build.fhir.org/ig/Healthedata1/Argo-DSTU2/StructureDefinition-argo-race.html
+[US Core Ethnicity]: http://build.fhir.org/ig/Healthedata1/Argo-DSTU2/StructureDefinition-argo-ethnicity.html
+[US Core Patient Birth Sex]: http://build.fhir.org/ig/Healthedata1/Argo-DSTU2/StructureDefinition-argo-birthsex.html
 [`token`]: http://hl7.org/fhir/DSTU2/search.html#token
 [`date`]: http://hl7.org/fhir/DSTU2/search.html#date
 [`string`]: http://hl7.org/fhir/DSTU2/search.html#string

--- a/content/dstu2/patient.md
+++ b/content/dstu2/patient.md
@@ -87,9 +87,12 @@ _Implementation Notes_
 
 ### Patient Combines
 
-If the requested patient record has been combined into another patient record, an inactive Patient entry will be
-returned which has a link to the Patient entry it has been combined into. Combined patient results will only be
-returned when retrieving by id values. They will not be returned when searching with other parameters.
+Cerner Millennium supports the ability to logically merge a patient record into another patient record when both records are describing the same patient. This is known
+as a "patient combine". If necessary, this merging can later be undone by performing a "patient uncombine". When the requested patient record has been combined into another
+record, an inactive Patient entry will be returned which has a link to the current Patient entry. Entries for combined patients will only be returned when retrieving
+the entries directly by id. They will not be returned when searching with other parameters.
+
+The ability to perform patient combine or uncombine operations is not available through the Cerner Ignite platform.
 
 <%= headers 200 %>
 <%= json(:dstu2_combined_patient_entry) %>

--- a/lib/resources/example_json/dstu2_examples_patient.rb
+++ b/lib/resources/example_json/dstu2_examples_patient.rb
@@ -12,6 +12,52 @@ module Cerner
         "status": "generated",
         "div": "&lt;div&gt;&lt;p&gt;&lt;b&gt;Patient&lt;/b&gt;&lt;/p&gt;&lt;p&gt;&lt;b&gt;Name&lt;/b&gt;: Smart, Wilma&lt;/p&gt;&lt;p&gt;&lt;b&gt;DOB&lt;/b&gt;: 1947-03-16&lt;/p&gt;&lt;p&gt;&lt;b&gt;Sex&lt;/b&gt;: Female&lt;/p&gt;&lt;p&gt;&lt;b&gt;Status&lt;/b&gt;: Active&lt;/p&gt;&lt;/div&gt;"
       },
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/patient-birthTime",
+          "valueDateTime": "1947-03-16T13:36:00.000-06:00"
+        },
+        {
+          "url": "http://fhir.org/guides/argonaut/StructureDefinition/argo-birthsex",
+          "valueCode": "F"
+        },
+        {
+          "url": "http://fhir.org/guides/argonaut/StructureDefinition/argo-race",
+          "extension": [
+            {
+              "url": "ombCategory",
+              "valueCoding": {
+                "system": "http://hl7.org/fhir/v3/Race",
+                "code": "2054-5",
+                "display": "Black or African American",
+                "userSelected": false
+              }
+            },
+            {
+              "url": "text",
+              "valueString": "Black or African American"
+            }
+          ]
+        },
+        {
+          "url": "http://fhir.org/guides/argonaut/StructureDefinition/argo-ethnicity",
+          "extension": [
+            {
+              "url": "ombCategory",
+              "valueCoding": {
+                "system": "http://hl7.org/fhir/v3/Ethnicity",
+                "code": "2135-2",
+                "display": "Hispanic or Latino",
+                "userSelected": false
+              }
+            },
+            {
+              "url": "text",
+              "valueString": "Hispanic or Latino"
+            }
+          ]
+        }
+      ],
       "identifier": [
         {
           "use": "usual",
@@ -51,6 +97,22 @@ module Cerner
       ],
       "gender": "female",
       "birthDate": "1947-03-16",
+      "communication": [
+        {
+          "language": {
+            "coding": [
+              {
+                "system": "urn:ietf:bcp:47",
+                "code": "en",
+                "display": "English",
+                "userSelected": false
+              }
+            ],
+            "text": "English"
+          },
+          "preferred": true
+        }
+      ],
       "careProvider": [
         {
           "reference": "Practitioner/1912007",
@@ -101,6 +163,52 @@ module Cerner
               "status": "generated",
               "div": "&lt;div&gt;&lt;p&gt;&lt;b&gt;Patient&lt;/b&gt;&lt;/p&gt;&lt;p&gt;&lt;b&gt;Name&lt;/b&gt;: Smart, Nancy&lt;/p&gt;&lt;p&gt;&lt;b&gt;DOB&lt;/b&gt;: 1980-08-11&lt;/p&gt;&lt;p&gt;&lt;b&gt;Sex&lt;/b&gt;: Female&lt;/p&gt;&lt;p&gt;&lt;b&gt;Marital Status&lt;/b&gt;: Married&lt;/p&gt;&lt;p&gt;&lt;b&gt;Status&lt;/b&gt;: Active&lt;/p&gt;&lt;/div&gt;"
             },
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/patient-birthTime",
+                "valueDateTime": "1980-08-11T12:33:00.000-05:00"
+              },
+              {
+                "url": "http://fhir.org/guides/argonaut/StructureDefinition/argo-birthsex",
+                "valueCode": "F"
+              },
+              {
+                "url": "http://fhir.org/guides/argonaut/StructureDefinition/argo-race",
+                "extension": [
+                  {
+                    "url": "ombCategory",
+                    "valueCoding": {
+                      "system": "http://hl7.org/fhir/v3/Race",
+                      "code": "2106-3",
+                      "display": "White",
+                      "userSelected": false
+                    }
+                  },
+                  {
+                    "url": "text",
+                    "valueString": "White"
+                  }
+                ]
+              },
+              {
+                "url": "http://fhir.org/guides/argonaut/StructureDefinition/argo-ethnicity",
+                "extension": [
+                  {
+                    "url": "ombCategory",
+                    "valueCoding": {
+                      "system": "http://hl7.org/fhir/v3/Ethnicity",
+                      "code": "2186-5",
+                      "display": "Not Hispanic or Latino",
+                      "userSelected": false
+                    }
+                  },
+                  {
+                    "url": "text",
+                    "valueString": "Not Hispanic or Latino"
+                  }
+                ]
+              }
+            ],
             "identifier": [
               {
                 "use": "usual",
@@ -151,6 +259,22 @@ module Cerner
               ],
               "text": "Married"
             },
+            "communication": [
+              {
+                "language": {
+                  "coding": [
+                    {
+                      "system": "urn:ietf:bcp:47",
+                      "code": "en",
+                      "display": "English",
+                      "userSelected": false
+                    }
+                  ],
+                  "text": "English"
+                },
+                "preferred": true
+              }
+            ],
             "careProvider": [
               {
                 "reference": "Practitioner/1912007",

--- a/lib/resources/example_json/dstu2_examples_patient.rb
+++ b/lib/resources/example_json/dstu2_examples_patient.rb
@@ -59,6 +59,23 @@ module Cerner
       ]
     }
 
+    DSTU2_COMBINED_PATIENT_ENTRY ||= {
+      "resourceType": "Patient",
+      "id": "4860007",
+      "meta": {
+        "versionId": "0"
+      },
+      "active": false,
+      "link": [
+        {
+          "other": {
+            "reference": "Patient/4342008"
+          },
+          "type": "replace"
+        }
+      ]
+    }
+
     DSTU2_PATIENT_BUNDLE ||= {
       "resourceType": "Bundle",
       "id": "567efe76-2573-46be-85dc-8ea698dfa9d0",


### PR DESCRIPTION
- Removing the Implementation Notes indicating that Patient.link will not be returned
- Pulling in Overview statement and updating to include Link as a returned field
- Adding a Patient Combines section to the Retrieve By Id section briefly describing the behavior of the link field and when it will be populated