### PR TITLE
Updated patient resource to reflect string field character limit

### DIFF
--- a/lib/resources/r4/patient.yaml
+++ b/lib/resources/r4/patient.yaml
@@ -209,6 +209,7 @@ fields:
       <li> Up to two `given` names may be provided. If additional given names are required they must be provided in the second value as a single string separated by blank spaces. </li>
       <li> Only one `prefix` and one `suffix` may be provided. </li>
       <li> When specifying a `period`, the fields must include a time component with a timezone. </li>
+      <li> `family`, `given`, `prefix`, and `suffix` have a character limit of 100. </li> 
     </ul>
   url: http://hl7.org/fhir/R4/patient-definitions.html#Patient.name
 
@@ -234,6 +235,7 @@ fields:
     <ul>
       <li> Each telecom must contain the `system`, `use`, and `value` fields. </li>
       <li> When specifying a `period`, the fields must include a time component with a timezone. </li>
+      <li> `value` has a character limit of 100. </li>
     </ul>
   url: http://hl7.org/fhir/R4/patient-definitions.html#Patient.telecom
 
@@ -289,6 +291,8 @@ fields:
       <li> Each address must contain the `use` field. </li>
       <li> Each address must not contain the `text` field. </li>
       <li> When specifying a `period`, the fields must include a time component with a timezone. </li>
+      <li> `line`, `city`, `district`, `state`, and `country` have a character limit of 100. </li>
+      <li> `postalCode` has a character limit of 25. </li>
     </ul>
   url: http://hl7.org/fhir/R4/patient-definitions.html#Patient.address
 

--- a/lib/resources/r4/patient.yaml
+++ b/lib/resources/r4/patient.yaml
@@ -137,16 +137,16 @@ fields:
     }
   note: |
     <ul>
-      <li> At least one identifier <b>must</b> be provided. The provided identifier must meet the following conditions:
+      <li>At least one identifier <b>must</b> be provided. The provided identifier must meet the following conditions:
         <ul>
-          <li> Must contain only an `assigner` field with a reference to the Organization in which the patient is being enrolled. </li>
+          <li>Must contain only an `assigner` field with a reference to the Organization in which the patient is being enrolled.</li>
         </ul>
       </li>
-      <li> Subsequent identifiers may be provided, but have the following constraints:
+      <li>Subsequent identifiers may be provided, but have the following constraints:
         <ul>
-          <li> Must not contain the `assigner` and `use` fields. </li>
-          <li> Must contain the `type`, `system`, and `value` fields. </li>
-          <li> When specifying a `period`, must include a time component with a timezone. </li>
+          <li>Must not contain the `assigner` and `use` fields.</li>
+          <li>Must contain the `type`, `system`, and `value` fields.</li>
+          <li>When specifying a `period`, must include a time component with a timezone.</li>
         </ul>
       </li>
     </ul>
@@ -196,20 +196,21 @@ fields:
     }
   note: |
     <ul>
-      <li> At least one name <b>must</b> be provided. The provided name must meet the following conditions:
+      <li>At least one name <b>must</b> be provided. The provided name must meet the following conditions:
         <ul>
-          <li> Must have a `use` of 'official'. </li>
-          <li> Must not have an `end` date on `period`, or must not include `period`. </li>
-          <li> Must include both `given` and `family`. </li>
+          <li>Must have a `use` of 'official'.</li>
+          <li>Must not have an `end` date on `period`, or must not include `period`.</li>
+          <li>Must include both `given` and `family`.</li>
         </ul>
       </li>
-      <li> Each name must include the `use` field. </li>
-      <li> Each name must contain either the `given` or `family` fields. </li>
-      <li> Each name cannot contain the `text` field. </li>
-      <li> Up to two `given` names may be provided. If additional given names are required they must be provided in the second value as a single string separated by blank spaces. </li>
-      <li> Only one `prefix` and one `suffix` may be provided. </li>
-      <li> When specifying a `period`, the fields must include a time component with a timezone. </li>
-      <li> `family`, `given`, `prefix`, and `suffix` have a character limit of 100. </li> 
+      <li>Each name must include the `use` field.</li>
+      <li>Each name must contain either the `given` or `family` fields.</li>
+      <li>Each name cannot contain the `text` field.</li>
+      <li>Up to two `given` names may be provided. If additional given names are required they must be provided in the second value as a single string separated by blank spaces.</li>
+      <li>Only one `prefix` and one `suffix` may be provided.</li>
+      <li>When specifying a `period`, the fields must include a time component with a timezone.</li>
+      <li>The `family` field has a character limit of 100.</li> 
+      <li>Each value for the `given`, `prefix`, and `suffix` fields has a character limit of 100.</li>
     </ul>
   url: http://hl7.org/fhir/R4/patient-definitions.html#Patient.name
 
@@ -233,9 +234,9 @@ fields:
     }
   note: |
     <ul>
-      <li> Each telecom must contain the `system`, `use`, and `value` fields. </li>
-      <li> When specifying a `period`, the fields must include a time component with a timezone. </li>
-      <li> `value` has a character limit of 100. </li>
+      <li>Each telecom must contain the `system`, `use`, and `value` fields.</li>
+      <li>When specifying a `period`, the fields must include a time component with a timezone.</li>
+      <li>The `value` field has a character limit of 100.</li>
     </ul>
   url: http://hl7.org/fhir/R4/patient-definitions.html#Patient.telecom
 
@@ -288,11 +289,12 @@ fields:
     }
   note: |
     <ul>
-      <li> Each address must contain the `use` field. </li>
-      <li> Each address must not contain the `text` field. </li>
-      <li> When specifying a `period`, the fields must include a time component with a timezone. </li>
-      <li> `line`, `city`, `district`, `state`, and `country` have a character limit of 100. </li>
-      <li> `postalCode` has a character limit of 25. </li>
+      <li>Each address must contain the `use` field.</li>
+      <li>Each address must not contain the `text` field.</li>
+      <li>When specifying a `period`, the fields must include a time component with a timezone.</li>
+      <li>Each value for the `line` field has a character limit of 100.</li>
+      <li>The `city`, `district`, `state`, and `country` fields have a character limit of 100.</li>
+      <li>The `postalCode` field has a character limit of 25.</li>
     </ul>
   url: http://hl7.org/fhir/R4/patient-definitions.html#Patient.address
 


### PR DESCRIPTION
Description
----
The R4 documentation for Patient was updated to reflect the character limits for its string fields.

Validation
----
The following changes are present on the body-fields table of Create section:
a) Patient.name character limits on family, given, prefix, and suffix
<img width="636" alt="Screen Shot 2020-07-01 at 8 46 42 AM" src="https://user-images.githubusercontent.com/18171913/86251377-6ea48700-bb77-11ea-9ea0-8fadf9d367f0.png">

b) Patient.telecom character limit on value
<img width="632" alt="Patient telecom string limits" src="https://user-images.githubusercontent.com/18171913/86251229-38670780-bb77-11ea-9a72-c6021297c33f.png">

c) Patient.address character limits on line, city, district, state, postalCode, and country
<img width="624" alt="Patient address string limits" src="https://user-images.githubusercontent.com/18171913/86251251-3dc45200-bb77-11ea-8976-c8f293d71896.png">

UPDATE: See https://github.com/cerner/fhir.cerner.com/pull/414#issuecomment-652500157 for updated screenshots.

PR Checklist
----
- [x] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.
