### PR TITLE
Add Documentation for DocumentReference Read and Search by ID

### DIFF
--- a/content/millennium/dstu2/infrastructure/document-reference.md
+++ b/content/millennium/dstu2/infrastructure/document-reference.md
@@ -58,16 +58,18 @@ _Implementation Notes_
 
 ### Parameters
 
- Name           | Required?          | Type          | Description
-----------------|--------------------|---------------|-----------------------------------------------------------------------------------------------
-`patient`       | This, or `subject` | [`reference`] | The patient to which the document reference belongs. Example: `patient=12345`
-`subject`       | This, or `patient` | [`reference`] | The subject of the document reference. Must represent a Patient resource. May use the :Patient modifier. Example: `subject=Patient/1316020 or subject:Patient=1316020`
-`encounter`     | No                 | [`reference`] | The encounter to which the document reference belongs.  Must represent an Encounter resource.  May include a single or comma separated list of references. Example: `encounter=1353`
-`created`       | No                 | [`date`]      | A date/time the referenced document was created.  Must use the `ge` and `le` prefixes.  Example: `created=le2017-01-5&created=ge2017-02-7`
-[`_count`]      | No                 | [`number`]    | The maximum number of results to return.
+ Name           | Required?                              | Type          | Description
+----------------|----------------------------------------|---------------|-----------------------------------------------------------------------------------------------
+`_id`           | This, or one of `patient` or `subject` | [`token`]     | The logical resource id associated with the resource. Example: `_id=7499283`
+`patient`       | This, or one of `_id` or `subject`     | [`reference`] | The patient to which the document reference belongs. Example: `patient=12345`
+`subject`       | This, or one of `_id` or `patient`     | [`reference`] | The subject of the document reference. Must represent a Patient resource. May use the :Patient modifier. Example: `subject=Patient/1316020 or subject:Patient=1316020`
+`encounter`     | No                                     | [`reference`] | The encounter to which the document reference belongs.  Must represent an Encounter resource.  May include a single or comma separated list of references. Example: `encounter=1353`
+`created`       | No                                     | [`date`]      | A date/time the referenced document was created.  Must use the `ge` and `le` prefixes.  Example: `created=le2017-01-5&created=ge2017-02-7`
+[`_count`]      | No                                     | [`number`]    | The maximum number of results to return.
 
 Notes:
 
+- The `_id` parameter may not be provided at the same time as the `patient`, `subject`, `encounter`, `created` or `_count` parameters.
 - When the `created` parameter is provided:
   - It must be provided twice, once with the `ge` parameter and once with the `le` parameter.
   - The two provided date/times may not be equal and must form a closed range.
@@ -164,6 +166,34 @@ The common [errors] may be returned. In addition, [OperationOutcomes] may be ret
  422         | Body contained implicit rules      | error     | unsupported
  422         | Body contained relatesTo           | error     | unsupported
 
+## Retrieve by id
+
+List an individual DocumentReference by its id:
+
+    GET /DocumentReference/:id
+
+### Authorization Types
+
+<%= authorization_types(practitioner: true, patient: true, system: true) %>
+
+### Headers
+
+<%= headers %>
+
+### Example
+
+#### Request
+
+    GET https://fhir-open.sandboxcerner.com/dstu2/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/DocumentReference/7499283
+
+#### Response
+
+<%= headers status: 200 %>
+<%= json(:dstu2_document_reference_docref_bundle_entry) %>
+
+### Errors
+
+The common [errors] may be returned.
 
 ## Operation: docref
 

--- a/content/millennium/dstu2/infrastructure/document-reference.md
+++ b/content/millennium/dstu2/infrastructure/document-reference.md
@@ -51,6 +51,7 @@ Search for DocumentReferences that meet supplied query parameters:
 _Implementation Notes_
 
 * Search results are currently limited to published clinical documents.
