### PR TITLE
Remove non-purposefully added response headers, standardize response header formatting

### DIFF
--- a/content/millennium/dstu2.md
+++ b/content/millennium/dstu2.md
@@ -20,10 +20,8 @@ Date: Tue, 05 Jan 2016 20:02:23 GMT
 cache-control: no-cache
 vary: Origin,User-Agent
 strict-transport-security: max-age=631152000
-server-response-time: 6003.4422970000005
 x-xss-protection: 1; mode=block
 x-request-id: 637dd651-6943-4d45-8e8a-0577da7640a2
-x-runtime: 6.003411
 x-frame-options: SAMEORIGIN
 x-content-type-options: nosniff
 Status: 200 OK

--- a/content/millennium/dstu2.md
+++ b/content/millennium/dstu2.md
@@ -24,7 +24,6 @@ x-xss-protection: 1; mode=block
 x-request-id: 637dd651-6943-4d45-8e8a-0577da7640a2
 x-frame-options: SAMEORIGIN
 x-content-type-options: nosniff
-Status: 200 OK
 Content-Type: application/json+fhir; charset=utf-8
 Transfer-Encoding: chunked
 

--- a/content/millennium/dstu2/general-clinical/allergy-intolerance.md
+++ b/content/millennium/dstu2/general-clinical/allergy-intolerance.md
@@ -163,24 +163,22 @@ Create new allergies.
 
 <%= headers status: 201 %>
 <pre class="terminal">
-    Date → Tue, 28 Feb 2017 21:08:20 GMT
-    Cache-Control → no-cache
-    Vary → Origin,User-Agent,Accept-Encoding
-    Strict-Transport-Security → max-age=631152000
-    Server-Response-Time → 10023.126891
-    X-Xss-Protection → 1; mode=block
-    Pragma → no-cache
-    X-Request-Id → b0fee21c20d2a240d9b4b86cfbcbd87c
-    Etag → W/"6167733"
-    X-Frame-Options → SAMEORIGIN
-    X-Runtime → 10.023081
-    X-Content-Type-Options → nosniff
-    Expires → Mon, 01 Jan 1990 00:00:00 GMT
-    Last-Modified → Tue, 28 Feb 2017 21:03:00 GMT
-    Location → https://fhir-ehr-code.cerner.com/dstu2/ec2458f2-1e24-41c8-b71b-0e701af7583d/AllergyIntolerance/6167733
-    Status → 201 Created
-    Content-Length → 0
-    Content-Type → application/json
+Date: Tue, 28 Feb 2017 21:08:20 GMT
+Cache-Control: no-cache
+Vary: Origin,User-Agent,Accept-Encoding
+Strict-Transport-Security: max-age=631152000
+X-Xss-Protection: 1; mode=block
+Pragma: no-cache
+X-Request-Id: b0fee21c20d2a240d9b4b86cfbcbd87c
+Etag: W/"6167733"
+X-Frame-Options: SAMEORIGIN
+X-Content-Type-Options: nosniff
+Expires: Mon, 01 Jan 1990 00:00:00 GMT
+Last-Modified: Tue, 28 Feb 2017 21:03:00 GMT
+Location: https://fhir-ehr-code.cerner.com/dstu2/ec2458f2-1e24-41c8-b71b-0e701af7583d/AllergyIntolerance/6167733
+Status: 201 Created
+Content-Length: 0
+Content-Type: application/json
 </pre>
 
 The `ETag` response header indicates the current `If-Match` version to use on subsequent updates.
@@ -231,23 +229,21 @@ Notes:
 
 <%= headers status: 200 %>
 <pre class="terminal">
-    Date →  Tue, 28 Feb 2017 21:19:18 GMT
-    Cache-Control →  no-cache
-    Vary →  Origin,User-Agent,Accept-Encoding
-    Strict-Transport-Security →  max-age=631152000
-    Server-Response-Time →  647.014821
-    X-Xss-Protection →  1; mode=block
-    Pragma →  no-cache
-    X-Request-Id →  d30766e5445f973b32efa9ec516cb5db
-    Etag →  W/"6167741"
-    X-Frame-Options →  SAMEORIGIN
-    X-Runtime →  0.646992
-    X-Content-Type-Options →  nosniff
-    Expires →  Mon, 01 Jan 1990 00:00:00 GMT
-    Last-Modified →  Tue, 28 Feb 2017 21:03:00 GMT
-    Status →  200 OK
-    Content-Length →  0
-    Content-Type →  application/json
+Date:  Tue, 28 Feb 2017 21:19:18 GMT
+Cache-Control:  no-cache
+Vary:  Origin,User-Agent,Accept-Encoding
+Strict-Transport-Security:  max-age=631152000
+X-Xss-Protection:  1; mode=block
+Pragma:  no-cache
+X-Request-Id:  d30766e5445f973b32efa9ec516cb5db
+Etag:  W/"6167741"
+X-Frame-Options:  SAMEORIGIN
+X-Content-Type-Options:  nosniff
+Expires:  Mon, 01 Jan 1990 00:00:00 GMT
+Last-Modified:  Tue, 28 Feb 2017 21:03:00 GMT
+Status:  200 OK
+Content-Length:  0
+Content-Type:  application/json
 </pre>
 
 The `ETag` response header indicates the current `If-Match` version to use on subsequent updates.

--- a/content/millennium/dstu2/general-clinical/allergy-intolerance.md
+++ b/content/millennium/dstu2/general-clinical/allergy-intolerance.md
@@ -176,7 +176,6 @@ X-Content-Type-Options: nosniff
 Expires: Mon, 01 Jan 1990 00:00:00 GMT
 Last-Modified: Tue, 28 Feb 2017 21:03:00 GMT
 Location: https://fhir-ehr-code.cerner.com/dstu2/ec2458f2-1e24-41c8-b71b-0e701af7583d/AllergyIntolerance/6167733
-Status: 201 Created
 Content-Length: 0
 Content-Type: application/json
 </pre>
@@ -229,21 +228,20 @@ Notes:
 
 <%= headers status: 200 %>
 <pre class="terminal">
-Date:  Tue, 28 Feb 2017 21:19:18 GMT
-Cache-Control:  no-cache
-Vary:  Origin,User-Agent,Accept-Encoding
-Strict-Transport-Security:  max-age=631152000
-X-Xss-Protection:  1; mode=block
-Pragma:  no-cache
-X-Request-Id:  d30766e5445f973b32efa9ec516cb5db
-Etag:  W/"6167741"
-X-Frame-Options:  SAMEORIGIN
-X-Content-Type-Options:  nosniff
-Expires:  Mon, 01 Jan 1990 00:00:00 GMT
-Last-Modified:  Tue, 28 Feb 2017 21:03:00 GMT
-Status:  200 OK
-Content-Length:  0
-Content-Type:  application/json
+Date: Tue, 28 Feb 2017 21:19:18 GMT
+Cache-Control: no-cache
+Vary: Origin,User-Agent,Accept-Encoding
+Strict-Transport-Security: max-age=631152000
+X-Xss-Protection: 1; mode=block
+Pragma: no-cache
+X-Request-Id: d30766e5445f973b32efa9ec516cb5db
+Etag: W/"6167741"
+X-Frame-Options: SAMEORIGIN
+X-Content-Type-Options: nosniff
+Expires: Mon, 01 Jan 1990 00:00:00 GMT
+Last-Modified: Tue, 28 Feb 2017 21:03:00 GMT
+Content-Length: 0
+Content-Type: application/json
 </pre>
 
 The `ETag` response header indicates the current `If-Match` version to use on subsequent updates.

--- a/content/millennium/dstu2/general-clinical/condition.md
+++ b/content/millennium/dstu2/general-clinical/condition.md
@@ -161,24 +161,22 @@ _Implementation Notes_
 
 <%= headers status: 201 %>
 <pre class="terminal">
-    Date → Tue, 28 Feb 2017 21:26:37 GMT
-    Cache-Control → no-cache
-    Vary → Origin,User-Agent,Accept-Encoding
-    Strict-Transport-Security → max-age=631152000
-    Server-Response-Time → 9272.410216999999
-    X-Xss-Protection → 1; mode=block
-    Pragma → no-cache
-    X-Request-Id → 78a19072002b8651623351cfedaffe70
-    Etag → W/"6809861"
-    X-Frame-Options → SAMEORIGIN
-    X-Runtime → 9.272318
-    X-Content-Type-Options → nosniff
-    Expires → Mon, 01 Jan 1990 00:00:00 GMT
-    Last-Modified → Tue, 28 Feb 2017 21:26:44 GMT
-    Location → https://fhir-ehr-code.cerner.com/dstu2/ec2458f2-1e24-41c8-b71b-0e701af7583d/Condition/p6809861
-    Status → 201 Created
-    Content-Length → 0
-    Content-Type → application/json
+Date: Tue, 28 Feb 2017 21:26:37 GMT
+Cache-Control: no-cache
+Vary: Origin,User-Agent,Accept-Encoding
+Strict-Transport-Security: max-age=631152000
+X-Xss-Protection: 1; mode=block
+Pragma: no-cache
+X-Request-Id: 78a19072002b8651623351cfedaffe70
+Etag: W/"6809861"
+X-Frame-Options: SAMEORIGIN
+X-Content-Type-Options: nosniff
+Expires: Mon, 01 Jan 1990 00:00:00 GMT
+Last-Modified: Tue, 28 Feb 2017 21:26:44 GMT
+Location: https://fhir-ehr-code.cerner.com/dstu2/ec2458f2-1e24-41c8-b71b-0e701af7583d/Condition/p6809861
+Status: 201 Created
+Content-Length: 0
+Content-Type: application/json
 </pre>
 
 The `ETag` response header indicates the current `If-Match` version to use on subsequent updates.
