### PR TITLE
Encounters JSON Inconsistencies

### DIFF
--- a/content/millennium/dstu2/encounters/encounter.md
+++ b/content/millennium/dstu2/encounters/encounter.md
@@ -95,6 +95,8 @@ _Implementation Notes_
 <%= headers status: 200 %>
 <%= json(:dstu2_encounter_bundle) %>
 
+<%= disclaimer %>
+
 ### Errors
 
 The common [errors] and [OperationOutcomes] may be returned.
@@ -128,6 +130,8 @@ _Implementation Notes_
 
 <%= headers status: 200 %>
 <%= json(:dstu2_encounter) %>
+
+<%= disclaimer %>
 
 ### Errors
 


### PR DESCRIPTION
The goal of these changes were to add a disclaimer to request examples in the Encounter resource that the data may be different than the response shown.

Verification:
<img width="750" alt="Screen Shot 2019-11-14 at 9 56 40 AM" src="https://user-images.githubusercontent.com/26021721/68873523-63264d80-06c5-11ea-99a6-54b6b57d66f9.png">
