### PR TITLE
Add DSTU2 Person/Patient Disclaimers

### DIFF
--- a/content/millennium/dstu2/entities/person.md
+++ b/content/millennium/dstu2/entities/person.md
@@ -62,6 +62,8 @@ Notes:
 <%= headers status: 200 %>
 <%= json(:dstu2_person_bundle) %>
 
+<%= disclaimer %>
+
 ### Errors
 
 The common [errors] and [OperationOutcomes] may be returned.

--- a/content/millennium/dstu2/individuals/patient.md
+++ b/content/millennium/dstu2/individuals/patient.md
@@ -228,6 +228,8 @@ Notes:
 
 The `ETag` response header indicates the current `If-Match` version to use on subsequent updates.
 
+<%= disclaimer %>
+
 ### Errors
 
 The common [errors] and [OperationOutcomes] may be returned.


### PR DESCRIPTION
Description
There were a couple of missing disclaimers that needed to be added to the docs.

PR Checklist
----
- [x] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.


Before Changes Merged: 

Patient Disclaimer
<img width="691" alt="Screen Shot 2020-04-08 at 9 07 11 AM" src="https://user-images.githubusercontent.com/26021721/78794086-e39d6180-7978-11ea-91e8-1ae0c36fbbec.png">

Person Disclaimer
<img width="694" alt="Screen Shot 2020-04-08 at 9 07 41 AM" src="https://user-images.githubusercontent.com/26021721/78794139-f57f0480-7978-11ea-8c9a-08ff486487ea.png">


