### PR TITLE
Add Documentation for StructureDefinition

### DIFF
--- a/content/millennium/dstu2/structure-definition.md
+++ b/content/millennium/dstu2/structure-definition.md
@@ -1,0 +1,75 @@
+---
+title: StructureDefinition | DSTU 2 API
+---
+
+# StructureDefinition
+
+* TOC
+{:toc}
+
+## Overview
+
+The StructureDefinition resource describes a FHIR structure including data elements and their usage. Our current implementation uses this resource to define custom extensions.
+
+The following fields are returned if valued:
+
+* [Id](http://hl7.org/fhir/dstu2/resource-definitions.html#Resource.id){:target="_blank"}
+* [Publisher](http://hl7.org/fhir/DSTU2/structuredefinition-definitions.html#StructureDefinition.publisher){:target="_blank"}
+* [Snapshot](http://hl7.org/fhir/DSTU2/structuredefinition-definitions.html#StructureDefinition.snapshot){:target="_blank"}
+* [Date](http://hl7.org/fhir/DSTU2/structuredefinition-definitions.html#StructureDefinition.date){:target="_blank"}
+* [Fhir version](http://hl7.org/fhir/DSTU2/structuredefinition-definitions.html#StructureDefinition.fhirVersion){:target="_blank"}
+* [Constrained type](http://hl7.org/fhir/DSTU2/structuredefinition-definitions.html#StructureDefinition.constrainedType){:target="_blank"}
+* [Description](http://hl7.org/fhir/DSTU2/structuredefinition-definitions.html#StructureDefinition.description){:target="_blank"}
+* [Status](http://hl7.org/fhir/DSTU2/structuredefinition-definitions.html#StructureDefinition.status){:target="_blank"}
+* [Context type](http://hl7.org/fhir/DSTU2/structuredefinition-definitions.html#StructureDefinition.contextType){:target="_blank"}
+* [Context](http://hl7.org/fhir/DSTU2/structuredefinition-definitions.html#StructureDefinition.context){:target="_blank"}
+* [URL](http://hl7.org/fhir/DSTU2/structuredefinition-definitions.html#StructureDefinition.url){:target="_blank"}
+* [Kind](http://hl7.org/fhir/DSTU2/structuredefinition-definitions.html#StructureDefinition.kind){:target="_blank"}
+* [Differential](http://hl7.org/fhir/DSTU2/structuredefinition-definitions.html#StructureDefinition.differential){:target="_blank"}
+* [Abstract](http://hl7.org/fhir/DSTU2/structuredefinition-definitions.html#StructureDefinition.abstract){:target="_blank"}
+* [Base](http://hl7.org/fhir/DSTU2/structuredefinition-definitions.html#StructureDefinition.base){:target="_blank"}
+* [Name](http://hl7.org/fhir/DSTU2/structuredefinition-definitions.html#StructureDefinition.name){:target="_blank"}
+
+_List of StructureDefinitions_
+
+* [`patient-friendly-display`](http://fhir.cerner.com/millennium/dstu2/medications/medication-order/#custom-extensions): Display string suitable for patient viewing.
+* [`scheduling-location`](http://fhir.cerner.com/millennium/dstu2/scheduling/schedule/#custom-extensions): Reference to the location an appointment being scheduled.
+* [`medication-statement-category`](http://fhir.cerner.com/millennium/dstu2/medications/medication-statement/#custom-extensions): Category of an order.
+
+
+## Retrieve by id
+
+List an individual StructureDefinition by its id:
+
+    GET /StructureDefinition/:id
+
+_Implementation Notes_
+
+* Authentication is not required to access the StructureDefinition resource
+* This resource can be retrieved by its defining URL or from the StructureDefinition resource located at the [service root URL](../#service-root-url). For example, both of these URLs work:
+
+    `https://fhir-ehr.cerner.com/dstu2/StructureDefinition/patient-friendly-display`
+
+    `https://fhir-open.sandboxcerner.com/dstu2/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/StructureDefinition/patient-friendly-display`
+
+### Authorization Types
+
+Authorization is not required.
+
+<%= authorization_types(practitioner: true, patient: true, system: true) %>
+
+### Headers
+
+<%= headers head: {Accept: 'application/json+fhir'} %>
+
+### Example
+
+
+#### Request
+
+    GET https://fhir-ehr.cerner.com/dstu2/StructureDefinition/patient-friendly-display
+
+#### Response
+
+<%= headers status: 200 %>
+<%= json(:dstu2_structure_definition_bundle) %>

--- a/content/millennium/dstu2/structure-definition.md
+++ b/content/millennium/dstu2/structure-definition.md
@@ -33,7 +33,7 @@ The following fields are returned if valued:
 _List of StructureDefinitions_
 
 * [`patient-friendly-display`](http://fhir.cerner.com/millennium/dstu2/medications/medication-order/#custom-extensions): Display string suitable for patient viewing.
-* [`scheduling-location`](http://fhir.cerner.com/millennium/dstu2/scheduling/schedule/#custom-extensions): Reference to the location an appointment being scheduled.
+* [`scheduling-location`](http://fhir.cerner.com/millennium/dstu2/scheduling/schedule/#custom-extensions): Reference to the location of an appointment being scheduled.
 * [`medication-statement-category`](http://fhir.cerner.com/millennium/dstu2/medications/medication-statement/#custom-extensions): Category of an order.
 
 

--- a/layouts/millennium_dstu2_sidebar.html
+++ b/layouts/millennium_dstu2_sidebar.html
@@ -8,6 +8,7 @@
           <li><a href="/authorization/">Authorization</a></li>
           <li><a href="/millennium/dstu2/conformance/">Conformance Metadata</a></li>
           <li><a href="/millennium/dstu2/operation-definition/">OperationDefinition</a></li>
+          <li><a href="/millennium/dstu2/structure-definition/">StructureDefinition</a></li>
         </ul>
       </li>
       <li class="js-topic">

--- a/lib/resources/example_json/dstu2_examples_structure_definition.rb
+++ b/lib/resources/example_json/dstu2_examples_structure_definition.rb
@@ -1,0 +1,144 @@
+module Cerner
+  module Resources
+
+    DSTU2_STRUCTURE_DEFINITION_BUNDLE ||= {
+      "resourceType": "StructureDefinition",
+      "id": "patient-friendly-display",
+      "url": "https://fhir-ehr.cerner.com/dstu2/StructureDefinition/patient-friendly-display",
+      "name": "Patient-Friendly Display",
+      "status": "draft",
+      "publisher": "Cerner",
+      "date": "2016-12-13",
+      "description": "An expression of the original string in terminology that patients should be able to understand",
+      "fhirVersion": "1.0.2",
+      "kind": "datatype",
+      "constrainedType": "Extension",
+      "abstract": false,
+      "contextType": "datatype",
+      "context": [
+        "string"
+      ],
+      "base": "http://hl7.org/fhir/StructureDefinition/Extension",
+      "snapshot": {
+        "element": [{
+            "path": "Extension",
+            "short": "String equivalent with patient-friendly terminology",
+            "definition": "An expression of the original string in terminology that patients should be able to understand",
+            "min": 0,
+            "max": "1",
+            "base": {
+              "path": "Extension",
+              "min": 0,
+              "max": "*"
+            },
+            "type": [{
+              "code": "Extension"
+            }]
+          },
+          {
+            "path": "Extension.id",
+            "representation": [
+              "xmlAttr"
+            ],
+            "short": "xml:id (or equivalent in JSON)",
+            "definition": "unique id for the element within a resource (for internal references).",
+            "min": 0,
+            "max": "1",
+            "base": {
+              "path": "Extension.id",
+              "min": 0,
+              "max": "1"
+            },
+            "type": [{
+              "code": "id"
+            }]
+          },
+          {
+            "path": "Extension.extension",
+            "name": "extension",
+            "short": "Extension",
+            "definition": "An Extension",
+            "min": 0,
+            "max": "0",
+            "base": {
+              "path": "Extension.extension",
+              "min": 0,
+              "max": "*"
+            },
+            "type": [{
+              "code": "Extension"
+            }]
+          },
+          {
+            "path": "Extension.url",
+            "representation": [
+              "xmlAttr"
+            ],
+            "short": "identifies the meaning of the extension",
+            "definition": "Source of the definition for the extension code - a logical name or a URL.",
+            "comments": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition should be version specific.  This will ideally be the URI for the Resource Profile defining the extension, with the code for the extension after a #.",
+            "min": 1,
+            "max": "1",
+            "base": {
+              "path": "Extension.url",
+              "min": 1,
+              "max": "1"
+            },
+            "type": [{
+              "code": "uri"
+            }],
+            "fixedUri": "https://fhir-ehr.cerner.com/dstu2/StructureDefinition/patient-friendly-display"
+          },
+          {
+            "path": "Extension.valueString",
+            "short": "Value of extension",
+            "definition": "Value of extension - may be a resource or one of a constrained set of the data types (see Extensibility in the spec for list).",
+            "min": 1,
+            "max": "1",
+            "base": {
+              "path": "Extension.value[x]",
+              "min": 0,
+              "max": "1"
+            },
+            "type": [{
+              "code": "string"
+            }]
+          }
+        ]
+      },
+      "differential": {
+        "element": [{
+            "path": "Extension",
+            "short": "String equivalent with patient-friendly terminology",
+            "definition": "An expression of the original string in terminology that patients should be able to understand",
+            "min": 0,
+            "max": "1",
+            "type": [{
+              "code": "Extension"
+            }]
+          },
+          {
+            "path": "Extension.extension",
+            "name": "extension",
+            "max": "0"
+          },
+          {
+            "path": "Extension.url",
+            "type": [{
+              "code": "uri"
+            }],
+            "fixedUri": "https://fhir-ehr.cerner.com/dstu2/StructureDefinition/patient-friendly-display"
+          },
+          {
+            "path": "Extension.value[x]",
+            "min": 1,
+            "type": [{
+              "code": "string"
+            }]
+          }
+        ]
+      }
+    }
+
+  end
+end


### PR DESCRIPTION
Adds documentation for StructureDefinition.  

A couple things I could use feedback on:

- Do we want to list the custom extensions for which we define StructureDefinitions?  We do something similar in OperationDefinition.
- If so, I could use some help thinking of appropriate descriptions for each of the extensions.  I've gone ahead and included them and taken a shot at describing them.