### PR TITLE
Add authorization header to Encounter actions

### DIFF
--- a/content/millennium/dstu2/encounters/encounter.md
+++ b/content/millennium/dstu2/encounters/encounter.md
@@ -26,6 +26,10 @@ _Implementation Notes_
 * The [Encounter.hospitalization.destination] will be returned as a reference to a [contained] location resource.
 * The [Encounter.location.location] may be returned as a reference to a [contained] location resource.
 
+### Authorization Types
+
+<%= authorization_types(practitioner: true, system: true)%>
+
 ### Parameters
 
  Name      | Required?       | Type          | Description
@@ -48,6 +52,10 @@ _Implementation Notes_
 
 * The [Encounter.hospitalization.destination] will be returned as a reference to a [contained] location resource.
 * The [Encounter.location.location] may be returned as a reference to a [contained] location resource.
+
+### Authorization Types
+
+<%= authorization_types(practitioner: true, system: true)%>
 
 ### Response
 


### PR DESCRIPTION
Updates Encounter page to include authorization header for each action.  Uses same format as [Patient](http://fhir.cerner.com/millennium/dstu2/individuals/patient/#authorization-types).  Encounters are only authorized for Practitioner and System.