@@ -198,6 +196,7 @@ The `ETag` response header indicates the current `If-Match` version to use on su
 
 <%= headers status: 201 %>
 <pre class="terminal">
+<<<<<<< HEAD
     Date → Tue, 28 Feb 2017 21:30:28 GMT
     Cache-Control → no-cache
     Vary → Origin,User-Agent,Accept-Encoding
@@ -216,6 +215,24 @@ The `ETag` response header indicates the current `If-Match` version to use on su
     Status → 201 Created
     Content-Length → 0
     Content-Type → application/json
+=======
+Date: Tue, 28 Feb 2017 21:30:28 GMT
+Cache-Control: no-cache
+Vary: Origin,User-Agent,Accept-Encoding
+Strict-Transport-Security: max-age=631152000
+X-Xss-Protection: 1; mode=block
+Pragma: no-cache
+X-Request-Id: 1b0d589dde95bcafcefd3a1965b5cadf
+Etag: W/"36474555"
+X-Frame-Options: SAMEORIGIN
+X-Content-Type-Options: nosniff
+Expires: Mon, 01 Jan 1990 00:00:00 GMT
+Last-Modified: Tue, 28 Feb 2017 21:30:28 GMT
+Location: https://fhir-ehr.sandboxcerner.com/dstu2/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/Condition/d36474555
+Status: 201 Created
+Content-Length: 0
+Content-Type: application/json
+>>>>>>> ee8b9b0... Remove non-purposefully added response headers, standardize response header formatting. Fixes #397
 </pre>
 
 The `ETag` response header indicates the current `If-Match` version to use on subsequent updates.
@@ -269,23 +286,21 @@ Notes:
 
 <%= headers status: 200 %>
 <pre class="terminal">
-    Date → Wed, 01 Mar 2017 15:42:52 GMT
-    Cache-Control → no-cache
-    Vary → Origin,User-Agent,Accept-Encoding
-    Strict-Transport-Security → max-age=631152000
-    Server-Response-Time → 1227.508429
-    X-Xss-Protection → 1; mode=block
-    Pragma → no-cache
-    X-Request-Id → c58a2925586fa64a89568b9ceac14475
-    Etag → W/"43538555"
-    X-Frame-Options → SAMEORIGIN
-    X-Runtime → 1.227476
-    X-Content-Type-Options → nosniff
-    Expires → Mon, 01 Jan 1990 00:00:00 GMT
-    Last-Modified → Wed, 01 Mar 2017 15:42:52 GMT
-    Status → 200 OK
-    Content-Length → 0
-    Content-Type → application/json
+Date: Wed, 01 Mar 2017 15:42:52 GMT
+Cache-Control: no-cache
+Vary: Origin,User-Agent,Accept-Encoding
+Strict-Transport-Security: max-age=631152000
+X-Xss-Protection: 1; mode=block
+Pragma: no-cache
+X-Request-Id: c58a2925586fa64a89568b9ceac14475
+Etag: W/"43538555"
+X-Frame-Options: SAMEORIGIN
+X-Content-Type-Options: nosniff
+Expires: Mon, 01 Jan 1990 00:00:00 GMT
+Last-Modified: Wed, 01 Mar 2017 15:42:52 GMT
+Status: 200 OK
+Content-Length: 0
+Content-Type: application/json
 </pre>
 
 The `ETag` response header indicates the current `If-Match` version to use on subsequent updates.

--- a/content/millennium/dstu2/general-clinical/condition.md
+++ b/content/millennium/dstu2/general-clinical/condition.md
@@ -174,7 +174,6 @@ X-Content-Type-Options: nosniff
 Expires: Mon, 01 Jan 1990 00:00:00 GMT
 Last-Modified: Tue, 28 Feb 2017 21:26:44 GMT
 Location: https://fhir-ehr-code.cerner.com/dstu2/ec2458f2-1e24-41c8-b71b-0e701af7583d/Condition/p6809861
-Status: 201 Created
 Content-Length: 0
 Content-Type: application/json
 </pre>
@@ -196,26 +195,6 @@ The `ETag` response header indicates the current `If-Match` version to use on su
 
 <%= headers status: 201 %>
 <pre class="terminal">
-<<<<<<< HEAD
-    Date → Tue, 28 Feb 2017 21:30:28 GMT
-    Cache-Control → no-cache
-    Vary → Origin,User-Agent,Accept-Encoding
-    Strict-Transport-Security → max-age=631152000
-    Server-Response-Time → 767.841864
-    X-Xss-Protection → 1; mode=block
-    Pragma → no-cache
-    X-Request-Id → 1b0d589dde95bcafcefd3a1965b5cadf
-    Etag → W/"36474555"
-    X-Frame-Options → SAMEORIGIN
-    X-Runtime → 0.767820
-    X-Content-Type-Options → nosniff
-    Expires → Mon, 01 Jan 1990 00:00:00 GMT
-    Last-Modified → Tue, 28 Feb 2017 21:30:28 GMT
-    Location → https://fhir-ehr-code.cerner.com/dstu2/ec2458f2-1e24-41c8-b71b-0e701af7583d/Condition/d36474555
-    Status → 201 Created
-    Content-Length → 0
-    Content-Type → application/json
-=======
 Date: Tue, 28 Feb 2017 21:30:28 GMT
 Cache-Control: no-cache
 Vary: Origin,User-Agent,Accept-Encoding
@@ -228,11 +207,9 @@ X-Frame-Options: SAMEORIGIN
 X-Content-Type-Options: nosniff
 Expires: Mon, 01 Jan 1990 00:00:00 GMT
 Last-Modified: Tue, 28 Feb 2017 21:30:28 GMT
-Location: https://fhir-ehr.sandboxcerner.com/dstu2/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/Condition/d36474555
-Status: 201 Created
+Location: https://fhir-ehr-code.cerner.com/dstu2/ec2458f2-1e24-41c8-b71b-0e701af7583d/Condition/d36474555
 Content-Length: 0
 Content-Type: application/json
->>>>>>> ee8b9b0... Remove non-purposefully added response headers, standardize response header formatting. Fixes #397
 </pre>
 
 The `ETag` response header indicates the current `If-Match` version to use on subsequent updates.
@@ -298,7 +275,6 @@ X-Frame-Options: SAMEORIGIN
 X-Content-Type-Options: nosniff
 Expires: Mon, 01 Jan 1990 00:00:00 GMT
 Last-Modified: Wed, 01 Mar 2017 15:42:52 GMT
-Status: 200 OK
 Content-Length: 0
 Content-Type: application/json
 </pre>

--- a/content/millennium/dstu2/individuals/patient.md
+++ b/content/millennium/dstu2/individuals/patient.md
@@ -219,7 +219,6 @@ X-Content-Type-Options: nosniff
 Expires: Mon, 01 Jan 1990 00:00:00 GMT
 Last-Modified: Tue, 27 Feb 2018 16:48:00 GMT
 Location: https://fhir-ehr-code.cerner.com/dstu2/ec2458f2-1e24-41c8-b71b-0e701af7583d/Patient/4842008
-Status: 201 Created
 Content-Length: 0
 Content-Type: application/json
 </pre>

--- a/content/millennium/dstu2/individuals/patient.md
+++ b/content/millennium/dstu2/individuals/patient.md
@@ -206,24 +206,22 @@ Notes:
 
 <%= headers status: 201 %>
 <pre class="terminal">
-    Date → Tue, 27 Feb 2018 16:47:59 GMT
-    Cache-Control → no-cache
-    Vary → Origin,User-Agent,Accept-Encoding
-    Strict-Transport-Security → max-age=631152000
-    Server-Response-Time → 9272.410216999999
-    X-Xss-Protection → 1; mode=block
-    Pragma → no-cache
-    X-Request-Id → 78a19072002b8651623351cfedaffe70
-    Etag → W/"0"
-    X-Frame-Options → SAMEORIGIN
-    X-Runtime → 9.272318
-    X-Content-Type-Options → nosniff
-    Expires → Mon, 01 Jan 1990 00:00:00 GMT
-    Last-Modified → Tue, 27 Feb 2018 16:48:00 GMT
-    Location → https://fhir-ehr-code.cerner.com/dstu2/ec2458f2-1e24-41c8-b71b-0e701af7583d/Patient/4842008
-    Status → 201 Created
-    Content-Length → 0
-    Content-Type → application/json
+Date: Tue, 27 Feb 2018 16:47:59 GMT
+Cache-Control: no-cache
+Vary: Origin,User-Agent,Accept-Encoding
+Strict-Transport-Security: max-age=631152000
+X-Xss-Protection: 1; mode=block
+Pragma: no-cache
+X-Request-Id: 78a19072002b8651623351cfedaffe70
+Etag: W/"0"
+X-Frame-Options: SAMEORIGIN
+X-Content-Type-Options: nosniff
+Expires: Mon, 01 Jan 1990 00:00:00 GMT
+Last-Modified: Tue, 27 Feb 2018 16:48:00 GMT
+Location: https://fhir-ehr-code.cerner.com/dstu2/ec2458f2-1e24-41c8-b71b-0e701af7583d/Patient/4842008
+Status: 201 Created
+Content-Length: 0
+Content-Type: application/json
 </pre>
 
 The `ETag` response header indicates the current `If-Match` version to use on subsequent updates.

