### PR TITLE
Remove birth date from Millennium Practitioner

### DIFF
--- a/content/millennium/dstu2/individuals/practitioner.md
+++ b/content/millennium/dstu2/individuals/practitioner.md
@@ -20,7 +20,6 @@ The following fields are returned if valued:
   * [Contact (secure email and phone)](http://hl7.org/fhir/DSTU2/practitioner-definitions.html#Practitioner.telecom){:target="_blank"}
   * [Address](http://hl7.org/fhir/DSTU2/practitioner-definitions.html#Practitioner.address){:target="_blank"}
   * [Gender](http://hl7.org/fhir/DSTU2/practitioner-definitions.html#Practitioner.gender){:target="_blank"}
-  * [Date of birth](http://hl7.org/fhir/DSTU2/practitioner-definitions.html#Practitioner.birthDate){:target="_blank"}
 
 ## Terminology Bindings
 
@@ -53,6 +52,7 @@ Search for Practitioners that meet supplied query parameters:
     GET https://fhir-open.sandboxcerner.com/dstu2/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/Practitioner?_id=1994021
 
 #### Response
+
 <%= headers status: 200 %> <%= json(:dstu2_practitioner_bundle) %>
 
 ### Errors

--- a/lib/resources/example_json/dstu2_examples_practitioner.rb
+++ b/lib/resources/example_json/dstu2_examples_practitioner.rb
@@ -10,7 +10,7 @@ module Cerner
       },
       "text": {
         "status": "generated",
-        "div": "&lt;div&gt;&lt;p&gt;&lt;b&gt;Practitioner&lt;/b&gt;&lt;/p&gt;&lt;p&gt;&lt;b&gt;Name&lt;/b&gt;: PCTAUT, OrdersPhy3&lt;/p&gt;&lt;p&gt;&lt;b&gt;Identifiers&lt;/b&gt;: DOCDEA: 234234123&lt;/p&gt;&lt;p&gt;&lt;b&gt;Gender&lt;/b&gt;: Male&lt;/p&gt;&lt;p&gt;&lt;b&gt;Birthdate&lt;/b&gt;: 1975-10-12&lt;/p&gt;&lt;p&gt;&lt;b&gt;Status&lt;/b&gt;: Active&lt;/p&gt;&lt;/div&gt;"
+        "div": "&lt;div&gt;&lt;p&gt;&lt;b&gt;Practitioner&lt;/b&gt;&lt;/p&gt;&lt;p&gt;&lt;b&gt;Name&lt;/b&gt;: PCTAUT, OrdersPhy3&lt;/p&gt;&lt;p&gt;&lt;b&gt;Identifiers&lt;/b&gt;: DOCDEA: 234234123&lt;/p&gt;&lt;p&gt;&lt;b&gt;Gender&lt;/b&gt;: Male&lt;/p&gt;&lt;p&gt;&lt;b&gt;Status&lt;/b&gt;: Active&lt;/p&gt;&lt;/div&gt;"
       },
       "identifier": [
         {
@@ -57,8 +57,7 @@ module Cerner
           "country": "USA"
         }
       ],
-      "gender": "male",
-      "birthDate": "1975-10-12"
+      "gender": "male"
     }
 
 
@@ -85,7 +84,7 @@ module Cerner
             },
             "text": {
               "status": "generated",
-              "div": "&lt;div&gt;&lt;p&gt;&lt;b&gt;Practitioner&lt;/b&gt;&lt;/p&gt;&lt;p&gt;&lt;b&gt;Name&lt;/b&gt;: PCTAUT, OrdersPhy3&lt;/p&gt;&lt;p&gt;&lt;b&gt;Identifiers&lt;/b&gt;: DOCDEA: 234234123&lt;/p&gt;&lt;p&gt;&lt;b&gt;Gender&lt;/b&gt;: Male&lt;/p&gt;&lt;p&gt;&lt;b&gt;Birthdate&lt;/b&gt;: 1975-10-12&lt;/p&gt;&lt;p&gt;&lt;b&gt;Status&lt;/b&gt;: Active&lt;/p&gt;&lt;/div&gt;"
+              "div": "&lt;div&gt;&lt;p&gt;&lt;b&gt;Practitioner&lt;/b&gt;&lt;/p&gt;&lt;p&gt;&lt;b&gt;Name&lt;/b&gt;: PCTAUT, OrdersPhy3&lt;/p&gt;&lt;p&gt;&lt;b&gt;Identifiers&lt;/b&gt;: DOCDEA: 234234123&lt;/p&gt;&lt;p&gt;&lt;b&gt;Gender&lt;/b&gt;: Male&lt;/p&gt;&lt;p&gt;&lt;b&gt;Status&lt;/b&gt;: Active&lt;/p&gt;&lt;/div&gt;"
             },
             "identifier": [
               {
@@ -132,8 +131,7 @@ module Cerner
                 "country": "USA"
               }
             ],
-            "gender": "male",
-            "birthDate": "1975-10-12"
+            "gender": "male"
           }
         }
       ]


### PR DESCRIPTION
Update Millennium Practitioner documentation and examples to reflect that birth date is no longer returned