### PR TITLE
Set action to terminology for R4 Appointment reasonCode

### DIFF
--- a/lib/resources/r4/appointment.yaml
+++ b/lib/resources/r4/appointment.yaml
@@ -175,6 +175,7 @@ fields:
   cardinality: 0..*
   type: CodeableConcept
   description: Coded reason this appointment is scheduled.
+  action: terminology
   binding:
     description: Coded reason this appointment is scheduled.
     note: Currently not bound to any terminology.


### PR DESCRIPTION
This change removes reasonCode from the R4 Appointment create body fields table. We did not set an action key in the R4 Appointment yaml file until now. R4 Appointment create ignores reasonCode if it is set.

Local verification - comment is now the final field in the create body fields table:
![Screen Shot 2020-01-17 at 3 53 32 PM](https://user-images.githubusercontent.com/5505772/72648861-c476d100-3941-11ea-834b-5fa69c75b26f.png)

Fixes #339 