### PR TITLE
Fix typos in authorization doc

### DIFF
--- a/content/authorization.md
+++ b/content/authorization.md
@@ -480,7 +480,7 @@ TLS/EVSSL indicators are included for display to the user.
 Such visual cues are an important part of security for
 some authentication systems.
 
-Your authorization repsonse comes in the form of a redirect
+Your authorization response comes in the form of a redirect
 (which is orchestrated within the child window) to your
 registered redirect URI.  Once your server has processed
 the response, Javascript can be utilized to notify the
@@ -569,7 +569,7 @@ down certain behaviors within their browsers that were
 traditionally used to facilitate OAuth2-based authorization
 workflows.  Specifically, browsers now interrupt any
 attempt to direct a user to a native application due to
-absue from advertisers of mobile apps.  As a result,
+abuse from advertisers of mobile apps.  As a result,
 OS platforms now offer "in-app" browsers useful for
 orchestrating authorization workflows that are free of
 such impediments.  These "in-app" browsers also improve


### PR DESCRIPTION
Fix typos in authorization doc (Thanks John Moses for reporting this)