### PR TITLE
Update CarePlan Conformance

### DIFF
--- a/lib/resources/example_json/dstu2_examples_conformance.rb
+++ b/lib/resources/example_json/dstu2_examples_conformance.rb
@@ -85,12 +85,17 @@ module Cerner
                 {
                   "name": "patient",
                   "type": "reference",
-                  "documentation": "Who care plan is for. It is a required field if _id field is not given"
+                  "documentation": "Who care plan is for. Either the '_id' parameter or one of the 'patient' or 'subject' parameters must be set."
+                },
+                {
+                  "name": "subject",
+                  "type": "reference",
+                  "documentation": "Who care plan is for. Must be a patient. Either the '_id' parameter or one of the 'patient' or 'subject' parameters must be set."
                 },
                 {
                   "name": "_id",
                   "type": "token",
-                  "documentation": "A single or comma separated list of CarePlan ids. It is a required field if patient field is not given"
+                  "documentation": "A single or comma separated list of CarePlan ids. Either the '_id' parameter or one of the 'patient' or 'subject' parameters must be set."
                 },
                 {
                   "name": "date",
@@ -591,12 +596,17 @@ module Cerner
                 {
                   "name": "patient",
                   "type": "reference",
-                  "documentation": "Who care plan is for. It is a required field if _id field is not given"
+                  "documentation": "Who care plan is for. Either the '_id' parameter or one of the 'patient' or 'subject' parameters must be set."
+                },
+                {
+                  "name": "subject",
+                  "type": "reference",
+                  "documentation": "Who care plan is for. Must be a patient. Either the '_id' parameter or one of the 'patient' or 'subject' parameters must be set."
                 },
                 {
                   "name": "_id",
                   "type": "token",
-                  "documentation": "A single or comma separated list of CarePlan ids. It is a required field if patient field is not given"
+                  "documentation": "A single or comma separated list of CarePlan ids. Either the '_id' parameter or one of the 'patient' or 'subject' parameters must be set."
                 },
                 {
                   "name": "date",


### PR DESCRIPTION
The CarePlan 'subject' search parameter is currently functional but is not included in the server's conformance document.

Once the change goes out to include it in the conformance, we can merge this pull request to get the example updated.