### PR TITLE
Individuals JSON Inconsistencies Update

### DIFF
--- a/content/millennium/dstu2/individuals/patient.md
+++ b/content/millennium/dstu2/individuals/patient.md
@@ -97,6 +97,8 @@ Notes:
 <%= headers status: 200 %>
 <%= json(:dstu2_patient_bundle) %>
 
+<%= disclaimer %>
+
 ### Errors
 
 The common [errors] and [OperationOutcomes] may be returned. In addition, a `422 Unprocessable Entity` will be returned when too many (>1000) patients qualify for the search criteria.
@@ -131,6 +133,8 @@ _Implementation Notes_
 <%= headers status: 200 %>
 <%= json(:dstu2_patient_entry) %>
 
+<%= disclaimer %>
+
 ### Patient Combines Example
 
 Cerner Millennium supports the ability to logically merge a patient record into another patient record when both records are describing the same patient. This is known
@@ -142,12 +146,14 @@ The ability to perform patient combine or uncombine operations is not available 
 
 #### Request
 
-    GET https://fhir-open.sandboxcerner.com/dstu2/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/Patient/4860007
+    GET https://fhir-open.sandboxcerner.com/dstu2/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/Patient/1504027
 
 #### Response
 
 <%= headers status: 200 %>
 <%= json(:dstu2_combined_patient_entry) %>
+
+<%= disclaimer %>
 
 ### Errors
 

--- a/content/millennium/dstu2/individuals/practitioner.md
+++ b/content/millennium/dstu2/individuals/practitioner.md
@@ -55,6 +55,8 @@ Search for Practitioners that meet supplied query parameters:
 
 <%= headers status: 200 %> <%= json(:dstu2_practitioner_bundle) %>
 
+<%= disclaimer %>
+
 ### Errors
 
 The common [errors] and [OperationOutcomes] may be returned.
@@ -82,6 +84,8 @@ List an individual Practitioner by its id:
 #### Response
 
 <%= headers status: 200 %> <%= json(:dstu2_practitioner_entry) %>
+
+<%= disclaimer %>
 
 ### Errors
 

--- a/content/millennium/dstu2/individuals/related-person.md
+++ b/content/millennium/dstu2/individuals/related-person.md
@@ -67,6 +67,8 @@ Notes:
 <%= headers status: 200 %>
 <%= json(:dstu2_relatedperson_bundle) %>
 
+<%= disclaimer %>
+
 ### Errors
 
 The common [errors] and [OperationOutcomes] may be returned.
@@ -95,6 +97,8 @@ List an individual RelatedPerson by its id:
 
 <%= headers status: 200 %>
 <%= json(:dstu2_relatedperson_entry) %>
+
+<%= disclaimer %>
 
 ### Errors
 

--- a/lib/resources/example_json/dstu2_examples_patient.rb
+++ b/lib/resources/example_json/dstu2_examples_patient.rb
@@ -123,15 +123,19 @@ module Cerner
 
     DSTU2_COMBINED_PATIENT_ENTRY ||= {
       "resourceType": "Patient",
-      "id": "4860007",
+      "id": "1504027",
       "meta": {
         "versionId": "0"
+      },
+      "text": {
+        "status": "generated",
+        "div": "&lt;div>&lt;p>&lt;b>Patient&lt;/b>&lt;/p>&lt;p>&lt;b>Replaced By&lt;/b>: Patient/1504028&lt;/p>&lt;p>&lt;b>Status&lt;/b>: Inactive&lt;/p>&lt;/div>"
       },
       "active": false,
       "link": [
         {
           "other": {
-            "reference": "Patient/4342008"
+            "reference": "Patient/1504028"
           },
           "type": "replace"
         }


### PR DESCRIPTION
Patient, Practitioner, and Related Person updates.
Added disclaimers to responses where data may not be the same in FHIRPLAY, and updated the combine example with valid combined patient.

Patient update:
<img width="709" alt="Screen Shot 2020-03-26 at 1 29 44 PM" src="https://user-images.githubusercontent.com/26021721/77683170-05a0e800-6f66-11ea-91e0-add816e59f9c.png">

Practitioner update: 
<img width="672" alt="Screen Shot 2020-03-26 at 1 30 03 PM" src="https://user-images.githubusercontent.com/26021721/77683346-3ed95800-6f66-11ea-972a-47c0590d88ab.png">

Related Person update:
<img width="657" alt="Screen Shot 2020-03-26 at 1 30 14 PM" src="https://user-images.githubusercontent.com/26021721/77683364-47319300-6f66-11ea-980e-eebfab33699b.png">

