### PR TITLE
Add presentedForm.title to DiagnosticReport

### DIFF
--- a/content/millennium/dstu2/diagnostic/diagnostic-report.md
+++ b/content/millennium/dstu2/diagnostic/diagnostic-report.md
@@ -26,7 +26,7 @@ The following fields are returned if valued:
 * [Issued date/time](http://hl7.org/fhir/DSTU2/diagnosticreport-definitions.html#DiagnosticReport.issued){:target="_blank"}
 * [Performer (practitioner)](http://hl7.org/fhir/DSTU2/diagnosticreport-definitions.html#DiagnosticReport.performer){:target="_blank"}
 * [Request (order)](http://hl7.org/fhir/DSTU2/diagnosticreport-definitions.html#DiagnosticReport.request){:target="_blank"}
-* [ContentType and URL (fully qualified link to the document](http://hl7.org/fhir/DSTU2/diagnosticreport-definitions.html#DiagnosticReport.presentedForm){:target="_blank"}
+* [ContentType, URL, and Title (fully qualified link to the document)](http://hl7.org/fhir/DSTU2/diagnosticreport-definitions.html#DiagnosticReport.presentedForm){:target="_blank"}
 
 ## Terminology Bindings
 

--- a/content/millennium/dstu2/diagnostic/diagnostic-report.md
+++ b/content/millennium/dstu2/diagnostic/diagnostic-report.md
@@ -10,7 +10,7 @@ title: DiagnosticReport | DSTU 2 API
 ## Overview
 
 The DiagnosticReport resource typically provides a textual set of information and interpretation after performing a
-diagnostic service or procedure such as a Radiology or Pathology report.  
+diagnostic service or procedure such as a Radiology or Pathology report.
 
 This resource currently only supports Radiology reports in the presented form of either PDF or HTML.
 
@@ -26,7 +26,8 @@ The following fields are returned if valued:
 * [Issued date/time](http://hl7.org/fhir/DSTU2/diagnosticreport-definitions.html#DiagnosticReport.issued){:target="_blank"}
 * [Performer (practitioner)](http://hl7.org/fhir/DSTU2/diagnosticreport-definitions.html#DiagnosticReport.performer){:target="_blank"}
 * [Request (order)](http://hl7.org/fhir/DSTU2/diagnosticreport-definitions.html#DiagnosticReport.request){:target="_blank"}
-* [ContentType, URL, and Title (fully qualified link to the document)](http://hl7.org/fhir/DSTU2/diagnosticreport-definitions.html#DiagnosticReport.presentedForm){:target="_blank"}
+* PresentedForms:
+  * [ContentType, URL, and Title (fully qualified link to the document)](http://hl7.org/fhir/DSTU2/diagnosticreport-definitions.html#DiagnosticReport.presentedForm){:target="_blank"}
 
 ## Terminology Bindings
 

--- a/content/millennium/dstu2/diagnostic/diagnostic-report.md
+++ b/content/millennium/dstu2/diagnostic/diagnostic-report.md
@@ -27,7 +27,7 @@ The following fields are returned if valued:
 * [Performer (practitioner)](http://hl7.org/fhir/DSTU2/diagnosticreport-definitions.html#DiagnosticReport.performer){:target="_blank"}
 * [Request (order)](http://hl7.org/fhir/DSTU2/diagnosticreport-definitions.html#DiagnosticReport.request){:target="_blank"}
 * [Presented Form](http://hl7.org/fhir/DSTU2/diagnosticreport-definitions.html#DiagnosticReport.presentedForm){:target="_blank"}
-  * [ContentType](http://hl7.org/fhir/DSTU2/datatypes-definitions.html#Attachment.contentType){:target="_blank"}
+  * [Content type](http://hl7.org/fhir/DSTU2/datatypes-definitions.html#Attachment.contentType){:target="_blank"}
   * [URL (fully qualified link to the document)](http://hl7.org/fhir/DSTU2/datatypes-definitions.html#Attachment.url){:target="_blank"}
   * [Title](http://hl7.org/fhir/DSTU2/datatypes-definitions.html#Attachment.title){:target="_blank"}
 

--- a/content/millennium/dstu2/diagnostic/diagnostic-report.md
+++ b/content/millennium/dstu2/diagnostic/diagnostic-report.md
@@ -26,8 +26,10 @@ The following fields are returned if valued:
 * [Issued date/time](http://hl7.org/fhir/DSTU2/diagnosticreport-definitions.html#DiagnosticReport.issued){:target="_blank"}
 * [Performer (practitioner)](http://hl7.org/fhir/DSTU2/diagnosticreport-definitions.html#DiagnosticReport.performer){:target="_blank"}
 * [Request (order)](http://hl7.org/fhir/DSTU2/diagnosticreport-definitions.html#DiagnosticReport.request){:target="_blank"}
-* PresentedForms:
-  * [ContentType, URL, and Title (fully qualified link to the document)](http://hl7.org/fhir/DSTU2/diagnosticreport-definitions.html#DiagnosticReport.presentedForm){:target="_blank"}
+* [Presented Form](http://hl7.org/fhir/DSTU2/diagnosticreport-definitions.html#DiagnosticReport.presentedForm){:target="_blank"}
+  * [ContentType](http://hl7.org/fhir/DSTU2/datatypes-definitions.html#Attachment.contentType){:target="_blank"}
+  * [URL (fully qualified link to the document)](http://hl7.org/fhir/DSTU2/datatypes-definitions.html#Attachment.url){:target="_blank"}
+  * [Title](http://hl7.org/fhir/DSTU2/datatypes-definitions.html#Attachment.title){:target="_blank"}
 
 ## Terminology Bindings
 

--- a/lib/resources/example_json/dstu2_examples_diagnostic_report.rb
+++ b/lib/resources/example_json/dstu2_examples_diagnostic_report.rb
@@ -52,11 +52,13 @@ module Cerner
             "presentedForm": [
               {
                 "contentType": "text/html",
-                "url": "https://fhir-open.sandboxcerner.com/dstu2/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/Binary/TR-5153487"
+                "url": "https://fhir-open.sandboxcerner.com/dstu2/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/Binary/TR-5153487",
+                "title": "XR Wrist Complete Left"
               },
               {
                 "contentType": "application/pdf",
-                "url": "https://fhir-open.sandboxcerner.com/dstu2/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/Binary/XR-5153487"
+                "url": "https://fhir-open.sandboxcerner.com/dstu2/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/Binary/XR-5153487",
+                "title": "XR Wrist Complete Left"
               }
             ]
           }
@@ -102,11 +104,13 @@ module Cerner
             "presentedForm": [
               {
                 "contentType": "text/html",
-                "url": "https://fhir-open.sandboxcerner.com/dstu2/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/Binary/TR-4135365"
+                "url": "https://fhir-open.sandboxcerner.com/dstu2/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/Binary/TR-4135365",
+                "title": "CT Abdomen w/ Contrast"
               },
               {
                 "contentType": "application/pdf",
-                "url": "https://fhir-open.sandboxcerner.com/dstu2/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/Binary/XR-4135365"
+                "url": "https://fhir-open.sandboxcerner.com/dstu2/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/Binary/XR-4135365",
+                "title": "CT Abdomen w/ Contrast"
               }
             ]
           }
@@ -155,11 +159,13 @@ module Cerner
             "presentedForm": [
               {
                 "contentType": "text/html",
-                "url": "https://fhir-open.sandboxcerner.com/dstu2/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/Binary/TR-3411366"
+                "url": "https://fhir-open.sandboxcerner.com/dstu2/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/Binary/TR-3411366",
+                "title": "XR Abdomen AP | XR Abdomen Series w/ Chest 1 View"
               },
               {
                 "contentType": "application/pdf",
-                "url": "https://fhir-open.sandboxcerner.com/dstu2/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/Binary/XR-3411366"
+                "url": "https://fhir-open.sandboxcerner.com/dstu2/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/Binary/XR-3411366",
+                "title": "XR Abdomen AP | XR Abdomen Series w/ Chest 1 View"
               }
             ]
           }


### PR DESCRIPTION
DiagnosticReport now returns a title in PresentedForm, so here is an updated Overview and JSON example.

Pics of changes running locally:
Overview:
<img width="1677" alt="DiagRepOverview" src="https://user-images.githubusercontent.com/18541545/72075277-060bda00-32b9-11ea-8c10-7dd6da35c90b.png">

JSON example:
<img width="1672" alt="DiagRepJSON" src="https://user-images.githubusercontent.com/18541545/72075313-1a4fd700-32b9-11ea-921b-edbd18ed7d5d.png">
