### PR TITLE
Remove duplicated fullUrl and resource keys from AllergyIntolerance search JSON example. Fixes #401

### DIFF
--- a/lib/resources/example_json/r4_examples_allergy_intolerance.rb
+++ b/lib/resources/example_json/r4_examples_allergy_intolerance.rb
@@ -131,8 +131,7 @@ module Cerner
         }
       ],
       "entry": [
-        "fullUrl": "https://fhir-open.sandboxcerner.com/r4/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/AllergyIntolerance/983733",
-        "resource": R4_ALLERGY_INTOLERANCE_ENTRY
+        R4_ALLERGY_INTOLERANCE_ENTRY
       ]
     }
 


### PR DESCRIPTION
Description
----
Remove a couple duplicated JSON keys

PR Checklist
----
- [x] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.
