### PR TITLE
docRef proprietary codes documentation

### DIFF
--- a/content/millennium/dstu2/infrastructure/document-reference.md
+++ b/content/millennium/dstu2/infrastructure/document-reference.md
@@ -175,6 +175,7 @@ _Implementation Notes_
 
 * Contents of the document are found by following the Attachment URL. See more information on the [Binary resource] to determine what Authorization scopes are required, and how to set the Accept header when downloading document contents.
 * If no mappings are available for LOINC codes when returning DocumentReference.type codings, an unknown data absent reason will be returned in place of the LOINC codes. This is to follow the [Argonaut profile's](http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-documentreference.html) required binding for type. When available, Proprietary codings will be returned in addition to the data absent reason.
+
 ### Authorization Types
 
 <%= authorization_types(practitioner: true, patient: true, system: true) %>

--- a/content/millennium/dstu2/infrastructure/document-reference.md
+++ b/content/millennium/dstu2/infrastructure/document-reference.md
@@ -174,8 +174,7 @@ List an individual DocumentReference by its id:
 _Implementation Notes_
 
 * Contents of the document are found by following the Attachment URL. See more information on the [Binary resource] to determine what Authorization scopes are required, and how to set the Accept header when downloading document contents.
-* When returning the type codings, if the LOINC mappings are missing, an unknown data absent reason is returned as the [Argonaut profile](http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-documentreference.html) has a required binding for type.
-
+* If no mappings are available for LOINC codes when returning DocumentReference.type codings, an unknown data absent reason will be returned in place of the LOINC codes. This is to follow the [Argonaut profile's](http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-documentreference.html) required binding for type. When available, Proprietary codings will be returned in addition to the data absent reason.
 ### Authorization Types
 
 <%= authorization_types(practitioner: true, patient: true, system: true) %>

--- a/content/millennium/dstu2/infrastructure/document-reference.md
+++ b/content/millennium/dstu2/infrastructure/document-reference.md
@@ -174,6 +174,7 @@ List an individual DocumentReference by its id:
 _Implementation Notes_
 
 * Contents of the document are found by following the Attachment URL. See more information on the [Binary resource] to determine what Authorization scopes are required, and how to set the Accept header when downloading document contents.
+* When returning the type codings, if the LOINC mappings are missing, an unknown data absent reason is returned as the [Argonaut profile](http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-documentreference.html) has a required binding for type.
 
 ### Authorization Types
 

--- a/lib/definition_table_generator.rb
+++ b/lib/definition_table_generator.rb
@@ -70,6 +70,7 @@ class DefinitionTableGenerator
                 cardinality: get_value(field['cardinality']),
                 description: get_value(field['description']),
                 example: get_value(field['example']),
+                example2: get_value(field['example2']),
                 note: get_value(field['note']),
                 binding: get_value(field['binding']),
                 url: url}

--- a/lib/field_definition_table.erb
+++ b/lib/field_definition_table.erb
@@ -34,6 +34,10 @@
         <li><i>Example</i></li>
         <ul style="list-style-type: none"><li><pre><%= item[:example] %></pre></li></ul>
       <%end%>
+      <% unless item[:example2].nil? %>
+        <li><i>Example</i></li>
+        <ul style="list-style-type: none"><li><pre><%= item[:example2] %></pre></li></ul>
+      <%end%>
       <% unless item[:note].nil? %>
         <li><i>Notes</i></li>
         <ul style="list-style-type: none"><li><%= item[:note] %></li></ul>

--- a/lib/resources/dstu2/document_reference.yaml
+++ b/lib/resources/dstu2/document_reference.yaml
@@ -35,9 +35,20 @@ fields:
         }
       ]
     }
-  note: The type must include a LOINC or a proprietary coding. If multiple codings are provided they must be either all LOINC codings or all proprietary codings.
+
+              <b>(OR)</b>
+
+    {
+      "coding": [
+        {
+          "system": "https://fhir.cerner.com/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/codeSet/72",
+          "code": "3374547"
+        }
+      ]
+    }
+  note: The type must include a LOINC or a proprietary coding. Multiple LOINC codings or a single proprietary coding can be provided.
         <br/><br/>
