### PR TITLE
Adding AllergyIntolerance terminology binding: RxNorm

### DIFF
--- a/lib/resources/r4/allergy_intolerance.yaml
+++ b/lib/resources/r4/allergy_intolerance.yaml
@@ -98,6 +98,9 @@ fields:
                  or a negated/excluded code for a specific substance or class (e.g., "No latex allergy") or a general or
                  categorical negated statement (e.g., "No known allergy", "No known drug allergies").
     terminology:
+    - display: RxNorm
+      system: http://www.nlm.nih.gov/research/umls/rxnorm
+      info_link: http://hl7.org/fhir/dstu2/rxnorm.html
     - display: Substance Code
       system: http://hl7.org/fhir/ValueSet/substance-code
       info_link: http://hl7.org/fhir/valueset-allergyintolerance-code.html

--- a/lib/resources/r4/allergy_intolerance.yaml
+++ b/lib/resources/r4/allergy_intolerance.yaml
@@ -100,7 +100,7 @@ fields:
     terminology:
     - display: RxNorm
       system: http://www.nlm.nih.gov/research/umls/rxnorm
-      info_link: http://hl7.org/fhir/dstu2/rxnorm.html
+      info_link: http://hl7.org/fhir/r4/rxnorm.html
     - display: Substance Code
       system: http://hl7.org/fhir/ValueSet/substance-code
       info_link: http://hl7.org/fhir/valueset-allergyintolerance-code.html


### PR DESCRIPTION
Adding RxNorm to the terminology bindings for r4. It's already documented in DSTU2, just updated in R4.