--- a/content/millennium/dstu2/infrastructure/document-reference.md
+++ b/content/millennium/dstu2/infrastructure/document-reference.md
@@ -179,7 +179,6 @@ Content-Length: 20
 Content-Type: text/html; charset=UTF-8
 Date: Wed, 06 Jan 2016 18:09:18 GMT
 Keep-Alive: timeout=15, max=100
-Status: 201 Created
 access-control-allow-methods: DELETE, GET, POST, PUT, OPTIONS, HEAD
 access-control-allow-origin: *
 access-control-expose-headers: ETag, Content-Location, Location, X-Request-Id, WWW-Authenticate, Date

--- a/content/millennium/dstu2/infrastructure/document-reference.md
+++ b/content/millennium/dstu2/infrastructure/document-reference.md
@@ -173,27 +173,25 @@ _Implementation Notes_
 
 <%= headers status: 201 %>
 <pre class="terminal">
-   Connection → Keep-Alive
-   Content-Encoding → gzip
-   Content-Length → 20
-   Content-Type → text/html; charset=UTF-8
-   Date → Wed, 06 Jan 2016 18:09:18 GMT
-   Keep-Alive → timeout=15, max=100
-   Status → 201 Created
-   access-control-allow-methods → DELETE, GET, POST, PUT, OPTIONS, HEAD
-   access-control-allow-origin → *
-   access-control-expose-headers → ETag, Content-Location, Location, X-Request-Id, WWW-Authenticate, Date
-   access-control-max-age → 0
-   cache-control → no-cache
-   location → https://fhir-ehr-code.cerner.com/dstu2/ec2458f2-1e24-41c8-b71b-0e701af7583d/DocumentReference/5789254
-   server-response-time → 5497.564885
-   strict-transport-security → max-age=631152000
-   vary → Origin,User-Agent,Accept-Encoding
-   x-content-type-options → nosniff
-   x-frame-options → SAMEORIGIN
-   x-request-id → 9c7510c0-0bb5-4148-b37e-51a774c4091b
-   x-runtime → 5.497541
-   x-xss-protection → 1; mode=block
+Connection: Keep-Alive
+Content-Encoding: gzip
+Content-Length: 20
+Content-Type: text/html; charset=UTF-8
+Date: Wed, 06 Jan 2016 18:09:18 GMT
+Keep-Alive: timeout=15, max=100
+Status: 201 Created
+access-control-allow-methods: DELETE, GET, POST, PUT, OPTIONS, HEAD
+access-control-allow-origin: *
+access-control-expose-headers: ETag, Content-Location, Location, X-Request-Id, WWW-Authenticate, Date
+access-control-max-age: 0
+cache-control: no-cache
+location: https://fhir-ehr-code.cerner.com/dstu2/ec2458f2-1e24-41c8-b71b-0e701af7583d/DocumentReference/5789254
+strict-transport-security: max-age=631152000
+vary: Origin,User-Agent,Accept-Encoding
+x-content-type-options: nosniff
+x-frame-options: SAMEORIGIN
+x-request-id: 9c7510c0-0bb5-4148-b37e-51a774c4091b
+x-xss-protection: 1; mode=block
 </pre>
 
 <%= disclaimer %>

--- a/content/millennium/dstu2/medications/medication-statement.md
+++ b/content/millennium/dstu2/medications/medication-statement.md
@@ -207,7 +207,6 @@ Content-Type: text/html; charset=UTF-8
 Date: Wed, 13 Jan 2016 21:45:47 GMT
 Keep-Alive: timeout=15, max=100
 Last-Modified: Tue, 15 Dec 2015 19:13:20 GMT
-Status: 201 Created
 access-control-allow-methods: DELETE, GET, POST, PUT, OPTIONS, HEAD
 access-control-allow-origin: *
 access-control-expose-headers: ETag, Content-Location, Location, X-Request-Id, WWW-Authenticate, Date
@@ -276,7 +275,6 @@ Content-Type: text/html; charset=UTF-8
 Date: Wed, 13 Jan 2016 21:50:53 GMT
 Keep-Alive: timeout=15, max=100
 Last-Modified: Tue, 15 Dec 2015 19:13:20 GMT
-Status: 200 OK
 access-control-allow-methods: DELETE, GET, POST, PUT, OPTIONS, HEAD
 access-control-allow-origin: *
 access-control-expose-headers: ETag, Content-Location, Location, X-Request-Id, WWW-Authenticate, Date

--- a/content/millennium/dstu2/medications/medication-statement.md
+++ b/content/millennium/dstu2/medications/medication-statement.md
@@ -200,29 +200,27 @@ _Implementation Notes_
 
 <%= headers status: 201 %>
 <pre class="terminal">
-    Connection → Keep-Alive
-    Content-Encoding → gzip
-    Content-Length → 20
-    Content-Type → text/html; charset=UTF-8
-    Date → Wed, 13 Jan 2016 21:45:47 GMT
-    Keep-Alive → timeout=15, max=100
-    Last-Modified → Tue, 15 Dec 2015 19:13:20 GMT
-    Status → 201 Created
-    access-control-allow-methods → DELETE, GET, POST, PUT, OPTIONS, HEAD
-    access-control-allow-origin → *
-    access-control-expose-headers → ETag, Content-Location, Location, X-Request-Id, WWW-Authenticate, Date
-    access-control-max-age → 0
-    cache-control → no-cache
-    etag → W/"0"
-    location → https://fhir-ehr-code.cerner.com/dstu2/ec2458f2-1e24-41c8-b71b-0e701af7583d/MedicationStatement/20465903
-    server-response-time → 1260.984596
-    strict-transport-security → max-age=631152000
-    vary → Origin,User-Agent,Accept-Encoding
-    x-content-type-options → nosniff
-    x-frame-options → SAMEORIGIN
-    x-request-id → 682c633c-b20f-4f6f-8fae-c58b3aeffe04
-    x-runtime → 1.260940
-    x-xss-protection → 1; mode=block
+Connection: Keep-Alive
+Content-Encoding: gzip
+Content-Length: 20
+Content-Type: text/html; charset=UTF-8
+Date: Wed, 13 Jan 2016 21:45:47 GMT
+Keep-Alive: timeout=15, max=100
+Last-Modified: Tue, 15 Dec 2015 19:13:20 GMT
+Status: 201 Created
+access-control-allow-methods: DELETE, GET, POST, PUT, OPTIONS, HEAD
+access-control-allow-origin: *
+access-control-expose-headers: ETag, Content-Location, Location, X-Request-Id, WWW-Authenticate, Date
+access-control-max-age: 0
+cache-control: no-cache
+etag: W/"0"
+location: https://fhir-ehr-code.cerner.com/dstu2/ec2458f2-1e24-41c8-b71b-0e701af7583d/MedicationStatement/20465903
+strict-transport-security: max-age=631152000
+vary: Origin,User-Agent,Accept-Encoding
+x-content-type-options: nosniff
+x-frame-options: SAMEORIGIN
+x-request-id: 682c633c-b20f-4f6f-8fae-c58b3aeffe04
+x-xss-protection: 1; mode=block
 </pre>
 
 The `ETag` response header indicates the current `If-Match` version to use on subsequent updates.
@@ -271,28 +269,26 @@ _Implementation Notes_
 
 <%= headers status: 200 %>
 <pre class="terminal">
