### PR TITLE
Add disclaimers to Diagnostic JSON examples

### DIFF
--- a/content/millennium/dstu2/diagnostic/diagnostic-report.md
+++ b/content/millennium/dstu2/diagnostic/diagnostic-report.md
@@ -76,6 +76,8 @@ information, see the [Binary accept] documentation.
 <%= headers status: 200 %>
 <%= json(:dstu2_diagnostic_report_bundle) %>
 
+<%= disclaimer %>
+
 ### Errors
 
 The common [errors] and [OperationOutcomes] may be returned.

--- a/content/millennium/dstu2/diagnostic/observation.md
+++ b/content/millennium/dstu2/diagnostic/observation.md
@@ -97,6 +97,8 @@ Notes:
 <%= headers status: 200 %>
 <%= json(:dstu2_observation_bundle) %>
 
+<%= disclaimer %>
+
 ### Errors
 
 The common [errors] and [OperationOutcomes] may be returned.


### PR DESCRIPTION
I checked both Diagnostic resources for any major JSON inconsistencies, but I found none. I then added the disclaimer after their example responses.
<img width="1680" alt="Screen Shot 2020-03-27 at 12 52 36 PM" src="https://user-images.githubusercontent.com/18541545/77933130-14dcaa00-7274-11ea-8758-5508f57be381.png">
 