### PR TITLE
Remove <sup></sup> from authorization-specification title

### DIFF
--- a/content/authorization/authorization-specification.md
+++ b/content/authorization/authorization-specification.md
@@ -1,5 +1,5 @@
 ---
-title: FHIR<sup>®</sup> Service Authorization Specification
+title: FHIR® Service Authorization Specification
 layout: authorization
 ---
 


### PR DESCRIPTION
Current rendering:
<img width="522" alt="screen shot 2018-06-27 at 4 09 12 pm" src="https://user-images.githubusercontent.com/5505772/42000033-0a019b16-7a25-11e8-92cd-5fc042287393.png">

Fixed rendering:
<img width="418" alt="screen shot 2018-06-27 at 4 14 22 pm" src="https://user-images.githubusercontent.com/5505772/42000075-328ccfce-7a25-11e8-98f7-dbb4b16fa1cb.png">

This was the only place on the site I saw \<sup>\</sup> tags in a title