### PR TITLE
Update MedicationRequest.medication[x] terminology display

### DIFF
--- a/lib/resources/r4/medication_request.yaml
+++ b/lib/resources/r4/medication_request.yaml
@@ -66,7 +66,7 @@ fields:
   binding:
     description: A code that defines the medication
     terminology:
-    - display: Request Priority
+    - display: RxNorm
       system: https://www.nlm.nih.gov/research/umls/rxnorm
       info_link: https://www.nlm.nih.gov/research/umls/rxnorm/index.html
 - name: reasonCode

--- a/lib/resources/r4/medication_request_contained_medication.yaml
+++ b/lib/resources/r4/medication_request_contained_medication.yaml
@@ -10,7 +10,7 @@ fields:
   binding:
     description: A code that defines the medication
     terminology:
-    - display: Request Priority
+    - display: RxNorm
       system: https://www.nlm.nih.gov/research/umls/rxnorm
       info_link: https://www.nlm.nih.gov/research/umls/rxnorm/index.html
 - name: form


### PR DESCRIPTION
I updated the MedicationRequest.medication[x] terminology field to display RxNorm.

screenshot:
<img width="1675" alt="rxNorm" src="https://user-images.githubusercontent.com/18541545/77335229-e3a02f00-6cf3-11ea-835a-60c4e85fbad2.png">
