### PR TITLE
Add warning against writing both standard and proprietary codes

### DIFF
--- a/content/millennium/dstu2/proprietary-codes.md
+++ b/content/millennium/dstu2/proprietary-codes.md
@@ -27,7 +27,7 @@ The following are true for all Millennium proprietary codes:
 * The `userSelected` value is set to true
 * On inbound requests (POST, PUT, PATCH), proprietary codes and standard codes may not be set in the same coding array. If they are, the create or update request will fail with a 422 Unprocessable Entity response.
 
-Example outbound from CodeableConcept displaying both standard and proprietary codes:
+Example outbound CodeableConcept displaying both standard and proprietary codes:
 
     {
       "type": {

--- a/content/millennium/dstu2/proprietary-codes.md
+++ b/content/millennium/dstu2/proprietary-codes.md
@@ -25,8 +25,9 @@ The following are true for all Millennium proprietary codes:
 * The `code` value is the numeric code value as a string
 * The `display` value is the code value display
 * The `userSelected` value is set to true
+* On inbound requests (POST, PUT, PATCH), proprietary codes and standard codes may not be set in the same coding array. If they are, the create or update request will fail with a 422 Unprocessable Entity response.
 
-Example read from CodeableConcept displaying both standard and proprietary codes:
+Example outbound from CodeableConcept displaying both standard and proprietary codes:
 
     {
       "type": {
@@ -55,10 +56,6 @@ Example read from CodeableConcept displaying both standard and proprietary codes
 The DocumentReference Resource supports proprietary codes for:
 
 * DocumentReference.type codes are maintained in [Code Set 72 Event Code](#code-set-72-event-code)
-
-_Notes:_
-
-* When adding or updating data, if both proprietary and standard codes are populated for the specific request body field, the request will fail
 
 ## Scheduling
 

--- a/content/millennium/dstu2/proprietary-codes.md
+++ b/content/millennium/dstu2/proprietary-codes.md
@@ -25,7 +25,7 @@ The following are true for all Millennium proprietary codes:
 * The `code` value is the numeric code value as a string
 * The `display` value is the code value display
 * The `userSelected` value is set to true
-* On inbound requests (POST, PUT, PATCH), proprietary codes and standard codes may not be set in the same coding array. If they are, the create or update request will fail with a 422 Unprocessable Entity response.
+* On inbound requests (POST, PUT, PATCH), proprietary codes and standard codes may not be set in the same coding array. If they are, the create or update request will fail with a `422 Unprocessable Entity` response.
 
 Example outbound CodeableConcept displaying both standard and proprietary codes:
 

--- a/content/millennium/dstu2/proprietary-codes.md
+++ b/content/millennium/dstu2/proprietary-codes.md
@@ -26,7 +26,7 @@ The following are true for all Millennium proprietary codes:
 * The `display` value is the code value display
 * The `userSelected` value is set to true
 
-Example CodeableConcept displaying both standard and proprietary codes:
+Example read from CodeableConcept displaying both standard and proprietary codes:
 
     {
       "type": {
@@ -55,6 +55,10 @@ Example CodeableConcept displaying both standard and proprietary codes:
 The DocumentReference Resource supports proprietary codes for:
 
 * DocumentReference.type codes are maintained in [Code Set 72 Event Code](#code-set-72-event-code)
+
+_Notes:_
+
+* When adding or updating data, if both proprietary and standard codes are populated for the specific request body field, the request will fail
 
 ## Scheduling
 

--- a/content/millennium/r4/proprietary-codes-and-systems.md
+++ b/content/millennium/r4/proprietary-codes-and-systems.md
@@ -21,7 +21,7 @@ The following are true for all Millennium proprietary codes:
 * The `code` value is the numeric code value as a string
 * The `display` value is the code value display
 * The `userSelected` value is set to true
-* On inbound requests (POST, PUT, PATCH), proprietary codes and standard codes may not be set in the same coding array. If they are, the create or update request will fail with a 422 Unprocessable Entity response.
+* On inbound requests (POST, PUT, PATCH), proprietary codes and standard codes may not be set in the same coding array. If they are, the create or update request will fail with a `422 Unprocessable Entity` response.
 
 Example outbound CodeableConcept displaying both standard and proprietary codes:
 

--- a/content/millennium/r4/proprietary-codes-and-systems.md
+++ b/content/millennium/r4/proprietary-codes-and-systems.md
@@ -23,7 +23,7 @@ The following are true for all Millennium proprietary codes:
 * The `userSelected` value is set to true
 * On inbound requests (POST, PUT, PATCH), proprietary codes and standard codes may not be set in the same coding array. If they are, the create or update request will fail with a 422 Unprocessable Entity response.
 
-Example outbound from CodeableConcept displaying both standard and proprietary codes:
+Example outbound CodeableConcept displaying both standard and proprietary codes:
 
     {
       "type": {

--- a/content/millennium/r4/proprietary-codes-and-systems.md
+++ b/content/millennium/r4/proprietary-codes-and-systems.md
@@ -21,8 +21,9 @@ The following are true for all Millennium proprietary codes:
 * The `code` value is the numeric code value as a string
 * The `display` value is the code value display
 * The `userSelected` value is set to true
+* When adding or updating data, if both proprietary and standard codes are populated for the specific request body field, the request will fail
 
-Example CodeableConcept displaying both standard and proprietary codes:
+Example read from CodeableConcept displaying both standard and proprietary codes:
 
     {
       "type": {

--- a/content/millennium/r4/proprietary-codes-and-systems.md
+++ b/content/millennium/r4/proprietary-codes-and-systems.md
@@ -21,9 +21,9 @@ The following are true for all Millennium proprietary codes:
 * The `code` value is the numeric code value as a string
 * The `display` value is the code value display
 * The `userSelected` value is set to true
-* When adding or updating data, if both proprietary and standard codes are populated for the specific request body field, the request will fail
+* On inbound requests (POST, PUT, PATCH), proprietary codes and standard codes may not be set in the same coding array. If they are, the create or update request will fail with a 422 Unprocessable Entity response.
 
-Example read from CodeableConcept displaying both standard and proprietary codes:
+Example outbound from CodeableConcept displaying both standard and proprietary codes:
 
     {
       "type": {


### PR DESCRIPTION
When writing a proprietary code there will be a failure if standard codes are supplied as well. This affects DocumentReference writes in DSTU2 and all writes in R4. The documentation for proprietary codes now notes that when standard codes are provided on a write they will cause the write to fail.