### PR TITLE
Appointment Creation accepts .slot as a list

### DIFF
--- a/content/millennium/dstu2/scheduling/appointment.md
+++ b/content/millennium/dstu2/scheduling/appointment.md
@@ -139,7 +139,7 @@ _Implementation Notes_
 
 * The modifier elements [implicitRules] and [modifierExtension] are not supported and will be rejected if present.
 * `Appointment.status` must be set to `proposed`.
-* `Appointment.slot` must be a reference to the Slot in which this appointment is being booked.
+* `Appointment.slot` must be a list containing a single reference to the Slot in which this appointment is being booked.
 * `Appointment.participant` must have exactly one participant.
 * `Appointment.participant.status` must be set to `needs-action`.
 * `Appointment.participant.type` must not be set.

--- a/lib/resources/dstu2/appointment.yaml
+++ b/lib/resources/dstu2/appointment.yaml
@@ -44,14 +44,16 @@ fields:
 
 - name: slot
   required: 'Yes'
-  cardinality: 0..1
+  cardinality: 1..1
   type: Reference (Slot)
   description: The availability to which the appointment is booked.
   example: |
     {
-      "slot": {
-        "reference": "Slot/21265426-633867-6828001-60"
-      }
+      "slot": [
+        {
+          "reference": "Slot/21265426-633867-6828001-60"
+        }
+      ]
     }
   url: http://hl7.org/fhir/DSTU2/appointment-definitions.html#Appointment.slot
   action: create


### PR DESCRIPTION
Appointment creation now displays the .slot body field as a list containing a single reference to a Slot.