### PR TITLE
Added required field for reasonCode. Fixes #404

### DIFF
--- a/lib/resources/r4/appointment.yaml
+++ b/lib/resources/r4/appointment.yaml
@@ -65,6 +65,7 @@ fields:
       info_link: https://fhir.cerner.com/millennium/r4/proprietary-codes-and-systems/#code-set-14249-scheduling-appointment-type-synonyms
 
 - name: reasonCode
+  required: 'No'
   type: List of CodeableConcept
   description: Coded reason this appointment is scheduled.
   action:


### PR DESCRIPTION
Description
----
Added the missing `required` field for reasonCode in appointment.yaml

![Screen Shot 2020-06-23 at 5 29 26 PM](https://user-images.githubusercontent.com/28937462/85472239-30a3d380-b577-11ea-991f-636eeecdc725.png)

PR Checklist
----
- [x] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.
