### PR TITLE
Tweak R4 RelatedPerson terminology displays and fix Millennium PersonRelationships link. Fixes #309

### DIFF
--- a/lib/resources/r4/related_person.yaml
+++ b/lib/resources/r4/related_person.yaml
@@ -20,7 +20,7 @@ fields:
     binding:
       description: The type used to determine which identifier to use for a specific purpose.
       terminology:
-      - display: IdentifierType
+      - display: Identifier Type Codes
         system: http://terminology.hl7.org/CodeSystem/v2-0203
         info_link: http://hl7.org/fhir/R4/valueset-identifier-type.html
       - display: Millennium Person Identifier (Alias) Types
@@ -48,7 +48,7 @@ fields:
       - display: CommonLanguages
         system: urn:ietf:bcp:47
         info_link: http://hl7.org/fhir/R4/valueset-languages.html
-      - display: Millennium Language codes
+      - display: Millennium Languages
         system: https://fhir.cerner.com/&lt;EHR source id&gt;/codeSet/36
         info_link: https://fhir.cerner.com/millennium/r4/proprietary-codes-and-systems/#code-set-36-languages
 
@@ -69,6 +69,6 @@ fields:
     - display: Millennium Person Relationship Types
       system: https://fhir.cerner.com/&lt;EHR source id&gt;/codeSet/351
       info_link: https://fhir.cerner.com/millennium/r4/proprietary-codes-and-systems/#code-set-351-person-relationship-types
-    - display: Millennium Person Relationship
+    - display: Millennium Person Relationships
       system: https://fhir.cerner.com/&lt;EHR source id&gt;/codeSet/40
-      info_link: https://fhir.cerner.com/millennium/r4/proprietary-codes-and-systems/#code-set-40-person-relationship
+      info_link: https://fhir.cerner.com/millennium/r4/proprietary-codes-and-systems/#code-set-40-person-relationships


### PR DESCRIPTION
the name of valueset-identifier-type is "Identifier Type Codes"

the name of code set 36 is "Languages"

the name and URL of code set 40 are "Person Relationships"