### PR TITLE
Updated r4 Documentation for Observation to include Identifier and Performer

### DIFF
--- a/content/millennium/r4/diagnostic/observation.md
+++ b/content/millennium/r4/diagnostic/observation.md
@@ -13,6 +13,7 @@ The Observation resource provides measurements or simple assertions about a pati
 The following fields are returned if valued:
 
 * [Id](https://hl7.org/fhir/R4/resource-definitions.html#Resource.id){:target="_blank"}
+* [Identifier](https://hl7.org/fhir/R4/observation-definitions.html#Observation.identifier){:target="_blank"}
 * [Status](https://hl7.org/fhir/R4/observation-definitions.html#Observation.status){:target="_blank"}
 * [Category (laboratory, social history)](https://hl7.org/fhir/R4/observation-definitions.html#Observation.category){:target="_blank"}
 * [Code (Observation name or text)](https://hl7.org/fhir/R4/observation-definitions.html#Observation.code){:target="_blank"}
@@ -21,6 +22,7 @@ The following fields are returned if valued:
 * [Effective date/time (collection date/time for laboratory)](https://hl7.org/fhir/R4/observation-definitions.html#Observation.effective_x_){:target="_blank"}
 * [Extensions](#extensions){:target="_blank"}
 * [Issued (date/time observation made available, entered, verified)](https://hl7.org/fhir/R4/observation-definitions.html#Observation.issued){:target="_blank"}
+* [Performer](http://hl7.org/fhir/R4/observation-definitions.html#Observation.performer){:target="_blank"}
 * [Observation value or result](https://hl7.org/fhir/R4/observation-definitions.html#Observation.value_x_){:target="_blank"}
 * For Observations with `valueQuantity`
     * [Quantity comparator (<, <=, >, >=)](https://hl7.org/fhir/R4/datatypes-definitions.html#Quantity.comparator){:target="_blank"}

--- a/lib/resources/example_json/r4_examples_observation.rb
+++ b/lib/resources/example_json/r4_examples_observation.rb
@@ -419,6 +419,12 @@ module Cerner
                           "status": "generated",
                           "div": "&lt;div xmlns=\"http://www.w3.org/1999/xhtml\">&lt;p>&lt;b>Observation&lt;/b>&lt;/p>&lt;p>&lt;b>Patient Id&lt;/b>: 3998008&lt;/p>&lt;p>&lt;b>Status&lt;/b>: Final&lt;/p>&lt;p>&lt;b>Categories&lt;/b>: Vital Signs&lt;/p>&lt;p>&lt;b>Code&lt;/b>: Temperature Oral&lt;/p>&lt;p>&lt;b>Result&lt;/b>: 37 DegC&lt;/p>&lt;p>&lt;b>Interpretation&lt;/b>: Normal&lt;/p>&lt;p>&lt;b>Effective Date&lt;/b>: Sep 12, 2017  5:00 P.M. UTC&lt;/p>&lt;p>&lt;b>Reference Range&lt;/b>: 34.00-37.40 DegC&lt;/p>&lt;/div>"
                       },
+                      "identifier": [
+                        {
+                          "system": "https://fhir.cerner.com/ceuuid",
+                          "value": "CEfda49233-ccfa-4ed4-afbc-9f5082c2bf0c-17003791-2020030912450100"
+                        }
+                      ],
                       "status": "final",
                       "category": [
                           {
@@ -459,6 +465,11 @@ module Cerner
                       },
                       "effectiveDateTime": "2017-09-12T17:00:00.000Z",
                       "issued": "2017-09-12T17:00:48.000Z",
+                      "performer": [
+                        {
+                          "reference": "Practitioner/1994021"
+                        }
+                      ],
                       "valueQuantity": {
                           "value": 37,
                           "unit": "DegC",


### PR DESCRIPTION
Documentation for r4 Observation will be updated to include the fields Identifier and Performer.

Local verification:
![r4ObservationSearch_fhircernercom](https://user-images.githubusercontent.com/32961841/78294186-870cf300-74ef-11ea-9d04-1c6c403d0ba2.png)
