### PR TITLE
Clarified state of MedRequest intent.

### DIFF
--- a/content/millennium/r4/medications/medication-request.md
+++ b/content/millennium/r4/medications/medication-request.md
@@ -19,6 +19,9 @@ The following fields are returned if valued:
 * [Status](https://hl7.org/fhir/r4/medicationrequest-definitions.html#MedicationRequest.status){:target="_blank"}
 * [Status Reason](https://hl7.org/fhir/r4/medicationrequest-definitions.html#MedicationRequest.statusReason){:target="_blank"}
 * [Intent](https://hl7.org/fhir/r4/medicationrequest-definitions.html#MedicationRequest.intent){:target="_blank"}
+
+NOTE: For reads and searches we are currently always returning a value of "Order" in the intent field. We recommend using the reported field to determine if a medication is an authorization or a medication reported by a patient. In the future, we will support "Plan" and "Order" in accordance with the US Core Profile pending changes.
+
 * [Category](https://hl7.org/fhir/r4/medicationrequest-definitions.html#MedicationRequest.category){:target="_blank"}
 * [Priority](https://hl7.org/fhir/r4/medicationrequest-definitions.html#MedicationRequest.priority){:target="_blank"}
 * [Reported Boolean](https://hl7.org/fhir/r4/medicationrequest-definitions.html#MedicationRequest.reported_x_){:target="_blank"}

--- a/content/millennium/r4/medications/medication-request.md
+++ b/content/millennium/r4/medications/medication-request.md
@@ -19,9 +19,7 @@ The following fields are returned if valued:
 * [Status](https://hl7.org/fhir/r4/medicationrequest-definitions.html#MedicationRequest.status){:target="_blank"}
 * [Status Reason](https://hl7.org/fhir/r4/medicationrequest-definitions.html#MedicationRequest.statusReason){:target="_blank"}
 * [Intent](https://hl7.org/fhir/r4/medicationrequest-definitions.html#MedicationRequest.intent){:target="_blank"}
-
-NOTE: For reads and searches we are currently always returning a value of "Order" in the intent field. We recommend using the reported field to determine if a medication is an authorization or a medication reported by a patient. In the future, we will support "Plan" and "Order" in accordance with the US Core Profile pending changes.
-
+    * Details in Implementation Notes sections for reads and searches.
 * [Category](https://hl7.org/fhir/r4/medicationrequest-definitions.html#MedicationRequest.category){:target="_blank"}
 * [Priority](https://hl7.org/fhir/r4/medicationrequest-definitions.html#MedicationRequest.priority){:target="_blank"}
 * [Reported Boolean](https://hl7.org/fhir/r4/medicationrequest-definitions.html#MedicationRequest.reported_x_){:target="_blank"}
@@ -66,6 +64,10 @@ Search for MedicationRequests that meet supplied query parameters:
 
     GET /MedicationRequest?:parameters
 
+_Implementation Notes_
+
+We are currently always returning a value of "Order" in the intent field. We recommend using the reported field to determine if a medication is an authorization or a medication reported by a patient. In the future, we will support "Plan" and "Order" in accordance with the US Core Profile pending changes.
+
 ### Authorization Types
 
 <%= authorization_types(practitioner: true, patient: false, system: true) %>
@@ -109,6 +111,10 @@ The common [errors] and [OperationOutcomes] may be returned.
 List an individual MedicationRequest by its id:
 
     GET /MedicationRequest/:id
+
+_Implementation Notes_
+
+We are currently always returning a value of "Order" in the intent field. We recommend using the reported field to determine if a medication is an authorization or a medication reported by a patient. In the future, we will support "Plan" and "Order" in accordance with the US Core Profile pending changes.
 
 ### Authorization Types
 


### PR DESCRIPTION
Description
----
This PR adds clarification stating that we are currently hard-coding MedicationRequest intents to "ORDER" on reads and searches, and to use the reported field to determine if a medication is a authorized or a request by a patient.
I wasn't 100% sure where we wanted this information, so I added it as a note under the field in the Overview section. Let me know if we want this worded or laid out differently (like adding it to both the read and search sections separately or something).

![image](https://user-images.githubusercontent.com/57365731/83794655-edcf9980-a663-11ea-8f0c-1fb1a00c0b7f.png)


PR Checklist
----
- [x] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.
