### PR TITLE
Devices Json Inconsistencies

### DIFF
--- a/content/millennium/dstu2/devices/device.md
+++ b/content/millennium/dstu2/devices/device.md
@@ -69,6 +69,8 @@ _Implementation Notes_
 <%= headers status: 200 %>
 <%= json(:dstu2_device_bundle) %>
 
+<%= disclaimer %>
+
 ### Example Read by Ids
 
 #### Request
@@ -79,6 +81,8 @@ _Implementation Notes_
 
 <%= headers status: 200 %>
 <%= json(:dstu2_device_bundle_by_id) %>
+
+<%= disclaimer %>
 
 ### Errors
 
@@ -112,6 +116,8 @@ _Implementation Notes_
 
 <%= headers status: 200 %>
 <%= json(:dstu2_device) %>
+
+<%= disclaimer %>
 
 ### Errors
 


### PR DESCRIPTION
The goal of these changes were to add a disclaimer to request examples in the Device resource that the data may be different than the response shown.

Verifcation:
<img width="712" alt="Screen Shot 2019-11-14 at 9 47 31 AM" src="https://user-images.githubusercontent.com/26021721/68872540-cf07b680-06c3-11ea-928d-48ad04867251.png">
