### PR TITLE
R4 Account search clarification

### DIFF
--- a/content/millennium/r4/financial/account.md
+++ b/content/millennium/r4/financial/account.md
@@ -88,7 +88,7 @@ Notes:
   * `_id` alone
   * `patient`, `identifier`, and `type` set to 'statement'
   * `-guarantor` and `type` set to 'financial-account'
-* When searching via `identifier`, the system must be 'https://fhir.cerner.com/<EHR source id>/codeSet/28200'. You may not search via `identifier` with a system of 'https://fhir.cerner.com/accountnumber'.
+* When searching via `identifier`, the system must be 'https://fhir.cerner.com/&lt;EHR source id&gt;/codeSet/28200'. You may not search via `identifier` with a system of 'https://fhir.cerner.com/accountnumber'.
 * The `-guarantor` search parameter should contain a reference to a RelatedPerson when set.
 
 ### Headers

--- a/content/millennium/r4/financial/account.md
+++ b/content/millennium/r4/financial/account.md
@@ -86,8 +86,9 @@ Notes:
 
 * You may search via:
   * `_id` alone
-  * `patient`, `identifier` system set to codeSet 28200, and `type` set to 'statement'.
-  * `-guarantor` and `type` set to 'financial-account'.
+  * `patient`, `identifier`, and `type` set to 'statement'
+  * `-guarantor` and `type` set to 'financial-account'
+* When searching via `identifier`, the system must be 'https://fhir.cerner.com/<EHR source id>/codeSet/28200'. You may not search via `identifier` with a system of 'https://fhir.cerner.com/accountnumber'.
 * The `-guarantor` search parameter should contain a reference to a RelatedPerson when set.
 
 ### Headers

--- a/content/millennium/r4/financial/account.md
+++ b/content/millennium/r4/financial/account.md
@@ -86,7 +86,7 @@ Notes:
 
 * You may search via:
   * `_id` alone
-  * `patient`, `identifier`, and `type` set to 'statement'.
+  * `patient`, `identifier` system set to codeSet 28200, and `type` set to 'statement'.
   * `-guarantor` and `type` set to 'financial-account'.
 * The `-guarantor` search parameter should contain a reference to a RelatedPerson when set.
 


### PR DESCRIPTION
Description
----
Account search by patient with type 'statement' requires the identifier to have system codeSet 28200. Currently, is not clear that system 'https://fhir.cerner.com/accountnumber' cannot be used when type is 'statement'.

Account search by patient with type 'financial-account' is not currently supported

Validation
---
<img width="687" alt="Screen Shot 2020-06-24 at 12 15 48 PM" src="https://user-images.githubusercontent.com/56039503/85601980-837f9880-b614-11ea-90a6-8a9e4781b476.png">

PR Checklist
----
- [x] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.
