### PR TITLE
kramdown warning when compiling site

### DIFF
--- a/content/millennium/r4/devices/device.md
+++ b/content/millennium/r4/devices/device.md
@@ -16,8 +16,8 @@ The following fields are returned if valued:
 * [Device id](https://hl7.org/fhir/r4/device-definitions.html#Device.id){:target="_blank"}
 * [Device identifier](https://hl7.org/fhir/r4/device-definitions.html#Device.identifier){:target="_blank"}
 * [Udi carrier](https://hl7.org/fhir/r4/device-definitions.html#Device.udiCarrier){:target="_blank"}
-    * [Device identifier](https://hl7.org/fhir/r4/device-definitions.html#Device.udiCarrier.deviceIdentifier){:target="_blank"}
-    * [CarrierHRF](https://hl7.org/fhir/r4/device-definitions.html#Device.udiCarrier.carrierHRF){:target="_blank"}   
+  * [Device identifier](https://hl7.org/fhir/r4/device-definitions.html#Device.udiCarrier.deviceIdentifier){:target="_blank"}
+  * [CarrierHRF](https://hl7.org/fhir/r4/device-definitions.html#Device.udiCarrier.carrierHRF){:target="_blank"}
 * [Status](https://hl7.org/fhir/r4/device-definitions.html#Device.status){:target="_blank"}
 * [Distinct identifier](https://hl7.org/fhir/r4/device-definitions.html#Device.distinctIdentifier){:target="_blank"}
 * [Manufacturer](https://hl7.org/fhir/r4/device-definitions.html#Device.manufacturer){:target="_blank"}
@@ -26,8 +26,8 @@ The following fields are returned if valued:
 * [Lot number](https://hl7.org/fhir/r4/device-definitions.html#Device.lotNumber){:target="_blank"}
 * [Serial number](https://hl7.org/fhir/r4/device-definitions.html#Device.serialNumber){:target="_blank"}
 * [Device name](https://hl7.org/fhir/r4/device-definitions.html#Device.deviceName){:target="_blank"}
-    * [Name](https://hl7.org/fhir/r4/device-definitions.html#Device.deviceName.name){:target="_blank"}
-    * [Type](https://hl7.org/fhir/r4/device-definitions.html#Device.deviceName.type){:target="_blank"}
+  * [Name](https://hl7.org/fhir/r4/device-definitions.html#Device.deviceName.name){:target="_blank"}
+  * [Type](https://hl7.org/fhir/r4/device-definitions.html#Device.deviceName.type){:target="_blank"}
 * [Model number](https://hl7.org/fhir/r4/device-definitions.html#Device.modelNumber){:target="_blank"}
 * [Type](https://hl7.org/fhir/r4/device-definitions.html#Device.type){:target="_blank"}
 * [Patient](https://hl7.org/fhir/r4/device-definitions.html#Device.patient){:target="_blank"}
@@ -49,11 +49,11 @@ Search for Devices that meet supplied query parameters:
 
 ### Parameters
 
- Name       | Required?          | Type          | Description
-------------|--------------------|---------------|-------------------------------------------------------------------------------------------------------
- `_id`      | This or `patient`  | [`token`]     | The logical resource id associated with the Device. Example: `2226920`
- `patient`  | This or `_id`      | [`reference`] | The patient to whom the device is affixed. Example: `12345`
- 
+ Name      | Required?         | Type          | Description
+-----------|-------------------|---------------|------------------------------------------------------------------------
+ `_id`     | This or `patient` | [`token`]     | The logical resource id associated with the Device. Example: `2226920`
+ `patient` | This or `_id`     | [`reference`] | The patient to whom the device is affixed. Example: `12345`
+
 ### Headers
 
 <%= headers fhir_json: true %>
@@ -63,7 +63,7 @@ Search for Devices that meet supplied query parameters:
 #### Request
 
     GET https://fhir-ehr.sandboxcerner.com/r4/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/Device?patient=4478007
-    
+
 #### Response
 
 <%= headers status: 200 %>
@@ -91,7 +91,7 @@ List an individual Device by its id:
 
 #### Request
 
-    GET  https://fhir-ehr.sandboxcerner.com/r4/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/Device/15577765
+    GET https://fhir-ehr.sandboxcerner.com/r4/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/Device/15577765
 
 #### Response
 

--- a/lib/resources/example_json/r4_examples_device.rb
+++ b/lib/resources/example_json/r4_examples_device.rb
@@ -11,7 +11,7 @@ module Cerner
       },
       "text": {
         "status": "generated",
-        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">&lt;p>&lt;b>Device&lt;/b>&lt;/p>&lt;p>&lt;b>Unique Device Identifier (UDI)&lt;/b>: UDIDA88ABA9-9FAD-4A03-9E9A-B52299AE9AE4&lt;/p>&lt;p>&lt;b>Status&lt;/b>: Inactive&lt;/p>&lt;p>&lt;b>Manufacturer&lt;/b>: Smith and Nephew Wound Management D&lt;/p>&lt;p>&lt;b>Manufacture Date&lt;/b>: Apr 10, 2010  5:00 A.M. UTC&lt;/p>&lt;p>&lt;b>Expiration Date&lt;/b>: Jul  7, 2020  5:00 A.M. UTC&lt;/p>&lt;p>&lt;b>Lot Number&lt;/b>: LOTDA88ABA9-9FAD-4A03-9E9A-B52299AE9AE4&lt;/p>&lt;p>&lt;b>Serial Number&lt;/b>: SERIALNBRDA88ABA9-9FAD-4A03-9E9A-B52299AE9AE4&lt;/p>&lt;p>&lt;b>Type&lt;/b>: Total Hip Set&lt;/p>&lt;p>&lt;b>Model Number&lt;/b>: MODELNBR661488&lt;/p>&lt;p>&lt;b>Patient&lt;/b>: SMART Jr, FRED RICK&lt;/p>&lt;p>&lt;b>Owner&lt;/b>: Baseline East Medical Center&lt;/p>&lt;/div>"
+        "div": "&lt;div xmlns=\"http://www.w3.org/1999/xhtml\">&lt;p>&lt;b>Device&lt;/b>&lt;/p>&lt;p>&lt;b>Unique Device Identifier (UDI)&lt;/b>: UDIDA88ABA9-9FAD-4A03-9E9A-B52299AE9AE4&lt;/p>&lt;p>&lt;b>Status&lt;/b>: Inactive&lt;/p>&lt;p>&lt;b>Manufacturer&lt;/b>: Smith and Nephew Wound Management D&lt;/p>&lt;p>&lt;b>Manufacture Date&lt;/b>: Apr 10, 2010  5:00 A.M. UTC&lt;/p>&lt;p>&lt;b>Expiration Date&lt;/b>: Jul  7, 2020  5:00 A.M. UTC&lt;/p>&lt;p>&lt;b>Lot Number&lt;/b>: LOTDA88ABA9-9FAD-4A03-9E9A-B52299AE9AE4&lt;/p>&lt;p>&lt;b>Serial Number&lt;/b>: SERIALNBRDA88ABA9-9FAD-4A03-9E9A-B52299AE9AE4&lt;/p>&lt;p>&lt;b>Type&lt;/b>: Total Hip Set&lt;/p>&lt;p>&lt;b>Model Number&lt;/b>: MODELNBR661488&lt;/p>&lt;p>&lt;b>Patient&lt;/b>: SMART Jr, FRED RICK&lt;/p>&lt;p>&lt;b>Owner&lt;/b>: Baseline East Medical Center&lt;/p>&lt;/div>"
       },
       "identifier": [
         {
@@ -83,7 +83,7 @@ module Cerner
             },
             "text": {
               "status": "generated",
-              "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"&lt;p>&lt;b>Device&lt;/b>&lt;/p>&lt;p>&lt;b>Unique Device Identifier (UDI)&lt;/b>: UDIDA88ABA9-9FAD-4A03-9E9A-B52299AE9AE4&lt;/p>&lt;p>&lt;b>Status&lt;/b>: Inactive&lt;/p>&lt;p>&lt;b>Manufacturer&lt;/b>: Smith and Nephew Wound Management D&lt;/p>&lt;p>&lt;b>Manufacture Date&lt;/b>: Apr 10, 2010  5:00 A.M. UTC&lt;/p>&lt;p>&lt;b>Expiration Date&lt;/b>: Jul  7, 2020  5:00 A.M. UTC&lt;/p>&lt;p>&lt;b>Lot Number&lt;/b>: LOTDA88ABA9-9FAD-4A03-9E9A-B52299AE9AE4&lt;/p>&lt;p>&lt;b>Serial Number&lt;/b>: SERIALNBRDA88ABA9-9FAD-4A03-9E9A-B52299AE9AE4&lt;/p>&lt;p>&lt;b>Type&lt;/b>: Total Hip Set&lt;/p>&lt;p>&lt;b>Model Number&lt;/b>: MODELNBR661488&lt;/p>&lt;p>&lt;b>Patient&lt;/b>: SMART Jr, FRED RICK&lt;/p>&lt;p>&lt;b>Owner&lt;/b>: Baseline East Medical Center&lt;/p>&lt;/div>"
+              "div": "&lt;div xmlns=\"http://www.w3.org/1999/xhtml\"&lt;p>&lt;b>Device&lt;/b>&lt;/p>&lt;p>&lt;b>Unique Device Identifier (UDI)&lt;/b>: UDIDA88ABA9-9FAD-4A03-9E9A-B52299AE9AE4&lt;/p>&lt;p>&lt;b>Status&lt;/b>: Inactive&lt;/p>&lt;p>&lt;b>Manufacturer&lt;/b>: Smith and Nephew Wound Management D&lt;/p>&lt;p>&lt;b>Manufacture Date&lt;/b>: Apr 10, 2010  5:00 A.M. UTC&lt;/p>&lt;p>&lt;b>Expiration Date&lt;/b>: Jul  7, 2020  5:00 A.M. UTC&lt;/p>&lt;p>&lt;b>Lot Number&lt;/b>: LOTDA88ABA9-9FAD-4A03-9E9A-B52299AE9AE4&lt;/p>&lt;p>&lt;b>Serial Number&lt;/b>: SERIALNBRDA88ABA9-9FAD-4A03-9E9A-B52299AE9AE4&lt;/p>&lt;p>&lt;b>Type&lt;/b>: Total Hip Set&lt;/p>&lt;p>&lt;b>Model Number&lt;/b>: MODELNBR661488&lt;/p>&lt;p>&lt;b>Patient&lt;/b>: SMART Jr, FRED RICK&lt;/p>&lt;p>&lt;b>Owner&lt;/b>: Baseline East Medical Center&lt;/p>&lt;/div>"
             },
             "identifier": [
               {
@@ -143,7 +143,7 @@ module Cerner
             },
             "text": {
               "status": "generated",
-              "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">&lt;p>&lt;b>Device&lt;/b>&lt;/p>&lt;p>&lt;b>Status&lt;/b>: Active&lt;/p>&lt;p>&lt;b>Manufacture Date&lt;/b>: Jan  1, 2001  6:00 A.M. UTC&lt;/p>&lt;p>&lt;b>Lot Number&lt;/b>: 567884-IP&lt;/p>&lt;p>&lt;b>Serial Number&lt;/b>: PBR668583H&lt;/p>&lt;p>&lt;b>Type&lt;/b>: Insulin Pump&lt;/p>&lt;p>&lt;b>Model Number&lt;/b>: MiniMed Paradigm&#174; 522/722&lt;/p>&lt;p>&lt;b>Patient&lt;/b>: SMART Jr, FRED RICK&lt;/p>&lt;p>&lt;b>Owner&lt;/b>: Baseline East &lt;/p>&lt;/div>"
+              "div": "&lt;div xmlns=\"http://www.w3.org/1999/xhtml\">&lt;p>&lt;b>Device&lt;/b>&lt;/p>&lt;p>&lt;b>Status&lt;/b>: Active&lt;/p>&lt;p>&lt;b>Manufacture Date&lt;/b>: Jan  1, 2001  6:00 A.M. UTC&lt;/p>&lt;p>&lt;b>Lot Number&lt;/b>: 567884-IP&lt;/p>&lt;p>&lt;b>Serial Number&lt;/b>: PBR668583H&lt;/p>&lt;p>&lt;b>Type&lt;/b>: Insulin Pump&lt;/p>&lt;p>&lt;b>Model Number&lt;/b>: MiniMed Paradigm&#174; 522/722&lt;/p>&lt;p>&lt;b>Patient&lt;/b>: SMART Jr, FRED RICK&lt;/p>&lt;p>&lt;b>Owner&lt;/b>: Baseline East &lt;/p>&lt;/div>"
             },
             "identifier": [
               {
@@ -194,7 +194,7 @@ module Cerner
             },
             "text": {
               "status": "generated",
-              "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">&lt;p>&lt;b>Device&lt;/b>&lt;/p>&lt;p>&lt;b>Status&lt;/b>: Active&lt;/p>&lt;p>&lt;b>Manufacture Date&lt;/b>: Jan  1, 2002  6:00 A.M. UTC&lt;/p>&lt;p>&lt;b>Serial Number&lt;/b>: ser100-1001&lt;/p>&lt;p>&lt;b>Type&lt;/b>: Stryker MDM X3 Hip System&lt;/p>&lt;p>&lt;b>Model Number&lt;/b>: MDM X3&lt;/p>&lt;p>&lt;b>Patient&lt;/b>: SMART Jr, FRED RICK&lt;/p>&lt;p>&lt;b>Owner&lt;/b>: Baseline East Medical Center&lt;/p>&lt;/div>"
+              "div": "&lt;div xmlns=\"http://www.w3.org/1999/xhtml\">&lt;p>&lt;b>Device&lt;/b>&lt;/p>&lt;p>&lt;b>Status&lt;/b>: Active&lt;/p>&lt;p>&lt;b>Manufacture Date&lt;/b>: Jan  1, 2002  6:00 A.M. UTC&lt;/p>&lt;p>&lt;b>Serial Number&lt;/b>: ser100-1001&lt;/p>&lt;p>&lt;b>Type&lt;/b>: Stryker MDM X3 Hip System&lt;/p>&lt;p>&lt;b>Model Number&lt;/b>: MDM X3&lt;/p>&lt;p>&lt;b>Patient&lt;/b>: SMART Jr, FRED RICK&lt;/p>&lt;p>&lt;b>Owner&lt;/b>: Baseline East Medical Center&lt;/p>&lt;/div>"
             },
             "identifier": [
               {
@@ -244,7 +244,7 @@ module Cerner
             },
             "text": {
               "status": "generated",
-              "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">&lt;p>&lt;b>Device&lt;/b>&lt;/p>&lt;p>&lt;b>Status&lt;/b>: Active&lt;/p>&lt;p>&lt;b>Manufacture Date&lt;/b>: Jan  1, 2003  6:00 A.M. UTC&lt;/p>&lt;p>&lt;b>Serial Number&lt;/b>: ser100-1004&lt;/p>&lt;p>&lt;b>Type&lt;/b>: Stryker Triathalon Total Knee&lt;/p>&lt;p>&lt;b>Model Number&lt;/b>: Triathalon&lt;/p>&lt;p>&lt;b>Patient&lt;/b>: SMART Jr, FRED RICK&lt;/p>&lt;p>&lt;b>Owner&lt;/b>: Baseline East Medical Center&lt;/p>&lt;/div>"
+              "div": "&lt;div xmlns=\"http://www.w3.org/1999/xhtml\">&lt;p>&lt;b>Device&lt;/b>&lt;/p>&lt;p>&lt;b>Status&lt;/b>: Active&lt;/p>&lt;p>&lt;b>Manufacture Date&lt;/b>: Jan  1, 2003  6:00 A.M. UTC&lt;/p>&lt;p>&lt;b>Serial Number&lt;/b>: ser100-1004&lt;/p>&lt;p>&lt;b>Type&lt;/b>: Stryker Triathalon Total Knee&lt;/p>&lt;p>&lt;b>Model Number&lt;/b>: Triathalon&lt;/p>&lt;p>&lt;b>Patient&lt;/b>: SMART Jr, FRED RICK&lt;/p>&lt;p>&lt;b>Owner&lt;/b>: Baseline East Medical Center&lt;/p>&lt;/div>"
             },
             "identifier": [
               {
@@ -294,7 +294,7 @@ module Cerner
             },
             "text": {
               "status": "generated",
-              "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">&lt;p>&lt;b>Device&lt;/b>&lt;/p>&lt;p>&lt;b>Status&lt;/b>: Active&lt;/p>&lt;p>&lt;b>Manufacture Date&lt;/b>: Jan  1, 2004  6:00 A.M. UTC&lt;/p>&lt;p>&lt;b>Serial Number&lt;/b>: ser100-1004&lt;/p>&lt;p>&lt;b>Type&lt;/b>: Medtronic Advisa MRI SureScan&lt;/p>&lt;p>&lt;b>Model Number&lt;/b>: A2DR01&lt;/p>&lt;p>&lt;b>Patient&lt;/b>: SMART Jr, FRED RICK&lt;/p>&lt;p>&lt;b>Owner&lt;/b>: Baseline East Medical Center&lt;/p></div>"
+              "div": "&lt;div xmlns=\"http://www.w3.org/1999/xhtml\">&lt;p>&lt;b>Device&lt;/b>&lt;/p>&lt;p>&lt;b>Status&lt;/b>: Active&lt;/p>&lt;p>&lt;b>Manufacture Date&lt;/b>: Jan  1, 2004  6:00 A.M. UTC&lt;/p>&lt;p>&lt;b>Serial Number&lt;/b>: ser100-1004&lt;/p>&lt;p>&lt;b>Type&lt;/b>: Medtronic Advisa MRI SureScan&lt;/p>&lt;p>&lt;b>Model Number&lt;/b>: A2DR01&lt;/p>&lt;p>&lt;b>Patient&lt;/b>: SMART Jr, FRED RICK&lt;/p>&lt;p>&lt;b>Owner&lt;/b>: Baseline East Medical Center&lt;/p>&lt;/div>"
             },
             "identifier": [
               {


### PR DESCRIPTION
r4_examples_device contained some non-escaped < characters. escaped them in f4d8fee

R4 device.md contained some extra whitespace. removed it in 97a62a3