### PR TITLE
Update Medications JSON inconsistencies

### DIFF
--- a/content/millennium/dstu2/medications/immunization.md
+++ b/content/millennium/dstu2/medications/immunization.md
@@ -74,6 +74,8 @@ Notes:
 <%= headers status: 200 %>
 <%= json(:dstu2_immunization_bundle) %>
 
+<%= disclaimer %>
+
 ### Errors
 
 The common [errors] and [OperationOutcomes] may be returned.
@@ -102,6 +104,8 @@ List an individual Immunization by its id:
 
 <%= headers status: 200 %>
 <%= json(:dstu2_immunization_1) %>
+
+<%= disclaimer %>
 
 ### Errors
 

--- a/content/millennium/dstu2/medications/medication-administration.md
+++ b/content/millennium/dstu2/medications/medication-administration.md
@@ -86,6 +86,8 @@ Notes:
 <%= headers status: 200 %>
 <%= json(:dstu2_medication_administration_bundle) %>
 
+<%= disclaimer %>
+
 ### Errors
 
 The common [errors] and [OperationOutcomes] may be returned.
@@ -118,6 +120,8 @@ _Implementation Notes_
 
 <%= headers status: 200 %>
 <%= json(:dstu2_medication_administration_entry) %>
+
+<%= disclaimer %>
 
 ### Errors
 

--- a/content/millennium/dstu2/medications/medication-order.md
+++ b/content/millennium/dstu2/medications/medication-order.md
@@ -105,6 +105,8 @@ Notes:
 <%= headers status: 200 %>
 <%= json(:dstu2_medication_order_bundle) %>
 
+<%= disclaimer %>
+
 ### Errors
 
 The common [errors] and [OperationOutcomes] may be returned.
@@ -133,6 +135,8 @@ List an individual MedicationOrder by its id:
 
 <%= headers status: 200 %>
 <%= json(:dstu2_medication_order_entry) %>
+
+<%= disclaimer %>
 
 ### Errors
 

--- a/content/millennium/dstu2/medications/medication-statement.md
+++ b/content/millennium/dstu2/medications/medication-statement.md
@@ -115,6 +115,8 @@ Notes:
 <%= headers status: 200 %>
 <%= json(:dstu2_medication_statement_bundle) %>
 
+<%= disclaimer %>
+
 ### Errors
 
 The common [errors] and [OperationOutcomes] may be returned.
@@ -148,6 +150,8 @@ _Implementation Notes_
 
 <%= headers status: 200 %>
 <%= json(:dstu2_medication_statement_entry) %>
+
+<%= disclaimer %>
 
 ### Errors
 
@@ -223,6 +227,8 @@ _Implementation Notes_
 
 The `ETag` response header indicates the current `If-Match` version to use on subsequent updates.
 
+<%= disclaimer %>
+
 ### Errors
 
 The common [errors] and [OperationOutcomes] may be returned.
@@ -255,7 +261,7 @@ _Implementation Notes_
 
 #### Request
 
-    PUT https://fhir-ehr.sandboxcerner.com/dstu2/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/MedicationStatement/222
+    PUT https://fhir-ehr.sandboxcerner.com/dstu2/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/MedicationStatement/28953901
 
 #### Body
 
@@ -290,6 +296,8 @@ _Implementation Notes_
 </pre>
 
 The `ETag` response header indicates the current `If-Match` version to use on subsequent updates.
+
+<%= disclaimer %>
 
 ### Errors
 

--- a/lib/resources/example_json/dstu2_examples_medication_statement.rb
+++ b/lib/resources/example_json/dstu2_examples_medication_statement.rb
@@ -602,7 +602,7 @@ module Cerner
         }
       ],
       "patient": {
-        "reference":"Patient/234"
+        "reference":"Patient/1316024"
       },
       "status":"active",
       "medicationReference":{
@@ -635,7 +635,7 @@ module Cerner
 
     DSTU2_MEDICATION_STATEMENT_UPDATE ||= {
       "resourceType": "MedicationStatement",
-      "id": "222",
+      "id": "28953901",
       "contained":
       [
         {
@@ -648,12 +648,12 @@ module Cerner
       ],
       "status": "completed",
       "patient": {
-        "reference": "Patient/234"
+        "reference": "Patient/1316024"
       },
       "medicationReference": {
         "reference": "#123"
       }
     }
-        
+
   end
 end


### PR DESCRIPTION
I went through the DSTU2 Medications section and fixed some inconsistencies with the JSON.

**MedicationStatement**:
The current create example does not work so I updated the Patient to one that exists, so that it does.
EX:
<img width="1680" alt="medCreate" src="https://user-images.githubusercontent.com/18541545/77688546-400e8300-6f6e-11ea-8157-e1583661a88c.png">

The Update throws a 404, so I updated it to use a currently existing MedicationStatement and Patient. This call will not succeed since it has already been updated to complete, but now that it is tied to an existing MedicationStatement a user can read that resource to see its status.
EX:
<img width="1679" alt="medUpdate" src="https://user-images.githubusercontent.com/18541545/77689054-0be79200-6f6f-11ea-991f-13f449d90fdd.png">

**All**:
I also went through and added the disclaimer to all the Medications response examples.
EX:
<img width="1680" alt="medDisclaimer" src="https://user-images.githubusercontent.com/18541545/77689123-26ba0680-6f6f-11ea-85fe-43260580c858.png">