+* Contents of the document are found by following the Attachment url. See more information on the [Binary resource] to determine what Authorization scopes are required, and how to set the Accept header when downloading document contents.
 
 ### Authorization Types
 
@@ -172,6 +173,10 @@ List an individual DocumentReference by its id:
 
     GET /DocumentReference/:id
 
+_Implementation Notes_
+
+* Contents of the document are found by following the Attachment url. See more information on the [Binary resource] to determine what Authorization scopes are required, and how to set the Accept header when downloading document contents.
+
 ### Authorization Types
 
 <%= authorization_types(practitioner: true, patient: true, system: true) %>
@@ -259,4 +264,5 @@ The common [errors] may be returned.
 [dateTime]: http://hl7.org/fhir/DSTU2/datatypes.html#dateTime
 [DocumentReference.relatesTo]: http://hl7.org/fhir/DSTU2/documentreference-definitions.html#DocumentReference.relatesTo
 [errors]: ../../#client-errors
+[Binary resource]: ../Binary/#authorization-types
 [OperationOutcomes]: http://hl7.org/fhir/DSTU2/operationoutcome.html

--- a/content/millennium/dstu2/infrastructure/document-reference.md
+++ b/content/millennium/dstu2/infrastructure/document-reference.md
@@ -51,7 +51,7 @@ Search for DocumentReferences that meet supplied query parameters:
 _Implementation Notes_
 
 * Search results are currently limited to published clinical documents.
-* Contents of the document are found by following the Attachment url. See more information on the [Binary resource] to determine what Authorization scopes are required, and how to set the Accept header when downloading document contents.
+* Contents of the document are found by following the Attachment URL. See more information on the [Binary resource] to determine what Authorization scopes are required, and how to set the Accept header when downloading document contents.
 
 ### Authorization Types
 
@@ -70,7 +70,7 @@ _Implementation Notes_
 
 Notes:
 
-- The `_id` parameter may not be provided at the same time as the `patient`, `subject`, `encounter`, `created` or `_count` parameters.
+- The `_id` parameter may not be provided at the same time as the `patient`, `subject`, `encounter`, `created`, or `_count` parameters.
 - When the `created` parameter is provided:
   - It must be provided twice, once with the `ge` parameter and once with the `le` parameter.
   - The two provided date/times may not be equal and must form a closed range.
@@ -175,7 +175,7 @@ List an individual DocumentReference by its id:
 
 _Implementation Notes_
 
-* Contents of the document are found by following the Attachment url. See more information on the [Binary resource] to determine what Authorization scopes are required, and how to set the Accept header when downloading document contents.
+* Contents of the document are found by following the Attachment URL. See more information on the [Binary resource] to determine what Authorization scopes are required, and how to set the Accept header when downloading document contents.
 
 ### Authorization Types
 

--- a/content/millennium/dstu2/infrastructure/document-reference.md
+++ b/content/millennium/dstu2/infrastructure/document-reference.md
@@ -61,9 +61,9 @@ _Implementation Notes_
  Name           | Required?                              | Type          | Description
 ----------------|----------------------------------------|---------------|-----------------------------------------------------------------------------------------------
 `_id`           | This, or one of `patient` or `subject` | [`token`]     | The logical resource id associated with the resource. Example: `_id=7499283`
