### PR TITLE
Remove 'Patient' from Appointment creation auth types

### DIFF
--- a/content/millennium/dstu2/scheduling/appointment.md
+++ b/content/millennium/dstu2/scheduling/appointment.md
@@ -147,7 +147,7 @@ _Implementation Notes_
 
 ### Authorization Types
 
-<%= authorization_types(practitioner: true, patient: true, system: true) %>
+<%= authorization_types(practitioner: true, patient: false, system: true) %>
 
 ### Headers
 


### PR DESCRIPTION
Appointment creation now displays only the Practitioner and System authorization types.