-    Connection → Keep-Alive
-    Content-Encoding → gzip
-    Content-Length → 20
-    Content-Type → text/html; charset=UTF-8
-    Date → Wed, 13 Jan 2016 21:50:53 GMT
-    Keep-Alive → timeout=15, max=100
-    Last-Modified → Tue, 15 Dec 2015 19:13:20 GMT
-    Status → 200 OK
-    access-control-allow-methods → DELETE, GET, POST, PUT, OPTIONS, HEAD
-    access-control-allow-origin → *
-    access-control-expose-headers → ETag, Content-Location, Location, X-Request-Id, WWW-Authenticate, Date
-    access-control-max-age → 0
-    cache-control → no-cache
-    etag → W/"1"
-    server-response-time → 653.7616069999999
-    strict-transport-security → max-age=631152000
-    vary → Origin,User-Agent,Accept-Encoding
-    x-content-type-options → nosniff
-    x-frame-options → SAMEORIGIN
-    x-request-id → 9dba8326-899a-406f-a125-3fc3d6605dad
-    x-runtime → 0.653722
-    x-xss-protection → 1; mode=block
+Connection: Keep-Alive
+Content-Encoding: gzip
+Content-Length: 20
+Content-Type: text/html; charset=UTF-8
+Date: Wed, 13 Jan 2016 21:50:53 GMT
+Keep-Alive: timeout=15, max=100
+Last-Modified: Tue, 15 Dec 2015 19:13:20 GMT
+Status: 200 OK
+access-control-allow-methods: DELETE, GET, POST, PUT, OPTIONS, HEAD
+access-control-allow-origin: *
+access-control-expose-headers: ETag, Content-Location, Location, X-Request-Id, WWW-Authenticate, Date
+access-control-max-age: 0
+cache-control: no-cache
+etag: W/"1"
+strict-transport-security: max-age=631152000
+vary: Origin,User-Agent,Accept-Encoding
+x-content-type-options: nosniff
+x-frame-options: SAMEORIGIN
+x-request-id: 9dba8326-899a-406f-a125-3fc3d6605dad
+x-xss-protection: 1; mode=block
 </pre>
 
 The `ETag` response header indicates the current `If-Match` version to use on subsequent updates.

--- a/content/millennium/dstu2/scheduling/appointment.md
+++ b/content/millennium/dstu2/scheduling/appointment.md
@@ -182,7 +182,6 @@ Content-Type: text/html; charset=UTF-8
 Date: Wed, 13 Jan 2016 21:45:47 GMT
 Keep-Alive: timeout=15, max=100
 Last-Modified: Tue, 15 Dec 2015 19:13:20 GMT
-Status: 201 Created
 access-control-allow-methods: DELETE, GET, POST, PUT, OPTIONS, HEAD
 access-control-allow-origin: *
 access-control-expose-headers: ETag, Content-Location, Location, X-Request-Id, WWW-Authenticate, Date
@@ -252,7 +251,6 @@ Content-Type: text/html; charset=UTF-8
 Date: Wed, 13 Jan 2016 21:50:53 GMT
 Keep-Alive: timeout=15, max=100
 Last-Modified: Tue, 15 Dec 2015 19:13:20 GMT
-Status: 200 OK
 access-control-allow-methods: DELETE, GET, POST, PUT, OPTIONS, HEAD
 access-control-allow-origin: *
 access-control-expose-headers: ETag, Content-Location, Location, X-Request-Id, WWW-Authenticate, Date

--- a/content/millennium/dstu2/scheduling/appointment.md
+++ b/content/millennium/dstu2/scheduling/appointment.md
@@ -175,29 +175,27 @@ _Implementation Notes_
 #### Response
 <%= headers status: 201 %>
 <pre class="terminal">
-    Connection → Keep-Alive
-    Content-Encoding → gzip
-    Content-Length → 20
-    Content-Type → text/html; charset=UTF-8
-    Date → Wed, 13 Jan 2016 21:45:47 GMT
-    Keep-Alive → timeout=15, max=100
-    Last-Modified → Tue, 15 Dec 2015 19:13:20 GMT
-    Status → 201 Created
-    access-control-allow-methods → DELETE, GET, POST, PUT, OPTIONS, HEAD
-    access-control-allow-origin → *
-    access-control-expose-headers → ETag, Content-Location, Location, X-Request-Id, WWW-Authenticate, Date
-    access-control-max-age → 0
-    cache-control → no-cache
-    etag → W/"0"
-    location → https://fhir-ehr-code.cerner.com/dstu2/ec2458f2-1e24-41c8-b71b-0e701af7583d/Appointment/20465903
-    server-response-time → 1260.984596
-    strict-transport-security → max-age=631152000
-    vary → Origin,User-Agent,Accept-Encoding
-    x-content-type-options → nosniff
-    x-frame-options → SAMEORIGIN
-    x-request-id → 682c633c-b20f-4f6f-8fae-c58b3aeffe04
-    x-runtime → 1.260940
-    x-xss-protection → 1; mode=block
+Connection: Keep-Alive
+Content-Encoding: gzip
+Content-Length: 20
+Content-Type: text/html; charset=UTF-8
+Date: Wed, 13 Jan 2016 21:45:47 GMT
+Keep-Alive: timeout=15, max=100
+Last-Modified: Tue, 15 Dec 2015 19:13:20 GMT
+Status: 201 Created
+access-control-allow-methods: DELETE, GET, POST, PUT, OPTIONS, HEAD
+access-control-allow-origin: *
+access-control-expose-headers: ETag, Content-Location, Location, X-Request-Id, WWW-Authenticate, Date
+access-control-max-age: 0
+cache-control: no-cache
+etag: W/"0"
+location: https://fhir-ehr-code.cerner.com/dstu2/ec2458f2-1e24-41c8-b71b-0e701af7583d/Appointment/20465903
+strict-transport-security: max-age=631152000
+vary: Origin,User-Agent,Accept-Encoding
+x-content-type-options: nosniff
+x-frame-options: SAMEORIGIN
+x-request-id: 682c633c-b20f-4f6f-8fae-c58b3aeffe04
+x-xss-protection: 1; mode=block
 </pre>
 
 The `ETag` response header indicates the current `If-Match` version to use on subsequent updates.
@@ -247,28 +245,26 @@ In this example, only the `Appointment.status` field was updated.
 
 <%= headers status: 200 %>
 <pre class="terminal">
-    Connection → Keep-Alive
-    Content-Encoding → gzip
-    Content-Length → 20
-    Content-Type → text/html; charset=UTF-8
-    Date → Wed, 13 Jan 2016 21:50:53 GMT
-    Keep-Alive → timeout=15, max=100
-    Last-Modified → Tue, 15 Dec 2015 19:13:20 GMT
-    Status → 200 OK
-    access-control-allow-methods → DELETE, GET, POST, PUT, OPTIONS, HEAD
-    access-control-allow-origin → *
-    access-control-expose-headers → ETag, Content-Location, Location, X-Request-Id, WWW-Authenticate, Date
-    access-control-max-age → 0
-    cache-control → no-cache
-    etag → W/"1"
-    server-response-time → 653.7616069999999
-    strict-transport-security → max-age=631152000
-    vary → Origin,User-Agent,Accept-Encoding
-    x-content-type-options → nosniff
-    x-frame-options → SAMEORIGIN
-    x-request-id → 9dba8326-899a-406f-a125-3fc3d6605dad
-    x-runtime → 0.653722
-    x-xss-protection → 1; mode=block
+Connection: Keep-Alive
+Content-Encoding: gzip
+Content-Length: 20
+Content-Type: text/html; charset=UTF-8
+Date: Wed, 13 Jan 2016 21:50:53 GMT
+Keep-Alive: timeout=15, max=100
+Last-Modified: Tue, 15 Dec 2015 19:13:20 GMT
+Status: 200 OK
+access-control-allow-methods: DELETE, GET, POST, PUT, OPTIONS, HEAD
+access-control-allow-origin: *
+access-control-expose-headers: ETag, Content-Location, Location, X-Request-Id, WWW-Authenticate, Date
+access-control-max-age: 0
+cache-control: no-cache
+etag: W/"1"
+strict-transport-security: max-age=631152000
+vary: Origin,User-Agent,Accept-Encoding
+x-content-type-options: nosniff
+x-frame-options: SAMEORIGIN
+x-request-id: 9dba8326-899a-406f-a125-3fc3d6605dad
+x-xss-protection: 1; mode=block
 </pre>
 
 The `ETag` response header indicates the current `If-Match` version to use on subsequent updates.

--- a/content/millennium/r4.md
+++ b/content/millennium/r4.md
@@ -19,7 +19,6 @@ Date: Tue, 26 Mar 2019 15:50:49 GMT
 Cache-Control: no-cache
 Vary: Origin
 X-Request-Id: ecd13b72-4fde-11e9-8674-8b0a57a130fd
