### PR TITLE
Removed support for R4 Document Reference description field

### DIFF
--- a/content/millennium/r4/documents/document-reference.md
+++ b/content/millennium/r4/documents/document-reference.md
@@ -21,7 +21,6 @@ The following fields are returned if valued:
 * [Subject (Patient)](https://hl7.org/fhir/r4/documentreference-definitions.html#DocumentReference.subject){:target="_blank"}
 * [Author](https://hl7.org/fhir/r4/documentreference-definitions.html#DocumentReference.author){:target="_blank"}
 * [Authenticator/verifying provider](https://hl7.org/fhir/r4/documentreference-definitions.html#DocumentReference.authenticator){:target="_blank"}
-* [Document description/title]( https://hl7.org/fhir/r4/documentreference-definitions.html#DocumentReference.description){:target="_blank"}
 * [Document Attachment](https://hl7.org/fhir/r4/documentreference-definitions.html#DocumentReference.content.attachment){:target="_blank"}
     * [Attachment ContentType](https://hl7.org/fhir/r4/datatypes-definitions.html#Attachment.contentType){:target="_blank"}
     * [Created date/time](https://hl7.org/fhir/r4/datatypes-definitions.html#Attachment.creation){:target="_blank"}


### PR DESCRIPTION
Removed support for R4 Document Reference description field
<img width="1680" alt="Screen Shot 2020-02-17 at 10 55 11 AM" src="https://user-images.githubusercontent.com/57371947/74673060-20688b80-5174-11ea-9d7a-41ccee2a2715.png">
<img width="1680" alt="Screen Shot 2020-02-17 at 10 55 17 AM" src="https://user-images.githubusercontent.com/57371947/74673067-25c5d600-5174-11ea-9a12-dced9212d953.png">
<img width="1680" alt="Screen Shot 2020-02-17 at 10 55 23 AM" src="https://user-images.githubusercontent.com/57371947/74673073-28283000-5174-11ea-9b04-55bacc211274.png">
<img width="1680" alt="Screen Shot 2020-02-17 at 10 55 29 AM" src="https://user-images.githubusercontent.com/57371947/74673076-29595d00-5174-11ea-8af8-a1b0ee2c360f.png">
<img width="1680" alt="Screen Shot 2020-02-17 at 10 55 34 AM" src="https://user-images.githubusercontent.com/57371947/74673077-29595d00-5174-11ea-94fd-17f966a4f240.png">
<img width="1680" alt="Screen Shot 2020-02-17 at 10 55 41 AM" src="https://user-images.githubusercontent.com/57371947/74673079-29f1f380-5174-11ea-8b69-cf2368d5caac.png">
<img width="1680" alt="Screen Shot 2020-02-17 at 10 55 47 AM" src="https://user-images.githubusercontent.com/57371947/74673081-29f1f380-5174-11ea-8b42-acdd30ca33d7.png">
<img width="1680" alt="Screen Shot 2020-02-17 at 10 55 53 AM" src="https://user-images.githubusercontent.com/57371947/74673082-29f1f380-5174-11ea-9873-e7fc4ac8a0d2.png">
<img width="1680" alt="Screen Shot 2020-02-17 at 10 56 00 AM" src="https://user-images.githubusercontent.com/57371947/74673083-2a8a8a00-5174-11ea-8f5d-139f263f778b.png">
<img width="1680" alt="Screen Shot 2020-02-17 at 10 56 05 AM" src="https://user-images.githubusercontent.com/57371947/74673084-2a8a8a00-5174-11ea-836d-bd7279ccbdf2.png">

