### PR TITLE
Add content.attachment.title to DocumentReference

### DIFF
--- a/content/millennium/dstu2/infrastructure/document-reference.md
+++ b/content/millennium/dstu2/infrastructure/document-reference.md
@@ -34,7 +34,9 @@ The following fields are returned if valued for clinical documents:
 * [Indexed date/time](http://hl7.org/fhir/DSTU2/documentreference-definitions.html#DocumentReference.indexed){:target="_blank"}
 * [Status (typically current)](http://hl7.org/fhir/DSTU2/documentreference-definitions.html#DocumentReference.status){:target="_blank"}
 * [Document status (typically final or amended)](http://hl7.org/fhir/DSTU2/documentreference-definitions.html#DocumentReference.docStatus){:target="_blank"}
-* [ContentType, URL, and Title (fully qualified link to the document)](http://hl7.org/fhir/DSTU2/documentreference-definitions.html#DocumentReference.content.attachment){:target="_blank"}
+* Contents:
+  * [Attachment](http://hl7.org/fhir/DSTU2/documentreference-definitions.html#DocumentReference.content.attachment){:target="_blank"}
+    * [ContentType, URL, and Title](http://hl7.org/fhir/DSTU2/datatypes-definitions.html#Attachment)
 * [Patient encounter](http://hl7.org/fhir/DSTU2/documentreference-definitions.html#DocumentReference.context.encounter){:target="_blank"}
 
 
@@ -102,7 +104,7 @@ Create new documents. Currently limited to unstructured clinical notes or docume
 
     POST /DocumentReference
 
-_Implementation Notes_   
+_Implementation Notes_
 
 * The modifier elements [implicitRules], [modifierExtension] and [relatesTo] are not supported and will be rejected if present.
 * Currently only XHTML formatted documents are supported. You can validate your document using any available strict XHTML 1.0 validator (eg: [w3 validator] or this [html5 validator]).
@@ -128,7 +130,7 @@ _Implementation Notes_
 
 #### Body
 
-<%= json(:dstu2_document_reference_docref_create) %>    
+<%= json(:dstu2_document_reference_docref_create) %>
 
 #### Response
 
@@ -226,7 +228,7 @@ _Implementation Notes_
 `start`   | N         | [`date`]      | The start of the date range from which document reference records should be included. If not provided, then all records from the beginning of time are included. Example: `2014-09-24T12:00:00.000Z`
 `end`     | N         | [`date`]      | The end of the date range till which document reference records should be included. If not provided, then all records up to the current date are included. Example: `2016-09-24T12:00:00.000Z`
 
-Notes:   
+Notes:
 
 - The `type` parameter must include both a system and a code. (e.g. `&type=http://loinc.org|34133-9`)
 - The `start` and `end` parameters must be valid [dateTime]s with a time component. They must have prefixes of `eq` or nothing.

--- a/content/millennium/dstu2/infrastructure/document-reference.md
+++ b/content/millennium/dstu2/infrastructure/document-reference.md
@@ -34,7 +34,7 @@ The following fields are returned if valued for clinical documents:
 * [Indexed date/time](http://hl7.org/fhir/DSTU2/documentreference-definitions.html#DocumentReference.indexed){:target="_blank"}
 * [Status (typically current)](http://hl7.org/fhir/DSTU2/documentreference-definitions.html#DocumentReference.status){:target="_blank"}
 * [Document status (typically final or amended)](http://hl7.org/fhir/DSTU2/documentreference-definitions.html#DocumentReference.docStatus){:target="_blank"}
-* [ContentType and URL (fully qualified link to the document](http://hl7.org/fhir/DSTU2/documentreference-definitions.html#DocumentReference.content.attachment){:target="_blank"}
+* [ContentType, URL, and Title (fully qualified link to the document)](http://hl7.org/fhir/DSTU2/documentreference-definitions.html#DocumentReference.content.attachment){:target="_blank"}
 * [Patient encounter](http://hl7.org/fhir/DSTU2/documentreference-definitions.html#DocumentReference.context.encounter){:target="_blank"}
 
 

--- a/content/millennium/dstu2/infrastructure/document-reference.md
+++ b/content/millennium/dstu2/infrastructure/document-reference.md
@@ -34,9 +34,10 @@ The following fields are returned if valued for clinical documents:
 * [Indexed date/time](http://hl7.org/fhir/DSTU2/documentreference-definitions.html#DocumentReference.indexed){:target="_blank"}
 * [Status (typically current)](http://hl7.org/fhir/DSTU2/documentreference-definitions.html#DocumentReference.status){:target="_blank"}
 * [Document status (typically final or amended)](http://hl7.org/fhir/DSTU2/documentreference-definitions.html#DocumentReference.docStatus){:target="_blank"}
-* Contents:
-  * [Attachment](http://hl7.org/fhir/DSTU2/documentreference-definitions.html#DocumentReference.content.attachment){:target="_blank"}
-    * [ContentType, URL, and Title](http://hl7.org/fhir/DSTU2/datatypes-definitions.html#Attachment){:target="_blank"}
+* [Document Attachment](https://hl7.org/fhir/dstu2/documentreference-definitions.html#DocumentReference.content.attachment){:target="_blank"}
+  * [Attachement ContentType](https://hl7.org/fhir/dstu2/datatypes-definitions.html#Attachment.contentType){:target="_blank"}
+  * [URL (fully qualified link to the document)](https://hl7.org/fhir/dstu2/datatypes-definitions.html#Attachment.url){:target="_blank"}
+  * [Title](https://hl7.org/fhir/dstu2/datatypes-definitions.html#Attachment.title){:target="_blank"}
 * [Patient encounter](http://hl7.org/fhir/DSTU2/documentreference-definitions.html#DocumentReference.context.encounter){:target="_blank"}
 
 

--- a/content/millennium/dstu2/infrastructure/document-reference.md
+++ b/content/millennium/dstu2/infrastructure/document-reference.md
@@ -34,12 +34,12 @@ The following fields are returned if valued for clinical documents:
 * [Indexed date/time](http://hl7.org/fhir/DSTU2/documentreference-definitions.html#DocumentReference.indexed){:target="_blank"}
 * [Status (typically current)](http://hl7.org/fhir/DSTU2/documentreference-definitions.html#DocumentReference.status){:target="_blank"}
 * [Document status (typically final or amended)](http://hl7.org/fhir/DSTU2/documentreference-definitions.html#DocumentReference.docStatus){:target="_blank"}
-* [Document Attachment](https://hl7.org/fhir/dstu2/documentreference-definitions.html#DocumentReference.content.attachment){:target="_blank"}
-  * [Attachement ContentType](https://hl7.org/fhir/dstu2/datatypes-definitions.html#Attachment.contentType){:target="_blank"}
-  * [URL (fully qualified link to the document)](https://hl7.org/fhir/dstu2/datatypes-definitions.html#Attachment.url){:target="_blank"}
-  * [Title](https://hl7.org/fhir/dstu2/datatypes-definitions.html#Attachment.title){:target="_blank"}
+* [Content](https://hl7.org/fhir/dstu2/documentreference-definitions.html#DocumentReference.content){:target="_blank"}
+  * [Attachment](https://hl7.org/fhir/dstu2/documentreference-definitions.html#DocumentReference.content.attachment){:target="_blank"}
+    * [Content type](https://hl7.org/fhir/dstu2/datatypes-definitions.html#Attachment.contentType){:target="_blank"}
+    * [URL (fully qualified link to the document)](https://hl7.org/fhir/dstu2/datatypes-definitions.html#Attachment.url){:target="_blank"}
+    * [Title](https://hl7.org/fhir/dstu2/datatypes-definitions.html#Attachment.title){:target="_blank"}
 * [Patient encounter](http://hl7.org/fhir/DSTU2/documentreference-definitions.html#DocumentReference.context.encounter){:target="_blank"}
-
 
 ## Terminology Bindings
 

--- a/content/millennium/dstu2/infrastructure/document-reference.md
+++ b/content/millennium/dstu2/infrastructure/document-reference.md
@@ -36,7 +36,7 @@ The following fields are returned if valued for clinical documents:
 * [Document status (typically final or amended)](http://hl7.org/fhir/DSTU2/documentreference-definitions.html#DocumentReference.docStatus){:target="_blank"}
 * Contents:
   * [Attachment](http://hl7.org/fhir/DSTU2/documentreference-definitions.html#DocumentReference.content.attachment){:target="_blank"}
-    * [ContentType, URL, and Title](http://hl7.org/fhir/DSTU2/datatypes-definitions.html#Attachment)
+    * [ContentType, URL, and Title](http://hl7.org/fhir/DSTU2/datatypes-definitions.html#Attachment){:target="_blank"}
 * [Patient encounter](http://hl7.org/fhir/DSTU2/documentreference-definitions.html#DocumentReference.context.encounter){:target="_blank"}
 
 

--- a/lib/resources/example_json/dstu2_examples_document_reference.rb
+++ b/lib/resources/example_json/dstu2_examples_document_reference.rb
@@ -52,7 +52,8 @@ module Cerner
             "content": [{
               "attachment": {
                 "contentType": "application/pdf",
-                "url": "https://fhir-open.sandboxcerner.com/dstu2/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/Binary/XR-6589312"
+                "url": "https://fhir-open.sandboxcerner.com/dstu2/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/Binary/XR-6589312",
+                "title": "Rheumatology Note"
               }
             }],
             "context": {
@@ -104,7 +105,8 @@ module Cerner
             "content": [{
               "attachment": {
                 "contentType": "application/pdf",
-                "url": "https://fhir-open.sandboxcerner.com/dstu2/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/Binary/XR-6589307"
+                "url": "https://fhir-open.sandboxcerner.com/dstu2/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/Binary/XR-6589307",
+                "title": "Rheumatology Note"
               }
             }],
             "context": {
@@ -156,7 +158,8 @@ module Cerner
             "content": [{
               "attachment": {
                 "contentType": "application/pdf",
-                "url": "https://fhir-open.sandboxcerner.com/dstu2/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/Binary/XR-6589287"
+                "url": "https://fhir-open.sandboxcerner.com/dstu2/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/Binary/XR-6589287",
+                "title": "Rheumatology Note"
               }
             }],
             "context": {
@@ -208,7 +211,8 @@ module Cerner
             "content": [{
               "attachment": {
                 "contentType": "application/pdf",
-                "url": "https://fhir-open.sandboxcerner.com/dstu2/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/Binary/XR-6589283"
+                "url": "https://fhir-open.sandboxcerner.com/dstu2/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/Binary/XR-6589283",
+                "title": "Rheumatology Note"
               }
             }],
             "context": {
@@ -325,7 +329,8 @@ module Cerner
         {
           "attachment": {
             "contentType": "application/pdf",
-            "url": "https://fhir-open.sandboxcerner.com/dstu2/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/Binary/XR-7499283"
+            "url": "https://fhir-open.sandboxcerner.com/dstu2/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/Binary/XR-7499283",
+            "title": "Physician Emergency department Note"
           }
         }
       ],

--- a/static/css/documentation.css
+++ b/static/css/documentation.css
@@ -1074,7 +1074,7 @@ a .mega-octicon {
   list-style-type: disc;
 }
 
-.content ul ul{
+.content ul ul {
   margin: 0.5em 1.5em;
   list-style-type: disc;
 }

--- a/static/css/documentation.css
+++ b/static/css/documentation.css
@@ -1074,6 +1074,11 @@ a .mega-octicon {
   list-style-type: disc;
 }
 
+.content ul ul{
+  margin: 0.5em 1.5em;
+  list-style-type: disc;
+}
+
 .content dd ul {
   margin-top: 0;
 }


### PR DESCRIPTION
Document Reference now returns a title in Docref.content.attachment on reads/searches, so here is an updated overview and JSON example.

Pics from running locally:
Overview:
<img width="1676" alt="overview" src="https://user-images.githubusercontent.com/18541545/71921080-bc52b080-314d-11ea-81f8-a83cdbb046e9.png">

JSON update:
<img width="1674" alt="firstJSONExample" src="https://user-images.githubusercontent.com/18541545/71921098-c4aaeb80-314d-11ea-991b-1f8b2d1364ac.png">
