### PR TITLE
Add NDC to Immunization bindings for vaccineCode

### DIFF
--- a/lib/resources/dstu2/immunization.yaml
+++ b/lib/resources/dstu2/immunization.yaml
@@ -14,6 +14,10 @@ fields:
     - display: CVX
       system: http://hl7.org/fhir/sid/cvx
       info_link: http://hl7.org/fhir/dstu2/cvx.html
+    - display: NDC
+      system: http://hl7.org/fhir/sid/ndc
+      info_link: http://hl7.org/fhir/dstu2/ndc.html
+    note: The CVX binding will always be returned. A NDC binding will be returned when available.
 
 - name: site
   required: 'No'


### PR DESCRIPTION
Add the bindings for NDC to the Immunization bindings list for vaccineCode, including a note. 