### PR TITLE
Add R4 Encounter sorting details, update Pagination with previous link

### DIFF
--- a/content/millennium/dstu2.md
+++ b/content/millennium/dstu2.md
@@ -511,7 +511,7 @@ Please reference the <a href="/authorization/">authorization</a> documentation f
 
 ## Pagination
 
-The pagination links are included in the Bundle when a resource returns multiple items. It is important to
+The pagination links are included in the Bundle when a resource returns more items than the Bundle page size. It is important to
 follow these Link header values instead of constructing your own URLs.
 
     {
@@ -533,6 +533,7 @@ The possible `relation` values are:
 --------|------------------------------------------------------
  `self` | Shows the URL of the current page of results.
  `next` | Shows the URL of the immediate next page of results.
+ `previous` | If paging, shows the URL of the previous page of results.
 
 
 ### Concurrency

--- a/content/millennium/dstu2.md
+++ b/content/millennium/dstu2.md
@@ -529,10 +529,10 @@ follow these Link header values instead of constructing your own URLs.
 
 The possible `relation` values are:
 
- Name   | Description
---------|------------------------------------------------------
- `self` | Shows the URL of the current page of results.
- `next` | Shows the URL of the immediate next page of results.
+ Name       | Description
+------------|------------------------------------------------------
+ `self`     | Shows the URL of the current page of results.
+ `next`     | Shows the URL of the immediate next page of results.
  `previous` | If paging, shows the URL of the previous page of results.
 
 

--- a/content/millennium/r4.md
+++ b/content/millennium/r4.md
@@ -524,10 +524,10 @@ The pagination links are included in the Bundle when a resource returns more ite
 
 The possible `relation` values are:
 
- Name   | Description
---------|------------------------------------------------------
- `self` | Shows the URL of the current page of results.
- `next` | Shows the URL of the immediate next page of results.
+ Name       | Description
+------------|------------------------------------------------------
+ `self`     | Shows the URL of the current page of results.
+ `next`     | Shows the URL of the immediate next page of results.
  `previous` | If paging, shows the URL of the previous page of results.
 
 ### Concurrency

--- a/content/millennium/r4.md
+++ b/content/millennium/r4.md
@@ -503,7 +503,7 @@ Please reference the <a href="/authorization/">authorization</a> documentation f
 
 ## Pagination
 
-The pagination links are included in the Bundle when a resource returns multiple items. It is important to follow these Link header values instead of constructing your own URLs.
+The pagination links are included in the Bundle when a resource returns more items than the Bundle page size. It is important to follow these Link header values instead of constructing your own URLs.
 
     {
       "resourceType": "Bundle",
@@ -528,6 +528,7 @@ The possible `relation` values are:
 --------|------------------------------------------------------
  `self` | Shows the URL of the current page of results.
  `next` | Shows the URL of the immediate next page of results.
+ `previous` | If paging, shows the URL of the previous page of results.
 
 ### Concurrency
 

--- a/content/millennium/r4/encounters/encounter.md
+++ b/content/millennium/r4/encounters/encounter.md
@@ -56,7 +56,7 @@ _Implementation Notes_
 
 * The [Encounter.hospitalization.destination] will be returned as a reference to a [contained] location resource.
 * The [Encounter.location.location] may be returned as a reference to a [contained] location resource.
-* A populated Encounter response bundle will be sorted based on the start of the [Encounter.period].
+* A populated Encounter response bundle will be sorted from newest to oldest based on the start of the [Encounter.period].
 
 ### Authorization Types
 

--- a/content/millennium/r4/encounters/encounter.md
+++ b/content/millennium/r4/encounters/encounter.md
@@ -56,6 +56,7 @@ _Implementation Notes_
 
 * The [Encounter.hospitalization.destination] will be returned as a reference to a [contained] location resource.
 * The [Encounter.location.location] may be returned as a reference to a [contained] location resource.
+* A populated Encounter response bundle will be sorted based on the [Encounter.period].
 
 ### Authorization Types
 
@@ -236,6 +237,7 @@ The common [errors] and [OperationOutcomes] may be returned.
 [contained]: https://hl7.org/fhir/r4/references.html#contained
 [Encounter.hospitalization.destination]: https://hl7.org/fhir/r4/encounter-definitions.html#Encounter.hospitalization.destination
 [Encounter.location.location]: https://hl7.org/fhir/r4/encounter-definitions.html#Encounter.location.location
+[Encounter.period]: https://hl7.org/fhir/r4/encounter-definitions.html#Encounter.period
 [`reference`]: https://hl7.org/fhir/r4/search.html#reference
 [`token`]: https://hl7.org/fhir/r4/search.html#token
 [`number`]: https://hl7.org/fhir/r4/search.html#number

--- a/content/millennium/r4/encounters/encounter.md
+++ b/content/millennium/r4/encounters/encounter.md
@@ -56,7 +56,7 @@ _Implementation Notes_
 
 * The [Encounter.hospitalization.destination] will be returned as a reference to a [contained] location resource.
 * The [Encounter.location.location] may be returned as a reference to a [contained] location resource.
-* A populated Encounter response bundle will be sorted based on the [Encounter.period].
+* A populated Encounter response bundle will be sorted based on the start of the [Encounter.period].
 
 ### Authorization Types
 

--- a/content/soarian/dstu2.md
+++ b/content/soarian/dstu2.md
@@ -124,7 +124,7 @@ ID                                | Value\[x] Type      | Description
 
 ## Pagination
 
-The pagination [links](#secure-sandbox) are included in the Bundle when a resource returns multiple items. It is important to follow these Link header values instead of constructing your own URLs.
+The pagination [links](#secure-sandbox) are included in the Bundle when a resource returns more items than the Bundle page size. It is important to follow these Link header values instead of constructing your own URLs.
 
 <%= json(:SOARIAN_FHIR_LINK) %>
 
@@ -134,6 +134,7 @@ Name                                                 | Description
 -----------------------------------------------------|-----------------------------------------------------
 `self`                                               | Shows the URL of the current page of results.
 `next`                                               | Shows the URL of the immediate next page of results.
+`previous`                                           | If paging, shows the URL of the previous page of results.
 
 
 ## Common Errors

--- a/lib/resources.rb
+++ b/lib/resources.rb
@@ -142,9 +142,9 @@ module Cerner
 
       def data_currency
         "Developers need to account for data concurrency within the response. The FHIR specification states:\n\n"\
-        '> The results of a search operation are only guaranteed to be current at the moment the operation is'\
-        'executed. After the operation is executed, ongoing actions performed on the resources against which the'\
-        'search was executed will render the results increasingly stale. The significance of this depends on the'\
+        '> The results of a search operation are only guaranteed to be current at the moment the operation is '\
+        'executed. After the operation is executed, ongoing actions performed on the resources against which the '\
+        'search was executed will render the results increasingly stale. The significance of this depends on the '\
         "nature of the search, and the kind of use that is being made of the results.\n\n"\
         '> This is particularly relevant when the server is returning the results in a series of pages. '\
         'It is at the discretion of the search engine of how to handle ongoing updates to the resources '\
@@ -155,7 +155,7 @@ module Cerner
         'the data thus impacting clinical decision support and patient safety.'
       end
 
-      def disclaimer()
+      def disclaimer
         %(<p>Note: The examples provided here are non-normative and replaying them in the public sandbox is not guaranteed to yield the results shown on the site.</p>\n)
       end
     end


### PR DESCRIPTION
Description
----

- Document that R4 Encounter Bundles are sorted by the Encounter.period
- Update Bundle Page links to include the Previous link

PR Checklist
----
- [x] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.