-Status: 200 OK
 Content-Type: application/json+fhir
 
 {

--- a/content/millennium/r4.md
+++ b/content/millennium/r4.md
@@ -18,9 +18,7 @@ HTTP/1.1 200 OK
 Date: Tue, 26 Mar 2019 15:50:49 GMT
 Cache-Control: no-cache
 Vary: Origin
-Server-Response-Time: 216.449165
 X-Request-Id: ecd13b72-4fde-11e9-8674-8b0a57a130fd
-X-Runtime: 0.216357
 Status: 200 OK
 Content-Type: application/json+fhir
 

--- a/content/millennium/r4/diagnostic/observation.md
+++ b/content/millennium/r4/diagnostic/observation.md
@@ -226,11 +226,8 @@ Date: Mon, 16 Nov 2020 22:05:40 GMT
 Etag: W/"1"
 Location: https://fhir-ehr.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/Observation/M-197392513
 Last-Modified: Mon, 16 Nov 2020 22:05:40 GMT
-Server-Response-Time: 588.773291
-Status: 201 Created
 Vary: Origin
 X-Request-Id: 30a3177d-0987-460d-bb27-a5bb6303f03e
-X-Runtime: 0.588654
 </pre>
 
 The `ETag` response header indicates the current `If-Match` version to use on a subsequent update.
@@ -286,11 +283,8 @@ Content-Type: text/html
 Date: Thu, 19 Nov 2020 17:39:58 GMT
 Etag: W/"3"
 Last-Modified: Thu, 19 Nov 2020 17:39:58 GMT
-Server-Response-Time: 296.405243
-Status: 200 OK
 Vary: Origin
 X-Request-Id: f3c2b8d6-01d8-4dfc-b278-b67e76c7f834
-X-Runtime: 0.812593
 </pre>
 
 The `ETag` response header indicates the current `If-Match` version to use on a subsequent update.

--- a/content/millennium/r4/documents/document-reference.md
+++ b/content/millennium/r4/documents/document-reference.md
@@ -173,11 +173,8 @@ Content-Type: text/html
 Date: Fri, 14 Feb 2020 22:05:40 GMT
 Etag: W/"12793861"
 Location: https://fhir-ehr-code.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/DocumentReference/16885181
-Server-Response-Time: 296.405243
-Status: 201 Created
 Vary: Origin
 X-Request-Id: 3e4cb2f732daacdb6cca2eb944e80e55
-X-Runtime: 2.011826
 </pre>
 
 ## Update
@@ -219,17 +216,14 @@ Accept: 'application/json+fhir', 'Content-Type': 'application/fhir+json', 'If-Ma
 
 <%= headers status: 200 %>
 <pre class="terminal">
-  Cache-Control: no-cache
-  Content-Length: 0
-  Content-Type: text/html
-  Date: Tue, 20 Aug 2019 21:17:04 GMT
-  Etag: W/"12793861"
-  Last-Modified: Sat, 15 Feb 2020 22:05:40 GMT
-  Server-Response-Time: 777.661584
-  Status: 200 OK
-  Vary: Origin
-  X-Request-Id: 3e4cb2f732daacdb6cca2eb944e80e55
-  X-Runtime: 0.777583
+Cache-Control: no-cache
+Content-Length: 0
+Content-Type: text/html
+Date: Tue, 20 Aug 2019 21:17:04 GMT
+Etag: W/"12793861"
+Last-Modified: Sat, 15 Feb 2020 22:05:40 GMT
+Vary: Origin
+X-Request-Id: 3e4cb2f732daacdb6cca2eb944e80e55
 </pre>
 
 The `ETag` response header indicates the current `If-Match` version to use on subsequent update.
@@ -239,14 +233,6 @@ The `ETag` response header indicates the current `If-Match` version to use on su
 ### Errors
 
 The common [errors] and [OperationOutcomes] may be returned.
-
-[`token`]: https://hl7.org/fhir/R4/search.html#token
-[`reference`]: https://hl7.org/fhir/R4/search.html#reference
-[`date`]: https://hl7.org/fhir/R4/search.html#date
-[`number`]: https://hl7.org/fhir/R4/search.html#number
-[errors]: ../../#client-errors
-[OperationOutcomes]: ../../#operation-outcomes
-[Update documentation]: https://www.hl7.org/fhir/r4/http.html#update
 
 ## Operation: docref
 
@@ -294,3 +280,11 @@ _Implementation Notes_
 ### Errors
 
 The common [errors] and [OperationOutcomes] may be returned.
+
+[`token`]: https://hl7.org/fhir/R4/search.html#token
+[`reference`]: https://hl7.org/fhir/R4/search.html#reference
+[`date`]: https://hl7.org/fhir/R4/search.html#date
+[`number`]: https://hl7.org/fhir/R4/search.html#number
+[errors]: ../../#client-errors
+[OperationOutcomes]: ../../#operation-outcomes
+[Update documentation]: https://www.hl7.org/fhir/r4/http.html#update

--- a/content/millennium/r4/encounters/encounter.md
+++ b/content/millennium/r4/encounters/encounter.md
@@ -210,7 +210,6 @@ Date: Wed, 27 Mar 2019 15:59:33 GMT
 Etag: W/"0"
 Last-Modified: Wed, 27 Mar 2019 15:59:30 GMT
 Location: https://fhir-ehr-code.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/Encounter/1621910
-Status: 201 Created
 Vary: Origin
 X-Request-Id: 1638e30e497b93ff4383b2ff0eaeea68
 </pre>
@@ -265,7 +264,6 @@ Content-Type: text/html
 Date: Tue, 26 Mar 2019 15:42:29 GMT
 Etag: W/"10"
 Last-Modified: Tue, 26 Mar 2019 15:42:27 GMT
-Status: 200 OK
 Vary: Origin
 X-Request-Id: 47306a14c8a2c3afd4ab85aa9594101d
 </pre>

--- a/content/millennium/r4/encounters/encounter.md
+++ b/content/millennium/r4/encounters/encounter.md
@@ -210,11 +210,9 @@ Date: Wed, 27 Mar 2019 15:59:33 GMT
 Etag: W/"0"
 Last-Modified: Wed, 27 Mar 2019 15:59:30 GMT
 Location: https://fhir-ehr-code.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/Encounter/1621910
-Server-Response-Time: 3890.363996
 Status: 201 Created
 Vary: Origin
 X-Request-Id: 1638e30e497b93ff4383b2ff0eaeea68
-X-Runtime: 3.890282
 </pre>
 
 The `ETag` response header indicates the current `If-Match` version to use on subsequent updates.
@@ -267,11 +265,9 @@ Content-Type: text/html
 Date: Tue, 26 Mar 2019 15:42:29 GMT
 Etag: W/"10"
 Last-Modified: Tue, 26 Mar 2019 15:42:27 GMT
-Server-Response-Time: 2260.237021
 Status: 200 OK
 Vary: Origin
 X-Request-Id: 47306a14c8a2c3afd4ab85aa9594101d
-X-Runtime: 2.260092
 </pre>
 
 The `ETag` response header indicates the current `If-Match` version to use on subsequent updates.

--- a/content/millennium/r4/entities/organization.md
+++ b/content/millennium/r4/entities/organization.md
@@ -136,7 +136,7 @@ Content-Length: 0
 Content-Type: text/html
 Date: Wed, 14 Aug 2019 17:23:14 GMT
 Etag: W/"6767735"
-Location: https://fhir-ehr-code.cerner.com/dstu2/ec2458f2-1e24-41c8-b71b-0e701af7583d/Organization/6767735,
+Location: https://fhir-ehr-code.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/Organization/6767735
 Last-Modified: Wed, 14 Aug 2019 17:23:14 GMT
 Vary: Origin
 X-Request-Id: 11111111111111111111111111111111

--- a/content/millennium/r4/entities/organization.md
+++ b/content/millennium/r4/entities/organization.md
@@ -138,7 +138,6 @@ Date: Wed, 14 Aug 2019 17:23:14 GMT
 Etag: W/"6767735"
 Location: https://fhir-ehr-code.cerner.com/dstu2/ec2458f2-1e24-41c8-b71b-0e701af7583d/Organization/6767735,
 Last-Modified: Wed, 14 Aug 2019 17:23:14 GMT
-Status: 201 Created
 Vary: Origin
 X-Request-Id: 11111111111111111111111111111111
 </pre>

--- a/content/millennium/r4/entities/organization.md
+++ b/content/millennium/r4/entities/organization.md
@@ -136,13 +136,11 @@ Content-Length: 0
 Content-Type: text/html
 Date: Wed, 14 Aug 2019 17:23:14 GMT
 Etag: W/"6767735"
-Location: https://fhir-ehr-code.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/Organization/6767735
+Location: https://fhir-ehr-code.cerner.com/dstu2/ec2458f2-1e24-41c8-b71b-0e701af7583d/Organization/6767735,
 Last-Modified: Wed, 14 Aug 2019 17:23:14 GMT
-Server-Response-Time: 296.405243
 Status: 201 Created
 Vary: Origin
 X-Request-Id: 11111111111111111111111111111111
-X-Runtime: 2.011826
 </pre>
 
 The `ETag` response header indicates the current `If-Match` version to use on a subsequent update.

--- a/content/millennium/r4/financial/coverage.md
+++ b/content/millennium/r4/financial/coverage.md
@@ -175,12 +175,7 @@ Content-Type: text/html
 Date: Tue, 22 Oct 2019 15:59:33 GMT
 Etag: W/"0"
 Last-Modified: Tue, 22 Oct 2019 15:59:30 GMT
-<<<<<<< HEAD
 Location: https://fhir-ehr-code.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/Coverage/31363178-11500257
-Server-Response-Time: 3890.363996
-=======
-Location: https://fhir-ehr.sandboxcerner.com/r4/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/Coverage/31363178-11500257
->>>>>>> ee8b9b0... Remove non-purposefully added response headers, standardize response header formatting. Fixes #397
 Vary: Origin
 X-Request-Id: ef7c0ee60a8cf431403fe82d9009640b
 </pre>

--- a/content/millennium/r4/financial/coverage.md
+++ b/content/millennium/r4/financial/coverage.md
@@ -149,10 +149,8 @@ Date: Tue, 22 Oct 2019 15:59:33 GMT
 Etag: W/"0$0"
 Last-Modified: Tue, 22 Oct 2019 15:59:30 GMT
 Location: https://fhir-ehr-code.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/Coverage/589763-11500257-11500257
-Server-Response-Time: 3890.363996
 Vary: Origin
 X-Request-Id: ef7c0ee60a8cf431403fe82d9009640b
-X-Runtime: 3.890282
 </pre>
 
 <%= disclaimer %>
@@ -177,11 +175,14 @@ Content-Type: text/html
 Date: Tue, 22 Oct 2019 15:59:33 GMT
 Etag: W/"0"
 Last-Modified: Tue, 22 Oct 2019 15:59:30 GMT
+<<<<<<< HEAD
 Location: https://fhir-ehr-code.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/Coverage/31363178-11500257
 Server-Response-Time: 3890.363996
+=======
+Location: https://fhir-ehr.sandboxcerner.com/r4/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/Coverage/31363178-11500257
+>>>>>>> ee8b9b0... Remove non-purposefully added response headers, standardize response header formatting. Fixes #397
 Vary: Origin
 X-Request-Id: ef7c0ee60a8cf431403fe82d9009640b
-X-Runtime: 3.890282
 </pre>
 
 <%= disclaimer %>
@@ -235,10 +236,8 @@ Content-Type: text/html
 Date: Tue, 26 Mar 2019 15:42:29 GMT
 Etag: W/"10"
 Last-Modified: Tue, 26 Mar 2019 15:42:27 GMT
-Server-Response-Time: 2260.237021
 Vary: Origin
 X-Request-Id: 47306a14c8a2c3afd4ab85aa9594101d
-X-Runtime: 2.260092
 </pre>
 
 <%= disclaimer %>
@@ -279,10 +278,8 @@ _Implementation Notes_
 <pre class="terminal">
 Cache-Control: no-cache
 Date: Wed, 20 May 2020 18:55:23 GMT
-Server-Response-Time: 2260.237021
 Vary: Origin
 X-Request-Id: 160d603d256dce10d510f7da2ca1780e
-X-Runtime: 2.60092
 </pre>
 
 <%= disclaimer %>

--- a/content/millennium/r4/financial/financial-transaction.md
+++ b/content/millennium/r4/financial/financial-transaction.md
@@ -90,12 +90,7 @@ Content-Type: application/fhir+json
 Date: Mon, 04 Nov 2019 16:23:57 GMT
 Etag: W/"0"
 Last-Modified: Mon, 04 Nov 2019 16:23:57 GMT
-<<<<<<< HEAD
 Location: https://fhir-ehr-code.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/Basic/FT-PL-14266754
-Status: 201 Created
-=======
-Location: https://fhir-ehr.sandboxcerner.com/r4/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/Basic/FT-PL-14266754
->>>>>>> a9eafa7... Remove Status header
 Vary: Origin
 X-Request-Id: 1638e30e497b93ff4383b2ff0eaeea68
 </pre>
@@ -122,16 +117,7 @@ Content-Type: application/fhir+json
 Date: Mon, 04 Nov 2019 16:23:59 GMT
 Etag: W/"0"
 Last-Modified: Mon, 04 Nov 2019 16:23:59 GMT
-<<<<<<< HEAD
 Location: https://fhir-ehr-code.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/Basic/FT-PL-74389581
-Server-Response-Time: 3890.363996
-=======
-Location: https://fhir-ehr.sandboxcerner.com/r4/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/Basic/FT-PL-74389581
-<<<<<<< HEAD
->>>>>>> ee8b9b0... Remove non-purposefully added response headers, standardize response header formatting. Fixes #397
-Status: 201 Created
-=======
->>>>>>> a9eafa7... Remove Status header
 Vary: Origin
 X-Request-Id: 1638e30e497b93ff4383b2ff0eaeea69
 </pre>
@@ -158,16 +144,7 @@ Content-Type: application/fhir+json
 Date: Mon, 04 Nov 2019 16:23:58 GMT
 Etag: W/"0"
 Last-Modified: Mon, 04 Nov 2019 16:23:58 GMT
-<<<<<<< HEAD
 Location: https://fhir-ehr-code.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/Basic/FT-PL-3335800133
-Server-Response-Time: 3890.363996
-=======
-Location: https://fhir-ehr.sandboxcerner.com/r4/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/Basic/FT-PL-3335800133
-<<<<<<< HEAD
->>>>>>> ee8b9b0... Remove non-purposefully added response headers, standardize response header formatting. Fixes #397
-Status: 201 Created
-=======
->>>>>>> a9eafa7... Remove Status header
 Vary: Origin
 X-Request-Id: 1638e30e497b93ff4383b2ff0eaeea70
 </pre>

--- a/content/millennium/r4/financial/financial-transaction.md
+++ b/content/millennium/r4/financial/financial-transaction.md
@@ -90,8 +90,12 @@ Content-Type: application/fhir+json
 Date: Mon, 04 Nov 2019 16:23:57 GMT
 Etag: W/"0"
 Last-Modified: Mon, 04 Nov 2019 16:23:57 GMT
+<<<<<<< HEAD
 Location: https://fhir-ehr-code.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/Basic/FT-PL-14266754
 Status: 201 Created
+=======
+Location: https://fhir-ehr.sandboxcerner.com/r4/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/Basic/FT-PL-14266754
+>>>>>>> a9eafa7... Remove Status header
 Vary: Origin
 X-Request-Id: 1638e30e497b93ff4383b2ff0eaeea68
 </pre>
@@ -123,8 +127,11 @@ Location: https://fhir-ehr-code.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af758
 Server-Response-Time: 3890.363996
 =======
 Location: https://fhir-ehr.sandboxcerner.com/r4/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/Basic/FT-PL-74389581
+<<<<<<< HEAD
 >>>>>>> ee8b9b0... Remove non-purposefully added response headers, standardize response header formatting. Fixes #397
 Status: 201 Created
+=======
+>>>>>>> a9eafa7... Remove Status header
 Vary: Origin
 X-Request-Id: 1638e30e497b93ff4383b2ff0eaeea69
 </pre>
@@ -156,8 +163,11 @@ Location: https://fhir-ehr-code.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af758
 Server-Response-Time: 3890.363996
 =======
 Location: https://fhir-ehr.sandboxcerner.com/r4/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/Basic/FT-PL-3335800133
+<<<<<<< HEAD
 >>>>>>> ee8b9b0... Remove non-purposefully added response headers, standardize response header formatting. Fixes #397
 Status: 201 Created
+=======
+>>>>>>> a9eafa7... Remove Status header
 Vary: Origin
 X-Request-Id: 1638e30e497b93ff4383b2ff0eaeea70
 </pre>
@@ -184,13 +194,7 @@ Content-Type: application/fhir+json
 Date: Mon, 04 Nov 2019 16:23:58 GMT
 Etag: W/"0"
 Last-Modified: Mon, 04 Nov 2019 16:23:58 GMT
-<<<<<<< HEAD
 Location: https://fhir-ehr-code.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/Basic/FT-AL-3335800133
-Server-Response-Time: 3890.363996
-=======
-Location: https://fhir-ehr.sandboxcerner.com/r4/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/Basic/FT-AL-3335800133
->>>>>>> ee8b9b0... Remove non-purposefully added response headers, standardize response header formatting. Fixes #397
-Status: 201 Created
 Vary: Origin
 X-Request-Id: 1638e30e497b93ff4383b2ff0eaeea70
 </pre>

--- a/content/millennium/r4/financial/financial-transaction.md
+++ b/content/millennium/r4/financial/financial-transaction.md
@@ -91,11 +91,9 @@ Date: Mon, 04 Nov 2019 16:23:57 GMT
 Etag: W/"0"
 Last-Modified: Mon, 04 Nov 2019 16:23:57 GMT
 Location: https://fhir-ehr-code.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/Basic/FT-PL-14266754
-Server-Response-Time: 3890.363996
 Status: 201 Created
 Vary: Origin
 X-Request-Id: 1638e30e497b93ff4383b2ff0eaeea68
-X-Runtime: 3.890282
 </pre>
 
 <%= disclaimer %>
@@ -120,12 +118,15 @@ Content-Type: application/fhir+json
 Date: Mon, 04 Nov 2019 16:23:59 GMT
 Etag: W/"0"
 Last-Modified: Mon, 04 Nov 2019 16:23:59 GMT
+<<<<<<< HEAD
 Location: https://fhir-ehr-code.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/Basic/FT-PL-74389581
 Server-Response-Time: 3890.363996
+=======
+Location: https://fhir-ehr.sandboxcerner.com/r4/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/Basic/FT-PL-74389581
+>>>>>>> ee8b9b0... Remove non-purposefully added response headers, standardize response header formatting. Fixes #397
 Status: 201 Created
 Vary: Origin
 X-Request-Id: 1638e30e497b93ff4383b2ff0eaeea69
-X-Runtime: 3.890282
 </pre>
 
 <%= disclaimer %>
@@ -150,12 +151,15 @@ Content-Type: application/fhir+json
 Date: Mon, 04 Nov 2019 16:23:58 GMT
 Etag: W/"0"
 Last-Modified: Mon, 04 Nov 2019 16:23:58 GMT
+<<<<<<< HEAD
 Location: https://fhir-ehr-code.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/Basic/FT-PL-3335800133
 Server-Response-Time: 3890.363996
+=======
+Location: https://fhir-ehr.sandboxcerner.com/r4/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/Basic/FT-PL-3335800133
+>>>>>>> ee8b9b0... Remove non-purposefully added response headers, standardize response header formatting. Fixes #397
 Status: 201 Created
 Vary: Origin
 X-Request-Id: 1638e30e497b93ff4383b2ff0eaeea70
-X-Runtime: 3.890282
 </pre>
 
 <%= disclaimer %>
@@ -180,12 +184,15 @@ Content-Type: application/fhir+json
 Date: Mon, 04 Nov 2019 16:23:58 GMT
 Etag: W/"0"
 Last-Modified: Mon, 04 Nov 2019 16:23:58 GMT
+<<<<<<< HEAD
 Location: https://fhir-ehr-code.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/Basic/FT-AL-3335800133
 Server-Response-Time: 3890.363996
+=======
+Location: https://fhir-ehr.sandboxcerner.com/r4/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/Basic/FT-AL-3335800133
+>>>>>>> ee8b9b0... Remove non-purposefully added response headers, standardize response header formatting. Fixes #397
 Status: 201 Created
 Vary: Origin
 X-Request-Id: 1638e30e497b93ff4383b2ff0eaeea70
-X-Runtime: 3.890282
 </pre>
 
 <%= disclaimer %>

--- a/content/millennium/r4/general-clinical/allergy-intolerance.md
+++ b/content/millennium/r4/general-clinical/allergy-intolerance.md
@@ -183,11 +183,9 @@ Date: Wed, 14 Aug 2019 17:23:14 GMT
 Etag: W/"6767735"
 Location: https://fhir-ehr-code.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/AllergyIntolerance/6767735
 Last-Modified: Wed, 14 Aug 2019 17:23:14 GMT
-Server-Response-Time: 296.405243
 Status: 201 Created
 Vary: Origin
 X-Request-Id: 11111111111111111111111111111111
-X-Runtime: 2.011826
 </pre>
 
 The `ETag` response header indicates the current `If-Match` version to use on a subsequent update.
@@ -238,17 +236,15 @@ Notes:
 
 <%= headers status: 200 %>
 <pre class="terminal">
-    Cache-Control: no-cache
-    Content-Length: 0
-    Content-Type: application/json
-    Date: Thu, 05 Dec 2019 17:21:08 GMT
-    Etag: W/"8167765"
-    Last-Modified: Thu, 05 Dec 2019 17:21:08 GMT
-    Server-Response-Time: 743.187771
-    Status: 200 OK
-    X-Request-Id: a53f6469ff29031e9197b40f526e9ca6
-    X-Runtime: 0.743187
-    Vary: Origin
+Cache-Control: no-cache
+Content-Length: 0
+Content-Type: application/json
+Date: Thu, 05 Dec 2019 17:21:08 GMT
+Etag: W/"8167765"
+Last-Modified: Thu, 05 Dec 2019 17:21:08 GMT
+Status: 200 OK
+X-Request-Id: a53f6469ff29031e9197b40f526e9ca6
+Vary: Origin
 </pre>
 
 The `ETag` response header indicates the current `If-Match` version to use on subsequent updates.

--- a/content/millennium/r4/general-clinical/allergy-intolerance.md
+++ b/content/millennium/r4/general-clinical/allergy-intolerance.md
@@ -183,7 +183,6 @@ Date: Wed, 14 Aug 2019 17:23:14 GMT
 Etag: W/"6767735"
 Location: https://fhir-ehr-code.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/AllergyIntolerance/6767735
 Last-Modified: Wed, 14 Aug 2019 17:23:14 GMT
-Status: 201 Created
 Vary: Origin
 X-Request-Id: 11111111111111111111111111111111
 </pre>
@@ -242,7 +241,6 @@ Content-Type: application/json
 Date: Thu, 05 Dec 2019 17:21:08 GMT
 Etag: W/"8167765"
 Last-Modified: Thu, 05 Dec 2019 17:21:08 GMT
-Status: 200 OK
 X-Request-Id: a53f6469ff29031e9197b40f526e9ca6
 Vary: Origin
 </pre>

--- a/content/millennium/r4/general-clinical/condition.md
+++ b/content/millennium/r4/general-clinical/condition.md
@@ -202,11 +202,9 @@ Date: Wed, 14 Aug 2019 17:23:14 GMT
 Etag: W/"12793861"
 Location: https://fhir-ehr-code.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/Condition/p12793861
 Last-Modified: Wed, 14 Aug 2019 17:23:14 GMT
-Server-Response-Time: 296.405243
 Status: 201 Created
 Vary: Origin
 X-Request-Id: 11111111111111111111111111111111
-X-Runtime: 2.011826
 </pre>
 
 The `ETag` response header indicates the current `If-Match` version to use on a subsequent update.
@@ -255,17 +253,15 @@ _Implementation Notes_
 
 <%= headers status: 200 %>
 <pre class="terminal">
-    Cache-Control: no-cache
-    Content-Length: 0
-    Content-Type: text/html
-    Date: Tue, 20 Aug 2019 21:17:04 GMT
-    Etag: W/"12809861"
-    Last-Modified: TTue, 20 Aug 2019 21:17:04 GMT
-    Server-Response-Time: 777.661584
-    Status: 200 OK
-    Vary: Origin
-    X-Request-Id: 3e4cb2f732daacdb6cca2eb944e80e55
-    X-Runtime: 0.777583
+Cache-Control: no-cache
+Content-Length: 0
+Content-Type: text/html
+Date: Tue, 20 Aug 2019 21:17:04 GMT
+Etag: W/"12809861"
+Last-Modified: TTue, 20 Aug 2019 21:17:04 GMT
+Status: 200 OK
+Vary: Origin
+X-Request-Id: 3e4cb2f732daacdb6cca2eb944e80e55
 </pre>
 
 The `ETag` response header indicates the current `If-Match` version to use on subsequent update.

--- a/content/millennium/r4/general-clinical/condition.md
+++ b/content/millennium/r4/general-clinical/condition.md
@@ -202,7 +202,6 @@ Date: Wed, 14 Aug 2019 17:23:14 GMT
 Etag: W/"12793861"
 Location: https://fhir-ehr-code.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/Condition/p12793861
 Last-Modified: Wed, 14 Aug 2019 17:23:14 GMT
-Status: 201 Created
 Vary: Origin
 X-Request-Id: 11111111111111111111111111111111
 </pre>
@@ -259,7 +258,6 @@ Content-Type: text/html
 Date: Tue, 20 Aug 2019 21:17:04 GMT
 Etag: W/"12809861"
 Last-Modified: TTue, 20 Aug 2019 21:17:04 GMT
-Status: 200 OK
 Vary: Origin
 X-Request-Id: 3e4cb2f732daacdb6cca2eb944e80e55
 </pre>

--- a/content/millennium/r4/general-clinical/procedure.md
+++ b/content/millennium/r4/general-clinical/procedure.md
@@ -176,7 +176,6 @@ Date: Mon, 06 Apr 2020 19:00:43 GMT
 Etag: W/"1"
 Location: https://fhir-ehr-code.cerner.com/dstu2/ec2458f2-1e24-41c8-b71b-0e701af7583d/Procedure/17228728
 Last-Modified: Mon, 06 Apr 2020 19:00:43 GMT
-Status: 201 Created
 Vary: Origin
 X-Request-Id: 2e11665d-618d-4017-9a90-c3c1afeeac00
 </pre>

--- a/content/millennium/r4/general-clinical/procedure.md
+++ b/content/millennium/r4/general-clinical/procedure.md
@@ -174,13 +174,11 @@ Content-Length: 0
 Content-Type: text/html
 Date: Mon, 06 Apr 2020 19:00:43 GMT
 Etag: W/"1"
-Location: https://fhir-ehr-code.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/Procedure/17228728
+Location: https://fhir-ehr-code.cerner.com/dstu2/ec2458f2-1e24-41c8-b71b-0e701af7583d/Procedure/17228728
 Last-Modified: Mon, 06 Apr 2020 19:00:43 GMT
-Server-Response-Time: 296.405243
 Status: 201 Created
 Vary: Origin
 X-Request-Id: 2e11665d-618d-4017-9a90-c3c1afeeac00
-X-Runtime: 2.011826
 </pre>
 
 The `ETag` response header indicates the current `If-Match` version to use on a subsequent update.

--- a/content/millennium/r4/general-clinical/procedure.md
+++ b/content/millennium/r4/general-clinical/procedure.md
@@ -174,7 +174,7 @@ Content-Length: 0
 Content-Type: text/html
 Date: Mon, 06 Apr 2020 19:00:43 GMT
 Etag: W/"1"
-Location: https://fhir-ehr-code.cerner.com/dstu2/ec2458f2-1e24-41c8-b71b-0e701af7583d/Procedure/17228728
+Location: https://fhir-ehr-code.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/Procedure/17228728
 Last-Modified: Mon, 06 Apr 2020 19:00:43 GMT
 Vary: Origin
 X-Request-Id: 2e11665d-618d-4017-9a90-c3c1afeeac00

--- a/content/millennium/r4/individuals/patient.md
+++ b/content/millennium/r4/individuals/patient.md
@@ -199,11 +199,9 @@ Date: Wed, 27 Mar 2019 17:23:14 GMT
 Etag: W/"0"
 Location: https://fhir-ehr-code.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/Patient/5786010
 Last-Modified: Wed, 27 Mar 2019 17:23:14 GMT
-Server-Response-Time: 296.405243
 Status: 201 Created
 Vary: Origin
 X-Request-Id: 11111111111111111111111111111111
-X-Runtime: 2.011826
 </pre>
 
 The `ETag` response header indicates the current `If-Match` version to use on subsequent updates.
@@ -257,11 +255,9 @@ Content-Type: application/fhir+json
 Date: Wed, 27 Mar 2019 17:23:14 GMT
 Etag: W/"1"
 Last-Modified: Wed, 27 Mar 2019 17:23:14 GMT
-Server-Response-Time: 296.405243
 Status: 200 OK
 Vary: Origin
 X-Request-Id: 81c05ba01b2c19e5bf421449ff8e97eb
-X-Runtime: 0.296306
 </pre>
 
 The `ETag` response header indicates the current `If-Match` version to use on subsequent updates.

--- a/content/millennium/r4/individuals/patient.md
+++ b/content/millennium/r4/individuals/patient.md
@@ -199,7 +199,6 @@ Date: Wed, 27 Mar 2019 17:23:14 GMT
 Etag: W/"0"
 Location: https://fhir-ehr-code.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/Patient/5786010
 Last-Modified: Wed, 27 Mar 2019 17:23:14 GMT
-Status: 201 Created
 Vary: Origin
 X-Request-Id: 11111111111111111111111111111111
 </pre>
@@ -255,7 +254,6 @@ Content-Type: application/fhir+json
 Date: Wed, 27 Mar 2019 17:23:14 GMT
 Etag: W/"1"
 Last-Modified: Wed, 27 Mar 2019 17:23:14 GMT
-Status: 200 OK
 Vary: Origin
 X-Request-Id: 81c05ba01b2c19e5bf421449ff8e97eb
 </pre>

--- a/content/millennium/r4/individuals/practitioner.md
+++ b/content/millennium/r4/individuals/practitioner.md
@@ -151,7 +151,6 @@ Date: Mon, 09 Dec 2019 18:57:39 GMT
 Etag: W/"0"
 Last-Modified: Mon, 09 Dec 2019 18:57:39 GMT
 Location: https://fhir-ehr-code.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/Practitioner/7118008
-Status: 201 Created
 Vary: Origin
 X-Request-Id: 9d3aecfa-c846-4ce2-825a-7ba2fce4813f
 </pre>

--- a/content/millennium/r4/individuals/practitioner.md
+++ b/content/millennium/r4/individuals/practitioner.md
@@ -151,11 +151,9 @@ Date: Mon, 09 Dec 2019 18:57:39 GMT
 Etag: W/"0"
 Last-Modified: Mon, 09 Dec 2019 18:57:39 GMT
 Location: https://fhir-ehr-code.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/Practitioner/7118008
-Server-Response-Time: 724.624
 Status: 201 Created
 Vary: Origin
 X-Request-Id: 9d3aecfa-c846-4ce2-825a-7ba2fce4813f
-X-Runtime: 0.724450
 </pre>
 
 ### Errors

--- a/content/millennium/r4/individuals/related-person.md
+++ b/content/millennium/r4/individuals/related-person.md
@@ -193,11 +193,8 @@ Date: Wed, 27 Mar 2019 17:23:14 GMT
 Etag: W/"0"
 Location: https://fhir-ehr-code.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/RelatedPerson/E-12747484-97939518
 Last-Modified: Thu, 17 Dec 2020 16:37:42 GMT
-Server-Response-Time: 296.405243
-Status: 201 Created
 Vary: Origin
 X-Request-Id: 11111111111111111111111111111111
-X-Runtime: 2.011826
 </pre>
 
 The `ETag` response header indicates the current `If-Match` version to use on subsequent updates.
@@ -252,10 +249,8 @@ Content-Type: text/html
 Date: Tue, 26 Mar 2019 15:42:29 GMT
 Etag: W/"7"
 Last-Modified: Tue, 21 Jan 2020 15:57:25 GMT
-Server-Response-Time: 2260.237021
 Vary: Origin
 X-Request-Id: 47306a14c8a2c3afd4ab85aa9594101d
-X-Runtime: 2.260092
 </pre>
 
 <%= disclaimer %>

--- a/content/millennium/r4/medications/immunization.md
+++ b/content/millennium/r4/medications/immunization.md
@@ -201,8 +201,6 @@ Date: Sun, 30 Jun 2019 10:35:00 GMT
 Etag: W/"1"
 Last-Modified: Sun, 30 Jun 2019 10:35:00 GMT
 Location: https://fhir-ehr-code.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/Immunization/147391087
-Status: 201 Created
-Vary: Origin
 X-Request-Id: 1638e30e497b93ff4383b2ff0eaeea68
 </pre>
 
@@ -251,7 +249,6 @@ Content-Type: application/fhir+json
 Date: Sun, 30 Jun 2019 10:40:00 GMT
 Etag: W/"2"
 Last-Modified: Sun, 30 Jun 2019 10:40:00 GMT
-Status: 200 OK
 Vary: Origin
 X-Request-Id: 1638e30e497b93ff4383b2ff0eaeea91
 </pre>

--- a/content/millennium/r4/medications/immunization.md
+++ b/content/millennium/r4/medications/immunization.md
@@ -201,6 +201,7 @@ Date: Sun, 30 Jun 2019 10:35:00 GMT
 Etag: W/"1"
 Last-Modified: Sun, 30 Jun 2019 10:35:00 GMT
 Location: https://fhir-ehr-code.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/Immunization/147391087
+Vary: Origin
 X-Request-Id: 1638e30e497b93ff4383b2ff0eaeea68
 </pre>
 

--- a/content/millennium/r4/medications/immunization.md
+++ b/content/millennium/r4/medications/immunization.md
@@ -201,11 +201,9 @@ Date: Sun, 30 Jun 2019 10:35:00 GMT
 Etag: W/"1"
 Last-Modified: Sun, 30 Jun 2019 10:35:00 GMT
 Location: https://fhir-ehr-code.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/Immunization/147391087
-Server-Response-Time: 3890.363996
 Status: 201 Created
 Vary: Origin
 X-Request-Id: 1638e30e497b93ff4383b2ff0eaeea68
-X-Runtime: 3.890282
 </pre>
 
 The `ETag` response header indicates the current `If-Match` version to use on subsequent updates.
@@ -253,11 +251,9 @@ Content-Type: application/fhir+json
 Date: Sun, 30 Jun 2019 10:40:00 GMT
 Etag: W/"2"
 Last-Modified: Sun, 30 Jun 2019 10:40:00 GMT
-Server-Response-Time: 3890.363247
 Status: 200 OK
 Vary: Origin
 X-Request-Id: 1638e30e497b93ff4383b2ff0eaeea91
-X-Runtime: 3.890014
 </pre>
 
 The `ETag` response header indicates the current `If-Match` version to use on subsequent updates.

--- a/content/millennium/r4/medications/medication-request.md
+++ b/content/millennium/r4/medications/medication-request.md
@@ -268,11 +268,8 @@ Content-Type: text/html
 Date: Tue, 26 Mar 2019 15:42:29 GMT
 Etag: W/"10"
 Last-Modified: Tue, 26 Mar 2019 15:42:27 GMT
-Server-Response-Time: 2260.237021
-Status: 200 OK
 Vary: Origin
 X-Request-Id: 47306a14c8a2c3afd4ab85aa9594101d
-X-Runtime: 2.260092
 </pre>
 
 The `ETag` response header indicates the current `If-Match` version to use on subsequent updates.

--- a/content/millennium/r4/security/provenance.md
+++ b/content/millennium/r4/security/provenance.md
@@ -141,11 +141,8 @@ Date: Tue, 31 Mar 2020 15:37:25 GMT
 Etag: W/"881057"
 Location: https://fhir-open.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/Provenance/doc-881057
 Last-Modified: Tue, 31 Mar 2020 15:37:25 GMT
-Server-Response-Time: 296.405243
-Status: 201 Created
 Vary: Origin
 X-Request-Id: 11111111111111111111111111111111
-X-Runtime: 2.011826
 </pre>
 
 The `ETag` response header indicates the current `If-Match` version to use on subsequent updates.


### PR DESCRIPTION
Fixes #397

Description
----
Some response headers are auto-added by the server and may change at any time, so we should focus our documentation around response headers that are meaningful

PR Checklist
----
- [x] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.
