### PR TITLE
Add documentation for R4 Condition diagnosis read/search

### DIFF
--- a/content/millennium/r4.md
+++ b/content/millennium/r4.md
@@ -72,6 +72,9 @@ Content-Type: application/json+fhir
           "type": "Condition",
           "interaction": [
             {
+              "code": "read"
+            },
+            {
               "code": "search-type"
             }
           ],

--- a/content/millennium/r4.md
+++ b/content/millennium/r4.md
@@ -80,25 +80,25 @@ Content-Type: application/json+fhir
               "name": "patient",
               "definition": "http://hl7.org/fhir/R4/SearchParameter/clinical-patient",
               "type": "reference",
-              "documentation": "Who the sensitivity is for. It is a required field if the subject field is not given."
+              "documentation": "Who has the condition. It is a required field if the subject field is not given."
             },
             {
               "name": "subject",
               "definition": "http://hl7.org/fhir/R4/SearchParameter/Condition-subject",
               "type": "reference",
-              "documentation": "Who has the condition?. It is a required field if the patient field is not given."
+              "documentation": "Who has the condition. It is a required field if the patient field is not given."
             },
             {
               "name": "clinical-status",
               "definition": "http://hl7.org/fhir/R4/SearchParameter/Condition-clinical-status",
               "type": "token",
-              "documentation": "The clinical status of the condition"
+              "documentation": "The clinical status of the condition."
             },
             {
               "name": "category",
               "definition": "http://hl7.org/fhir/R4/SearchParameter/Condition-category",
               "type": "token",
-              "documentation": "The category of the condition. Category problem-list-item is supported as of now."
+              "documentation": "The category of the condition. Categories problem-list-item and encounter-diagnosis are supported as of now."
             }
           ]
         },

--- a/content/millennium/r4/general-clinical/condition.md
+++ b/content/millennium/r4/general-clinical/condition.md
@@ -39,7 +39,7 @@ Search for Conditions that meet supplied query parameters:
 
 _Implementation Notes_
 
-* Currently `problem-list-item` is supported.
+* Currently `problem-list-item` and `encounter-diagnosis` are supported.
 
 ### Authorization Types
 
@@ -53,7 +53,7 @@ _Implementation Notes_
  `patient`         | This or `_id` or `subject`     | [`reference`] | Who the condition is for. Example: `12345`
  `subject`         | This or `_id` or `patient`     | [`reference`] | Who the condition is for. Example: `Patient/12345`
  `clinical-status` | No                             | [`token`]     | The clinical status of the condition. Example: `active`, `inactive`, `resolved`
- `category`        | No                             | [`token`]     | The category of the condition. Category problem-list-item is supported as of now. Example: `problem-list-item`
+ `category`        | No                             | [`token`]     | The category of the condition. Categories problem-list-item and encounter-diagnosis are supported as of now. Example: `problem-list-item`, `encounter-diagnosis`
 
 Notes:
 

--- a/lib/resources/example_json/r4_examples_capabilitystatement.rb
+++ b/lib/resources/example_json/r4_examples_capabilitystatement.rb
@@ -194,25 +194,25 @@ module Cerner
                   "name": "patient",
                   "definition": "http://hl7.org/fhir/R4/SearchParameter/clinical-patient",
                   "type": "reference",
-                  "documentation": "Who the sensitivity is for. It is a required field if the subject or _id fields are not given."
+                  "documentation": "Who has the condition. It is a required field if the subject or _id fields are not given."
                 },
                 {
                   "name": "subject",
                   "definition": "http://hl7.org/fhir/R4/SearchParameter/Condition-subject",
                   "type": "reference",
-                  "documentation": "Who has the condition?. It is a required field if the patient or _id fields are not given."
+                  "documentation": "Who has the condition. It is a required field if the patient or _id fields are not given."
                 },
                 {
                   "name": "clinical-status",
                   "definition": "http://hl7.org/fhir/R4/SearchParameter/Condition-clinical-status",
                   "type": "token",
-                  "documentation": "The clinical status of the condition"
+                  "documentation": "The clinical status of the condition."
                 },
                 {
                   "name": "category",
                   "definition": "http://hl7.org/fhir/R4/SearchParameter/Condition-category",
                   "type": "token",
-                  "documentation": "The category of the condition. Category problem-list-item is supported as of now."
+                  "documentation": "The category of the condition. Categories problem-list-item and encounter-diagnosis are supported as of now."
                 }
               ]
             },
@@ -716,25 +716,25 @@ module Cerner
                   "name": "patient",
                   "definition": "http://hl7.org/fhir/R4/SearchParameter/clinical-patient",
                   "type": "reference",
-                  "documentation": "Who the sensitivity is for. It is a required field if the subject or _id fields are not given."
+                  "documentation": "Who has the condition. It is a required field if the subject or _id fields are not given."
                 },
                 {
                   "name": "subject",
                   "definition": "http://hl7.org/fhir/R4/SearchParameter/Condition-subject",
                   "type": "reference",
-                  "documentation": "Who has the condition?. It is a required field if the patient or _id fields are not given."
+                  "documentation": "Who has the condition. It is a required field if the patient or _id fields are not given."
                 },
                 {
                   "name": "clinical-status",
                   "definition": "http://hl7.org/fhir/R4/SearchParameter/Condition-clinical-status",
                   "type": "token",
-                  "documentation": "The clinical status of the condition"
+                  "documentation": "The clinical status of the condition."
                 },
                 {
                   "name": "category",
                   "definition": "http://hl7.org/fhir/R4/SearchParameter/Condition-category",
                   "type": "token",
-                  "documentation": "The category of the condition. Category problem-list-item is supported as of now."
+                  "documentation": "The category of the condition. Categories problem-list-item and encounter-diagnosis are supported as of now."
                 }
               ]
             },


### PR DESCRIPTION
Add documentation to show that diagnosis is supported in R4 Condition reads and searches. 

**Validation**

- Search

![condition_search_doc](https://user-images.githubusercontent.com/47217759/74850315-7158bb00-52ff-11ea-8d19-7ba5ccdb0148.png)

- Open Metadata

![metadata_open1](https://user-images.githubusercontent.com/47217759/74850349-7fa6d700-52ff-11ea-84e9-59a5fb4a63da.png)
![metadata_open2](https://user-images.githubusercontent.com/47217759/74850359-82093100-52ff-11ea-8827-237ba5410979.png)

- Closed Metadata

![metadata_closed1](https://user-images.githubusercontent.com/47217759/74850366-85042180-52ff-11ea-9e10-bbd7c95ff67f.png)
![metadata_closed2](https://user-images.githubusercontent.com/47217759/74850370-86cde500-52ff-11ea-9a10-7344a40f3b9a.png)