-        When providing proprietary codes, the system should be of format 'https://fhir.cerner.com/&lt;your EHR source id&gt;/codeSet/&lt;code set&gt;' (where code set is a Millennium code set) and the code should be a Millennium code value. Example&#58; 'https://fhir.cerner.com/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/codeSet/72|3374547'.
+        When providing proprietary code system, it should be of format 'https://fhir.cerner.com/&lt;your EHR source id&gt;/codeSet/&lt;code set&gt;' (where code set is a Millennium code set) and the code should be a Millennium code value. Example&#58; 'https://fhir.cerner.com/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/codeSet/72'.
         <br/><br/>
         Please note that the <a href="#terminology-bindings">list in the terminology bindings section</a> is not the complete list mapped for our sandbox. Our sandbox has many codes, but we only document a few to provide an example. The list does not represent what would be mapped for one of our client’s domains. This is one of the things we evaluate and implement as needed when we are making apps available at client sites.
         <br/><br/>

--- a/lib/resources/dstu2/document_reference.yaml
+++ b/lib/resources/dstu2/document_reference.yaml
@@ -36,19 +36,18 @@ fields:
       ]
     }
 
-              <b>(OR)</b>
-
-    {
-      "coding": [
-        {
-          "system": "https://fhir.cerner.com/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/codeSet/72",
-          "code": "3374547"
-        }
-      ]
+  example2: |
+   {
+     "coding": [
+       {
+        "system": "https://fhir.cerner.com/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/codeSet/72",
+        "code": "3374547"
+       }
+     ]
     }
   note: The type must include a LOINC or a proprietary coding. Multiple LOINC codings or a single proprietary coding can be provided.
         <br/><br/>
-        When providing proprietary code system, it should be of format 'https://fhir.cerner.com/&lt;your EHR source id&gt;/codeSet/&lt;code set&gt;' (where code set is a Millennium code set) and the code should be a Millennium code value. Example&#58; 'https://fhir.cerner.com/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/codeSet/72'.
+        When providing proprietary code system, it should be of format 'https://fhir.cerner.com/&lt;your EHR source id&gt;/codeSet/&lt;code set&gt;' (where code set is a Millennium code set). Example&#58; 'https://fhir.cerner.com/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/codeSet/72'.
         <br/><br/>
         Please note that the <a href="#terminology-bindings">list in the terminology bindings section</a> is not the complete list mapped for our sandbox. Our sandbox has many codes, but we only document a few to provide an example. The list does not represent what would be mapped for one of our client’s domains. This is one of the things we evaluate and implement as needed when we are making apps available at client sites.
         <br/><br/>

--- a/lib/resources/dstu2/document_reference.yaml
+++ b/lib/resources/dstu2/document_reference.yaml
@@ -35,7 +35,9 @@ fields:
         }
       ]
     }
-  note: The type must include a loinc coding.
+  note: The type must include a LOINC or a proprietary coding. If multiple codings are provided they must be either all LOINC codings or all proprietary codings.
+        <br/><br/>
+        When providing proprietary codes, the system should be of format 'https://fhir.cerner.com/&lt;your EHR source id&gt;/codeSet/&lt;code set&gt;' (where code set is a Millennium code set) and the code should be a Millennium code value. Example&#58; 'https://fhir.cerner.com/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/codeSet/72|3374547'.
         <br/><br/>
         Please note that the <a href="#terminology-bindings">list in the terminology bindings section</a> is not the complete list mapped for our sandbox. Our sandbox has many codes, but we only document a few to provide an example. The list does not represent what would be mapped for one of our client’s domains. This is one of the things we evaluate and implement as needed when we are making apps available at client sites.
         <br/><br/>

--- a/lib/resources/example_json/dstu2_examples_document_reference.rb
+++ b/lib/resources/example_json/dstu2_examples_document_reference.rb
@@ -293,6 +293,12 @@ module Cerner
           {
             "system": "http://loinc.org",
             "code": "68608-9"
+          },
+          {
+            "system": "https://fhir.cerner.com/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/codeSet/72",
+            "code": "3374547",
+            "display": "Depart Summary",
+            "userSelected": true
           }
         ],
         "text": "Depart Summary"


### PR DESCRIPTION
adding documentation for docRef proprietary codes

- Update read by ID example to reflect return of  proprietary codes

- Update documentation to reflect DARs on type if mappings for LOINC are missing

- Update create documentation to reflect support of proprietary codes