### PR TITLE
Removed a defaulted returned count on medication order and medication statement

### DIFF
--- a/lib/resources/example_json/dstu2_examples_medication_order.rb
+++ b/lib/resources/example_json/dstu2_examples_medication_order.rb
@@ -8,7 +8,7 @@ module Cerner
       "total": 4,
       "link": [{
         "relation": "self",
-        "url": "https://fhir-open.sandboxcerner.com/dstu2/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/MedicationOrder?patient=4342010&_count=25"
+        "url": "https://fhir-open.sandboxcerner.com/dstu2/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/MedicationOrder?patient=4342010"
       }],
       "entry": [{
         "fullUrl": "https://fhir-open.sandboxcerner.com/dstu2/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/MedicationOrder/21389901",

--- a/lib/resources/example_json/dstu2_examples_medication_statement.rb
+++ b/lib/resources/example_json/dstu2_examples_medication_statement.rb
@@ -8,7 +8,7 @@ module Cerner
       "total": 4,
       "link": [{
         "relation": "self",
-        "url": "https://fhir-open.sandboxcerner.com/dstu2/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/MedicationStatement?patient=4342010&_count=50"
+        "url": "https://fhir-open.sandboxcerner.com/dstu2/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/MedicationStatement?patient=4342010"
       }],
       "entry": [{
         "fullUrl": "https://fhir-open.sandboxcerner.com/dstu2/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/MedicationStatement/21389901",


### PR DESCRIPTION
Changed the expected response when calling a GET on medication order and medication statement to reflect that the _count/pageSize is no longer being defaulted. 