-`patient`       | This, or one of `_id` or `subject`     | [`reference`] | The patient to which the document reference belongs. Example: `patient=12345`
-`subject`       | This, or one of `_id` or `patient`     | [`reference`] | The subject of the document reference. Must represent a Patient resource. May use the :Patient modifier. Example: `subject=Patient/1316020 or subject:Patient=1316020`
-`encounter`     | No                                     | [`reference`] | The encounter to which the document reference belongs.  Must represent an Encounter resource.  May include a single or comma separated list of references. Example: `encounter=1353`
+`patient`       | This, or one of `_id` or `subject`     | [`reference`] | The patient to which the document reference belongs. Example: `patient=1316024`
+`subject`       | This, or one of `_id` or `patient`     | [`reference`] | The subject of the document reference. Must represent a Patient resource. May use the :Patient modifier. Example: `subject=Patient/1316024 or subject:Patient=1316024`
+`encounter`     | No                                     | [`reference`] | The encounter to which the document reference belongs.  Must represent an Encounter resource.  May include a single or comma separated list of references. Example: `encounter=1621910`
 `created`       | No                                     | [`date`]      | A date/time the referenced document was created.  Must use the `ge` and `le` prefixes.  Example: `created=le2017-01-5&created=ge2017-02-7`
 [`_count`]      | No                                     | [`number`]    | The maximum number of results to return.
 

--- a/lib/resources/example_json/dstu2_examples_document_reference.rb
+++ b/lib/resources/example_json/dstu2_examples_document_reference.rb
@@ -273,6 +273,63 @@ module Cerner
       ]
     }
 
+    DSTU2_DOCUMENT_REFERENCE_DOCREF_BUNDLE_ENTRY ||= {
+      "resourceType": "DocumentReference",
+      "id": "7499283",
+      "meta": {
+        "versionId": "7499282",
+        "lastUpdated": "2018-01-08T14:51:05.000Z"
+      },
+      "text": {
+        "status": "generated",
+        "div": "&lt;div&gt;&lt;p&gt;&lt;b&gt;DocumentReference&lt;/b&gt;&lt;/p&gt;&lt;p&gt;&lt;b&gt;Patient Name&lt;/b&gt;: PETERS, TIMOTHY&lt;/p&gt;&lt;p&gt;&lt;b&gt;Document Type&lt;/b&gt;: Depart Summary&lt;/p&gt;&lt;p&gt;&lt;b&gt;Document Title&lt;/b&gt;: Physician Emergency department Note&lt;/p&gt;&lt;p&gt;&lt;b&gt;Date&lt;/b&gt;: 2018-01-03T07:30:20.000Z&lt;/p&gt;&lt;p&gt;&lt;b&gt;Status&lt;/b&gt;: Auth (Verified)&lt;/p&gt;&lt;p&gt;&lt;b&gt;Verifying Provider&lt;/b&gt;: Portal, Portal&lt;/p&gt;&lt;/div&gt;"
+      },
+      "subject": {
+        "reference": "Patient/1316024",
+        "display": "PETERS, TIMOTHY"
+      },
+      "type": {
+        "coding": [
+          {
+            "system": "http://loinc.org",
+            "code": "68608-9"
+          }
+        ],
+        "text": "Depart Summary"
+      },
+      "authenticator": {
+        "reference": "Practitioner/4464007",
+        "display": "Portal, Portal"
+      },
+      "created": "2018-01-03T07:30:20.000Z",
+      "indexed": "2018-01-03T07:30:20.000Z",
+      "status": "current",
+      "docStatus": {
+        "coding": [
+          {
+            "system": "http://hl7.org/fhir/composition-status",
+            "code": "final",
+            "display": "Final"
+          }
+        ],
+        "text": "Auth (Verified)"
+      },
+      "description": "Physician Emergency department Note",
+      "content": [
+        {
+          "attachment": {
+            "contentType": "application/pdf",
+            "url": "https://fhir-open.sandboxcerner.com/dstu2/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/Binary/XR-7499283"
+          }
+        }
+      ],
+      "context": {
+        "encounter": {
+          "reference": "Encounter/1621910"
+        }
+      }
+    }
+
     DSTU2_DOCUMENT_REFERENCE_DOCREF_CREATE ||= {
       "resourceType": "DocumentReference",
       "subject": {


### PR DESCRIPTION
Updates documentation for new DocumentReference read/search by ID functionality.  Also updates example search parameters to be usable values with the open sandbox instance.

We'll need to wait a few days before this can be merged, but I wanted to go ahead and get it out here for review.