### PR TITLE
Add live request button to metadata and Device endpoints

### DIFF
--- a/content/millennium/dstu2/conformance/conformance.md
+++ b/content/millennium/dstu2/conformance/conformance.md
@@ -29,10 +29,6 @@ Authorization is not required.
 
 <%= authorization_types(practitioner: true, patient: true, system: true) %>
 
-### Headers
-
-<%= headers head: {Accept: 'application/json+fhir'} %>
-
 ### Open Endpoint Example
 
 #### Request

--- a/content/millennium/dstu2/conformance/conformance.md
+++ b/content/millennium/dstu2/conformance/conformance.md
@@ -39,7 +39,7 @@ Authorization is not required.
 
     curl -i -H "Accept: application/json+fhir" "https://fhir-open.sandboxcerner.com/dstu2/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/metadata"
 
-<%= RequestButton.get(:dstu2, 'metadata', 200, :dstu2_open_metadata) %>
+<%= RequestButton.get('open', :dstu2, 'metadata', 200, :dstu2_open_metadata) %>
 
 ### Closed Endpoint Example
 
@@ -47,6 +47,6 @@ Authorization is not required.
 
     curl -i -H "Accept: application/json+fhir" "https://fhir-ehr.sandboxcerner.com/dstu2/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/metadata"
 
-<%= RequestButton.get(:dstu2_closed, 'metadata', 200, :dstu2_auth_metadata) %>
+<%= RequestButton.get('ehr', :dstu2, 'metadata', 200, :dstu2_auth_metadata) %>
 
 [`:serviceRootURL/metadata`]: ../../#service-root-url

--- a/content/millennium/dstu2/conformance/conformance.md
+++ b/content/millennium/dstu2/conformance/conformance.md
@@ -37,26 +37,16 @@ Authorization is not required.
 
 #### Request
 
-    GET https://fhir-open.sandboxcerner.com/dstu2/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/metadata
+    curl -i -H "Accept: application/json+fhir" "https://fhir-open.sandboxcerner.com/dstu2/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/metadata"
 
-#### Response
-
-<%= headers status: 200 %>
-<%= json(:dstu2_open_metadata) %>
-
-<%= disclaimer %>
+<%= RequestButton.get(:dstu2, 'metadata', 200, :dstu2_open_metadata) %>
 
 ### Closed Endpoint Example
 
 #### Request
 
-    GET https://fhir-ehr.sandboxcerner.com/dstu2/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/metadata?_format=json
+    curl -i -H "Accept: application/json+fhir" "https://fhir-ehr.sandboxcerner.com/dstu2/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/metadata"
 
-#### Response
-
-<%= headers status: 200 %>
-<%= json(:dstu2_auth_metadata) %>
-
-<%= disclaimer %>
+<%= RequestButton.get(:dstu2_closed, 'metadata', 200, :dstu2_auth_metadata) %>
 
 [`:serviceRootURL/metadata`]: ../../#service-root-url

--- a/content/millennium/dstu2/devices/device.md
+++ b/content/millennium/dstu2/devices/device.md
@@ -62,27 +62,17 @@ _Implementation Notes_
 
 #### Request
 
-    GET https://fhir-open.sandboxcerner.com/dstu2/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/Device?patient=4478007
+    curl -i -H "Accept: application/json+fhir" "https://fhir-open.sandboxcerner.com/dstu2/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/Device?patient=4478007"
 
-#### Response
-
-<%= headers status: 200 %>
-<%= json(:dstu2_device_bundle) %>
-
-<%= disclaimer %>
+<%= RequestButton.get(:dstu2, 'Device?patient=4478007', 200, :dstu2_device_bundle) %>
 
 ### Example Read by Ids
 
 #### Request
 
-    GET https://fhir-open.sandboxcerner.com/dstu2/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/Device?_id=15575768
+    curl -i -H "Accept: application/json+fhir" "https://fhir-open.sandboxcerner.com/dstu2/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/Device?_id=15575768"
 
-#### Response
-
-<%= headers status: 200 %>
-<%= json(:dstu2_device_bundle_by_id) %>
-
-<%= disclaimer %>
+<%= RequestButton.get(:dstu2, 'Device?_id=15575768', 200, :dstu2_device_bundle_by_id) %>
 
 ### Errors
 
@@ -110,14 +100,9 @@ _Implementation Notes_
 
 #### Request
 
-    GET https://fhir-open.sandboxcerner.com/dstu2/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/Device/15575768
+    curl -i -H "Accept: application/json+fhir" "https://fhir-open.sandboxcerner.com/dstu2/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/Device/15575768"
 
-#### Response
-
-<%= headers status: 200 %>
-<%= json(:dstu2_device) %>
-
-<%= disclaimer %>
+<%= RequestButton.get(:dstu2, 'Device/15575768', 200, :dstu2_device) %>
 
 ### Errors
 

--- a/content/millennium/dstu2/devices/device.md
+++ b/content/millennium/dstu2/devices/device.md
@@ -54,10 +54,6 @@ _Implementation Notes_
  `_id`     | This or `patient` | [`token`]     | The logical resource id associated with the Device. Example: `7891`
  `patient` | This or `_id`     | [`reference`] | The patient on whom the device is affixed. Example: `12345`
 
-### Headers
-
-<%= headers %>
-
 ### Example
 
 #### Request
@@ -91,10 +87,6 @@ _Implementation Notes_
 ### Authorization Types
 
 <%= authorization_types(practitioner: true, patient: true, system: true) %>
-
-### Headers
-
-<%= headers %>
 
 ### Example
 

--- a/content/millennium/dstu2/devices/device.md
+++ b/content/millennium/dstu2/devices/device.md
@@ -64,7 +64,7 @@ _Implementation Notes_
 
     curl -i -H "Accept: application/json+fhir" "https://fhir-open.sandboxcerner.com/dstu2/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/Device?patient=4478007"
 
-<%= RequestButton.get(:dstu2, 'Device?patient=4478007', 200, :dstu2_device_bundle) %>
+<%= RequestButton.get('open', :dstu2, 'Device?patient=4342008', 200, :dstu2_device_bundle) %>
 
 ### Example Read by Ids
 
@@ -72,7 +72,7 @@ _Implementation Notes_
 
     curl -i -H "Accept: application/json+fhir" "https://fhir-open.sandboxcerner.com/dstu2/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/Device?_id=15575768"
 
-<%= RequestButton.get(:dstu2, 'Device?_id=15575768', 200, :dstu2_device_bundle_by_id) %>
+<%= RequestButton.get('open', :dstu2, 'Device?_id=15601768', 200, :dstu2_device_bundle_by_id) %>
 
 ### Errors
 
@@ -102,7 +102,7 @@ _Implementation Notes_
 
     curl -i -H "Accept: application/json+fhir" "https://fhir-open.sandboxcerner.com/dstu2/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/Device/15575768"
 
-<%= RequestButton.get(:dstu2, 'Device/15575768', 200, :dstu2_device) %>
+<%= RequestButton.get('open', :dstu2, 'Device/15601768', 200, :dstu2_device) %>
 
 ### Errors
 

--- a/content/millennium/r4/conformance/capability-statement.md
+++ b/content/millennium/r4/conformance/capability-statement.md
@@ -39,7 +39,7 @@ Authorization is not required.
 
     curl -i -H "Accept: application/fhir+json" "https://fhir-open.sandboxcerner.com/r4/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/metadata"
 
-<%= RequestButton.get(:r4, 'metadata', 200, :r4_open_metadata) %>
+<%= RequestButton.get('open', :r4, 'metadata', 200, :r4_open_metadata) %>
 
 ### Closed Endpoint Example
 
@@ -47,6 +47,6 @@ Authorization is not required.
 
     curl -i -H "Accept: application/fhir+json" "https://fhir-ehr.sandboxcerner.com/r4/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/metadata"
 
-<%= RequestButton.get(:r4_closed, 'metadata', 200, :r4_auth_metadata) %>
+<%= RequestButton.get('ehr', :r4, 'metadata', 200, :r4_auth_metadata) %>
 
 [`:serviceRootURL/metadata`]: ../../#service-root-url

--- a/content/millennium/r4/conformance/capability-statement.md
+++ b/content/millennium/r4/conformance/capability-statement.md
@@ -37,22 +37,16 @@ Authorization is not required.
 
 #### Request
 
-    GET /metadata
+    curl -i -H "Accept: application/fhir+json" "https://fhir-open.sandboxcerner.com/r4/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/metadata"
 
-#### Response
-
-<%= headers status: 200 %>
-<%= json(:r4_open_metadata) %>
+<%= RequestButton.get(:r4, 'metadata', 200, :r4_open_metadata) %>
 
 ### Closed Endpoint Example
 
 #### Request
 
-    GET /metadata?_format=json
+    curl -i -H "Accept: application/fhir+json" "https://fhir-ehr.sandboxcerner.com/r4/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/metadata"
 
-#### Response
-
-<%= headers status: 200 %>
-<%= json(:r4_auth_metadata) %>
+<%= RequestButton.get(:r4_closed, 'metadata', 200, :r4_auth_metadata) %>
 
 [`:serviceRootURL/metadata`]: ../../#service-root-url

--- a/content/millennium/r4/conformance/capability-statement.md
+++ b/content/millennium/r4/conformance/capability-statement.md
@@ -29,10 +29,6 @@ Authorization is not required.
 
 <%= authorization_types(practitioner: true, patient: true, system: true) %>
 
-### Headers
-
-<%= headers head: {Accept: 'application/fhir+json'} %>
-
 ### Open Endpoint Example
 
 #### Request

--- a/content/millennium/r4/devices/device.md
+++ b/content/millennium/r4/devices/device.md
@@ -54,9 +54,6 @@ Search for Devices that meet supplied query parameters:
  `_id`     | This or `patient` | [`token`]     | The logical resource id associated with the Device. Example: `2226920`
  `patient` | This or `_id`     | [`reference`] | The patient to whom the device is affixed. Example: `12345`
 
-### Headers
-
-<%= headers fhir_json: true %>
 
 ### Example
 
@@ -80,9 +77,6 @@ List an individual Device by its id:
 
 <%= authorization_types(practitioner: true, patient: false, system: true)%>
 
-### Headers
-
-<%= headers fhir_json: true %>
 
 ### Example
 

--- a/content/millennium/r4/devices/device.md
+++ b/content/millennium/r4/devices/device.md
@@ -62,12 +62,9 @@ Search for Devices that meet supplied query parameters:
 
 #### Request
 
-    GET https://fhir-ehr.sandboxcerner.com/r4/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/Device?patient=4478007
+    curl -i -H "Accept: application/fhir+json" "https://fhir-ehr.sandboxcerner.com/r4/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/Device?patient=4478007"
 
-#### Response
-
-<%= headers status: 200 %>
-<%= json(:R4_DEVICE_BUNDLE) %>
+<%= RequestButton.get(:r4, 'Device?patient=4478007', 200, :R4_DEVICE_BUNDLE) %>
 
 ### Errors
 
@@ -91,12 +88,9 @@ List an individual Device by its id:
 
 #### Request
 
-    GET https://fhir-ehr.sandboxcerner.com/r4/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/Device/15577765
+    curl -i -H "Accept: application/fhir+json" "https://fhir-ehr.sandboxcerner.com/r4/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/Device/15577765"
 
-#### Response
-
-<%= headers status: 200 %>
-<%= json(:R4_DEVICE) %>
+<%= RequestButton.get(:r4, 'Device/15577765', 200, :R4_DEVICE) %>
 
 ### Errors
 

--- a/content/millennium/r4/devices/device.md
+++ b/content/millennium/r4/devices/device.md
@@ -62,9 +62,9 @@ Search for Devices that meet supplied query parameters:
 
 #### Request
 
-    curl -i -H "Accept: application/fhir+json" "https://fhir-ehr.sandboxcerner.com/r4/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/Device?patient=4478007"
+    curl -i -H "Accept: application/fhir+json" "https://fhir-open.sandboxcerner.com/r4/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/Device?patient=4478007"
 
-<%= RequestButton.get(:r4, 'Device?patient=4478007', 200, :R4_DEVICE_BUNDLE) %>
+<%= RequestButton.get('open', :r4, 'Device?patient=1316024', 200, :R4_DEVICE_BUNDLE) %>
 
 ### Errors
 
@@ -88,9 +88,9 @@ List an individual Device by its id:
 
 #### Request
 
-    curl -i -H "Accept: application/fhir+json" "https://fhir-ehr.sandboxcerner.com/r4/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/Device/15577765"
+    curl -i -H "Accept: application/fhir+json" "https://fhir-open.sandboxcerner.com/r4/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/Device/15577765"
 
-<%= RequestButton.get(:r4, 'Device/15577765', 200, :R4_DEVICE) %>
+<%= RequestButton.get('open', :r4, 'Device/15573768', 200, :R4_DEVICE) %>
 
 ### Errors
 

--- a/layouts/head.html
+++ b/layouts/head.html
@@ -12,6 +12,7 @@
   <script src="/js/jquery.js" type="text/javascript"></script>
   <script src="/js/millennium_diff_table.js" type="text/javascript"></script>
   <script src="/js/documentation.js" type="text/javascript"></script>
+  <script src="/js/request_button.js" type="text/javascript"></script>
   <script>
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),

--- a/layouts/millennium_diff_table.html
+++ b/layouts/millennium_diff_table.html
@@ -19,7 +19,7 @@
   </div>
 </div>
 <div id="diff-table-spinner" class="loading-spinner"><div></div><div></div><div></div><div></div></div>
-<div id="table-failure-message">
+<div class="failure-message">
   Failed to fetch resource information: If this issue persists, please post to our 
   <a href="https://groups.google.com/d/forum/cerner-fhir-developers">developer group</a>.
 </div>

--- a/lib/request_button.rb
+++ b/lib/request_button.rb
@@ -34,14 +34,14 @@ class RequestButton
         <ul id="#{random_id}">
           <li>
             <a class="active" href="#example-response" data-tab="example-response-tab"
-              onclick="showResponse(this, '#{random_id}'); return false;">
+              onclick="showTab(this, '#{random_id}'); return false;">
               Example Response
             </a>
           </li>
           <li>
             <a href="#live-response" data-tab="live-response-tab" data-url="#{request_url}"
               data-header="#{accept_header}" data-status="#{example_status}"
-              onclick="showResponse(this, '#{random_id}'); makeRequest(this); return false;">
+              onclick="showTab(this, '#{random_id}'); makeRequest(this); return false;">
               Live Response
             </a>
           </li>

--- a/lib/request_button.rb
+++ b/lib/request_button.rb
@@ -3,13 +3,6 @@
 require 'securerandom'
 
 class RequestButton
-  # The open and closed URLs for each API version
-  URLS = {
-    dstu2: 'https://fhir-open.sandboxcerner.com/dstu2/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/',
-    dstu2_closed: 'https://fhir-ehr.sandboxcerner.com/dstu2/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/',
-    r4: 'https://fhir-open.sandboxcerner.com/r4/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/',
-    r4_closed: 'https://fhir-ehr.sandboxcerner.com/r4/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/'
-  }.freeze
 
   # The base URL for Cerner's sandbox server
   BASE_URL = 'https://fhir-%s.sandboxcerner.com/%s/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/%s'
@@ -36,15 +29,34 @@ class RequestButton
     accept_header = HEADERS[version]
     random_id = SecureRandom.uuid
 
-      "<div class=\"example-tabs\"><ul id=\"#{random_id}\"><li><a class=\"active\" href=\"#example-response\" "\
-      "data-tab=\"example-response-tab\" onclick=\"showResponse(this, '#{random_id}')\">Example Response</a></li>"\
-      "<li><a href=\"#live-response\" data-tab=\"live-response-tab\" data-url=\"#{request_url}\" "\
-      "data-header=\"#{accept_header}\" data-status=\"#{example_status}\" "\
-      "onclick=\"showResponse(this, '#{random_id}')\">Live Response</a></li></ul></div>"\
-      "<div data-id=\"#{random_id}\" class=\"example-tab-content\">"\
-      "<div>#{headers(status: example_status)}#{json(example_json)}</div>"\
-      '<div class="hide"><pre class="headers"><code> </code></pre><pre class="body-response">'\
-      "<code class=\"language-javascript\"></code></pre></div></div>#{disclaimer}"
-    end
+    <<~HTML.strip
+      <div class="example-tabs">
+        <ul id="#{random_id}">
+          <li>
+            <a class="active" href="#example-response" data-tab="example-response-tab"
+              onclick="showResponse(this, '#{random_id}'); return false;">
+              Example Response
+            </a>
+          </li>
+          <li>
+            <a href="#live-response" data-tab="live-response-tab" data-url="#{request_url}"
+              data-header="#{accept_header}" data-status="#{example_status}"
+              onclick="showResponse(this, '#{random_id}'); makeRequest(this); return false;">
+              Live Response
+            </a>
+          </li>
+        </ul>
+      </div>
+      <div data-id="#{random_id}" class="example-tab-content">
+        <div data-content="example-response-tab">
+          #{headers(status: example_status)}#{json(example_json)}
+        </div>
+        <div data-content="live-response-tab" class="hide">
+          <pre class="headers"><code> </code></pre>
+          <pre class="body-response"><code class="language-javascript"></code></pre>
+        </div>
+      </div>
+      #{disclaimer}
+    HTML
   end
 end

--- a/lib/request_button.rb
+++ b/lib/request_button.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'securerandom'
+
+class RequestButton
+  # The open and closed URLs for each API version
+  URLS = {
+    dstu2: 'https://fhir-open.sandboxcerner.com/dstu2/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/',
+    dstu2_closed: 'https://fhir-ehr.sandboxcerner.com/dstu2/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/',
+    r4: 'https://fhir-open.sandboxcerner.com/r4/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/',
+    r4_closed: 'https://fhir-ehr.sandboxcerner.com/r4/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/'
+  }.freeze
+
+  # The accept header for each API version
+  HEADERS = {
+    dstu2: 'application/json+fhir',
+    r4: 'application/fhir+json'
+  }.freeze
+
+  private_constant :URLS, :HEADERS
+
+  # @api public
+  # Public: Builds the HTML for the example and live response tabs using the provided parameters.
+  #
+  # @param version [Symbol] the API version, open or closed
+  # @param enpoint [String] the endpoint of the request in the example
+  # @param example_status [Number] the status for the example response header
+  # @param example_json [Symbol] the json for the example response body
+  #
+  # @return [String] the HTML for the request button and the example response
+  def self.get(version, endpoint, example_status, example_json)
+    if URLS.key?(version)
+      request_url = URLS[version] + endpoint
+      accept_header = version.to_s.start_with?('dstu2') ? HEADERS[:dstu2] : HEADERS[:r4]
+      random_id = SecureRandom.uuid
+
+      "<div class=\"example-tabs\"><ul id=\"#{random_id}\"><li><a class=\"active\" href=\"#example-response\" "\
+      "data-tab=\"example-response-tab\" onclick=\"showResponse(this, '#{random_id}')\">Example Response</a></li>"\
+      "<li><a href=\"#live-response\" data-tab=\"live-response-tab\" data-url=\"#{request_url}\" "\
+      "data-header=\"#{accept_header}\" data-status=\"#{example_status}\" "\
+      "onclick=\"showResponse(this, '#{random_id}')\">Live Response</a></li></ul></div>"\
+      "<div data-id=\"#{random_id}\" class=\"example-tab-content\">"\
+      "<div>#{headers(status: example_status)}#{json(example_json)}</div>"\
+      '<div class="hide"><pre class="headers"><code> </code></pre><pre class="body-response">'\
+      "<code class=\"language-javascript\"></code></pre></div></div>#{disclaimer}"
+    end
+  end
+end

--- a/lib/request_button.rb
+++ b/lib/request_button.rb
@@ -11,28 +11,30 @@ class RequestButton
     r4_closed: 'https://fhir-ehr.sandboxcerner.com/r4/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/'
   }.freeze
 
+  # The base URL for Cerner's sandbox server
+  BASE_URL = 'https://fhir-%s.sandboxcerner.com/%s/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/%s'
+
   # The accept header for each API version
   HEADERS = {
     dstu2: 'application/json+fhir',
     r4: 'application/fhir+json'
   }.freeze
 
-  private_constant :URLS, :HEADERS
+  private_constant :BASE_URL, :HEADERS
 
-  # @api public
   # Public: Builds the HTML for the example and live response tabs using the provided parameters.
   #
+  # @param prefix [String] the prefix for the base URL, used to select fhir-open, fhir-ehr, or fhir-myrecord
   # @param version [Symbol] the API version, open or closed
-  # @param enpoint [String] the endpoint of the request in the example
+  # @param suffix [String] the suffix for the base URL
   # @param example_status [Number] the status for the example response header
   # @param example_json [Symbol] the json for the example response body
   #
   # @return [String] the HTML for the request button and the example response
-  def self.get(version, endpoint, example_status, example_json)
-    if URLS.key?(version)
-      request_url = URLS[version] + endpoint
-      accept_header = version.to_s.start_with?('dstu2') ? HEADERS[:dstu2] : HEADERS[:r4]
-      random_id = SecureRandom.uuid
+  def self.get(prefix = nil, version, suffix, example_status, example_json)
+    request_url = format(BASE_URL, prefix, version, suffix)
+    accept_header = HEADERS[version]
+    random_id = SecureRandom.uuid
 
       "<div class=\"example-tabs\"><ul id=\"#{random_id}\"><li><a class=\"active\" href=\"#example-response\" "\
       "data-tab=\"example-response-tab\" onclick=\"showResponse(this, '#{random_id}')\">Example Response</a></li>"\

--- a/spec/lib/request_button_spec.rb
+++ b/spec/lib/request_button_spec.rb
@@ -3,30 +3,51 @@
 require 'request_button'
 
 describe RequestButton do
-  # Used to test the example and live response tabs based on a specific version, URL, and accept header.
+  # Used to test the example and live response tabs based on a specific prefix, version, and accept header.
   #
   # Example:
-  #   context 'when version is :version' do
+  #   context "when prefix is 'prefix' and version is :version" do
   #     include_examples(
-  #       'generates the example/live response HTML based on the provided parameters',
+  #       'generates the example/live response HTML based on the provided params',
+  #       'prefix',
   #       :version,
-  #       version_url,
   #       version_header
   #     )
   #   end
-  shared_examples 'generates the example/live response HTML based on the provided parameters' do |version, url, header|
-    subject(:get) { RequestButton.get(version, endpoint, example_status, example_json) }
+  shared_examples 'generates the example/live response HTML based on the provided params' do |prefix, version, header|
+    subject(:get) { RequestButton.get(prefix, version, suffix, example_status, example_json) }
 
+    let(:base_url) { 'https://fhir-%s.sandboxcerner.com/%s/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/%s' }
     let(:expected_html) do
-      "<div class=\"example-tabs\"><ul id=\"#{random_id}\"><li><a class=\"active\" href=\"#example-response\" "\
-      "data-tab=\"example-response-tab\" onclick=\"showResponse(this, '#{random_id}')\">Example Response</a></li>"\
-      "<li><a href=\"#live-response\" data-tab=\"live-response-tab\" data-url=\"#{url}#{endpoint}\" "\
-      "data-header=\"#{header}\" data-status=\"#{example_status}\" "\
-      "onclick=\"showResponse(this, '#{random_id}')\">Live Response</a></li></ul></div>"\
-      "<div data-id=\"#{random_id}\" class=\"example-tab-content\">"\
-      "<div>#{status}#{response}</div>"\
-      '<div class="hide"><pre class="headers"><code> </code></pre><pre class="body-response">'\
-      "<code class=\"language-javascript\"></code></pre></div></div>#{disclaimer}"
+      <<~HTML.strip
+        <div class="example-tabs">
+          <ul id="#{random_id}">
+            <li>
+              <a class="active" href="#example-response" data-tab="example-response-tab"
+                onclick="showResponse(this, '#{random_id}'); return false;">
+                Example Response
+              </a>
+            </li>
+            <li>
+              <a href="#live-response" data-tab="live-response-tab" data-url="#{format(base_url, prefix, version, suffix)}"
+                data-header="#{header}" data-status="#{example_status}"
+                onclick="showResponse(this, '#{random_id}'); makeRequest(this); return false;">
+                Live Response
+              </a>
+            </li>
+          </ul>
+        </div>
+        <div data-id="#{random_id}" class="example-tab-content">
+          <div data-content="example-response-tab">
+            #{status}#{response}
+          </div>
+          <div data-content="live-response-tab" class="hide">
+            <pre class="headers"><code> </code></pre>
+            <pre class="body-response"><code class="language-javascript"></code></pre>
+          </div>
+        </div>
+        #{disclaimer}
+      HTML
     end
     let(:random_id) { 123 }
     let(:status) { '<pre class="headers">...</pre>' }
@@ -62,42 +83,60 @@ describe RequestButton do
   end
 
   describe '.get' do
-    let(:endpoint) { 'metadata' }
+    let(:suffix) { 'metadata' }
     let(:example_status) { 200 }
     let(:example_json) { :dstu2_open_metadata }
 
-    context 'when version is :dstu2' do
+    context "when prefix is 'open' and version is :dstu2" do
       include_examples(
-        'generates the example/live response HTML based on the provided parameters',
+        'generates the example/live response HTML based on the provided params',
+        'open',
         :dstu2,
-        'https://fhir-open.sandboxcerner.com/dstu2/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/',
         'application/json+fhir'
       )
     end
 
-    context 'when version is :dstu2_closed' do
+    context "when prefix is 'ehr' and version is :dstu2" do
       include_examples(
-        'generates the example/live response HTML based on the provided parameters',
-        :dstu2_closed,
-        'https://fhir-ehr.sandboxcerner.com/dstu2/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/',
+        'generates the example/live response HTML based on the provided params',
+        'ehr',
+        :dstu2,
         'application/json+fhir'
       )
     end
 
-    context 'when version is :r4' do
+    context "when prefix is 'myrecord' and version is :dstu2" do
       include_examples(
-        'generates the example/live response HTML based on the provided parameters',
+        'generates the example/live response HTML based on the provided params',
+        'myrecord',
+        :dstu2,
+        'application/json+fhir'
+      )
+    end
+
+    context "when prefix is 'open' and version is :r4" do
+      include_examples(
+        'generates the example/live response HTML based on the provided params',
+        'open',
         :r4,
-        'https://fhir-open.sandboxcerner.com/r4/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/',
         'application/fhir+json'
       )
     end
 
-    context 'when version is :r4_closed' do
+    context "when prefix is 'ehr' and version is :r4" do
       include_examples(
-        'generates the example/live response HTML based on the provided parameters',
-        :r4_closed,
-        'https://fhir-ehr.sandboxcerner.com/r4/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/',
+        'generates the example/live response HTML based on the provided params',
+        'ehr',
+        :r4,
+        'application/fhir+json'
+      )
+    end
+
+    context "when prefix is 'myrecord' and version is :r4" do
+      include_examples(
+        'generates the example/live response HTML based on the provided params',
+        'myrecord',
+        :r4,
         'application/fhir+json'
       )
     end

--- a/spec/lib/request_button_spec.rb
+++ b/spec/lib/request_button_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require 'request_button'
+
+describe RequestButton do
+  # Used to test the example and live response tabs based on a specific version, URL, and accept header.
+  #
+  # Example:
+  #   context 'when version is :version' do
+  #     include_examples(
+  #       'generates the example/live response HTML based on the provided parameters',
+  #       :version,
+  #       version_url,
+  #       version_header
+  #     )
+  #   end
+  shared_examples 'generates the example/live response HTML based on the provided parameters' do |version, url, header|
+    subject(:get) { RequestButton.get(version, endpoint, example_status, example_json) }
+
+    let(:expected_html) do
+      "<div class=\"example-tabs\"><ul id=\"#{random_id}\"><li><a class=\"active\" href=\"#example-response\" "\
+      "data-tab=\"example-response-tab\" onclick=\"showResponse(this, '#{random_id}')\">Example Response</a></li>"\
+      "<li><a href=\"#live-response\" data-tab=\"live-response-tab\" data-url=\"#{url}#{endpoint}\" "\
+      "data-header=\"#{header}\" data-status=\"#{example_status}\" "\
+      "onclick=\"showResponse(this, '#{random_id}')\">Live Response</a></li></ul></div>"\
+      "<div data-id=\"#{random_id}\" class=\"example-tab-content\">"\
+      "<div>#{status}#{response}</div>"\
+      '<div class="hide"><pre class="headers"><code> </code></pre><pre class="body-response">'\
+      "<code class=\"language-javascript\"></code></pre></div></div>#{disclaimer}"
+    end
+    let(:random_id) { 123 }
+    let(:status) { '<pre class="headers">...</pre>' }
+    let(:response) { '<pre class="body-response">...</pre>' }
+    let(:disclaimer) { 'Disclaimer message' }
+
+    before do
+      allow(SecureRandom).to receive(:uuid).and_return(random_id)
+      allow(RequestButton).to receive(:headers).with({status: example_status}).and_return(status)
+      allow(RequestButton).to receive(:json).with(example_json).and_return(response)
+      allow(RequestButton).to receive(:disclaimer).and_return(disclaimer)
+    end
+
+    context 'when the example response is generated' do
+      after { subject }
+
+      it 'calls #headers' do
+        expect(RequestButton).to receive(:headers).with({status: example_status})
+      end
+
+      it 'calls #json' do
+        expect(RequestButton).to receive(:json).with(example_json)
+      end
+
+      it 'calls #disclaimer' do
+        expect(RequestButton).to receive(:disclaimer)
+      end
+    end
+
+    it 'returns the expected HTML' do
+      expect(subject).to eq(expected_html)
+    end
+  end
+
+  describe '.get' do
+    let(:endpoint) { 'metadata' }
+    let(:example_status) { 200 }
+    let(:example_json) { :dstu2_open_metadata }
+
+    context 'when version is :dstu2' do
+      include_examples(
+        'generates the example/live response HTML based on the provided parameters',
+        :dstu2,
+        'https://fhir-open.sandboxcerner.com/dstu2/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/',
+        'application/json+fhir'
+      )
+    end
+
+    context 'when version is :dstu2_closed' do
+      include_examples(
+        'generates the example/live response HTML based on the provided parameters',
+        :dstu2_closed,
+        'https://fhir-ehr.sandboxcerner.com/dstu2/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/',
+        'application/json+fhir'
+      )
+    end
+
+    context 'when version is :r4' do
+      include_examples(
+        'generates the example/live response HTML based on the provided parameters',
+        :r4,
+        'https://fhir-open.sandboxcerner.com/r4/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/',
+        'application/fhir+json'
+      )
+    end
+
+    context 'when version is :r4_closed' do
+      include_examples(
+        'generates the example/live response HTML based on the provided parameters',
+        :r4_closed,
+        'https://fhir-ehr.sandboxcerner.com/r4/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca/',
+        'application/fhir+json'
+      )
+    end
+  end
+end

--- a/spec/lib/request_button_spec.rb
+++ b/spec/lib/request_button_spec.rb
@@ -24,14 +24,14 @@ describe RequestButton do
           <ul id="#{random_id}">
             <li>
               <a class="active" href="#example-response" data-tab="example-response-tab"
-                onclick="showResponse(this, '#{random_id}'); return false;">
+                onclick="showTab(this, '#{random_id}'); return false;">
                 Example Response
               </a>
             </li>
             <li>
               <a href="#live-response" data-tab="live-response-tab" data-url="#{format(base_url, prefix, version, suffix)}"
                 data-header="#{header}" data-status="#{example_status}"
-                onclick="showResponse(this, '#{random_id}'); makeRequest(this); return false;">
+                onclick="showTab(this, '#{random_id}'); makeRequest(this); return false;">
                 Live Response
               </a>
             </li>

--- a/static/css/documentation.css
+++ b/static/css/documentation.css
@@ -1375,6 +1375,12 @@ ul + pre {
   margin-top: 1em;
 }
 
+pre.body-response {
+  height: 500px;
+  min-height: 200px;
+  resize: vertical;
+}
+
 pre span.comment {color: #aaa;}
 
 .headers {
@@ -1516,6 +1522,7 @@ pre span.comment {color: #aaa;}
 /*------------------------------------------------------------------------------
     Millennium Overview Table
 ------------------------------------------------------------------------------*/
+
 #millennium-table-div {
   width: 980px;
   margin-top: 40px;
@@ -1541,7 +1548,7 @@ pre span.comment {color: #aaa;}
 }
 
 #millennium-diff-table tr {
-  background-color: transparent;  
+  background-color: transparent;
 }
 
 #millennium-diff-table td {
@@ -1554,7 +1561,7 @@ pre span.comment {color: #aaa;}
   background: #f5faff;
 }
 
-#millennium-diff-table tbody:hover td[rowspan], 
+#millennium-diff-table tbody:hover td[rowspan],
 #millennium-diff-table tr:hover td {
    background: #ebf6fd;
 }
@@ -1568,12 +1575,18 @@ pre span.comment {color: #aaa;}
   margin: 0 3px;
 }
 
-#table-failure-message {
+.failure-message {
+  margin-top: 1em;
   padding: 12px;
   border: 1px solid transparent;
   border-radius: 4px;
   background-color: #FFF9E6;
   border-color: #FFE79D;
+}
+
+.failure-message p {
+  display: inline;
+  margin: 0;
 }
 
 .hide {
@@ -1645,6 +1658,57 @@ pre span.comment {color: #aaa;}
   transition-delay: 0.5s;
   transition-duration: 0.2s;
   transform: translateX(-50%) scaleY(1);
+}
+
+/* @end */
+
+/*------------------------------------------------------------------------------
+    Example/Live Response Tabs
+------------------------------------------------------------------------------*/
+
+.example-tabs {
+  max-width: 630px;
+  margin: 0 auto;
+  position: relative;
+}
+
+.example-tabs ul {
+  list-style: none;
+  margin: 0;
+}
+
+.example-tabs li {
+  display: inline-block;
+}
+
+.example-tabs li a {
+  color: #767676;
+  font-size: 14px;
+  margin-right: 16px;
+  padding: 4px 2px 8px;
+  text-decoration: none;
+}
+
+.example-tabs li a:hover {
+  color: #4183C4;
+}
+
+.example-tabs li .active{
+  color: #222;
+  border-bottom: 2px solid #d8d8d8;
+}
+
+.example-tabs li .active:hover {
+  color: #222;
+}
+
+.example-tab-content pre {
+  margin-top: 0;
+}
+
+.example-failure-message {
+  font: 13px/1.4em "Helvetica Neue", arial,freesans,clean,sans-serif;
+  white-space: pre-wrap;
 }
 
 /* @end */

--- a/static/js/documentation.js
+++ b/static/js/documentation.js
@@ -109,8 +109,8 @@ function fetchData(url, headers, cache = false, callback, onFail) {
       headers: headers,
       cache: cache,
     })
-    .done(function(response) {
-      callback(response);
+    .done(function(response, responseText, xhr) {
+      callback(response, xhr);
     })
     .fail(function(e) {
       onFail(e);

--- a/static/js/millennium_diff_table.js
+++ b/static/js/millennium_diff_table.js
@@ -433,7 +433,7 @@ function spanR4WithDstu2(dstu2Resources, r4Resources, notes) {
  * Spans a DSTU2 resource to align with the R4 resources that match it.
  * @param {array} dstu2Resources  - The array of DSTU2 resources.
  * @param {array} r4Resources - The array of R4 resources.
- * @param {*} notes - Notes to be displayed on the resource in the table.
+ * @param {string} notes - Notes to be displayed on the resource in the table.
  */
 function spanDstu2WithR4(dstu2Resources, r4Resources, notes) {
   let table = document.getElementById('millennium-diff-table');
@@ -567,9 +567,9 @@ function generateTable(resourcesObject) {
 /**
  * Hides the loading spinner and displays the failure message.
  */
-function showFailureMessage(error) {
+function showTableFailureMessage() {
   document.getElementById('diff-table-spinner').classList.toggle('hide');
-  document.getElementById('table-failure-message').classList.toggle('hide');
+  document.getElementsByClassName('failure-message')[0].classList.toggle('hide');
 }
 
 /**
@@ -578,7 +578,7 @@ function showFailureMessage(error) {
  */
 function displayOverviewTable() {
   document.getElementById('millennium-table-div').classList.toggle('hide');
-  document.getElementById('table-failure-message').classList.toggle('hide');
+  document.getElementsByClassName('failure-message')[0].classList.toggle('hide');
 
   fetchData(conformanceURL, conformanceHeaders, true, function(dstu2Response) {
     fetchData(capabilityStatementURL, capabilityStatementHeaders, true, function(r4Response) {
@@ -587,6 +587,6 @@ function displayOverviewTable() {
       generateTable(tableResources);
       document.getElementById('diff-table-spinner').classList.toggle('hide')
       document.getElementById('millennium-table-div').classList.toggle('hide');
-    }, showFailureMessage);
-  }, showFailureMessage);
+    }, showTableFailureMessage);
+  }, showTableFailureMessage);
 }

--- a/static/js/request_button.js
+++ b/static/js/request_button.js
@@ -28,7 +28,7 @@ function displayLoadingSpinner(responseBody) {
   let loadingSpinnerHTML = '<div class="loading-spinner"><div></div><div></div><div></div><div></div></div>';
   template.innerHTML = loadingSpinnerHTML.trim();
 
-  let loadingSpinner = template.content.firstChild;
+  let loadingSpinner = template.content.firstElementChild;
   responseBody.appendChild(loadingSpinner);
 }
 
@@ -45,16 +45,16 @@ function showRequestFailureMessage(xhr = null, emptyBundle = false) {
     body.children[1].classList.add('hide');
   }
 
-  status.firstChild.innerText = 'Status: ' + statuses[xhr.status];
-  body.firstChild.classList.add('example-failure-message');
+  status.firstElementChild.innerText = 'Status: ' + statuses[xhr.status];
+  body.firstElementChild.classList.add('example-failure-message');
 
   if (emptyBundle) {
-    body.firstChild.innerText = 'Unfortunately, this request returned no results. To view what a request containing ' +
+    body.firstElementChild.innerText = 'Unfortunately, this request returned no results. To view what a request containing ' +
                                 'results might look like, please view the example response.\n' +
                                 `X-Request-Id: ${xhr.getResponseHeader('X-Request-Id')}`;
   }
   else {
-    body.firstChild.innerHTML = 'Failed to make this request: If this issue persists, please post to our ' +
+    body.firstElementChild.innerHTML = 'Failed to make this request: If this issue persists, please post to our ' +
                                 '<a href="https://groups.google.com/d/forum/cerner-fhir-developers">developer group' +
                                 `</a>.\nX-Request-Id: ${xhr.getResponseHeader('X-Request-Id')}`;
   }
@@ -84,8 +84,8 @@ function makeRequest(liveResponseTab) {
         showRequestFailureMessage(xhr, true);
       }
       else {
-        status.firstChild.innerText = 'Status: ' + statuses[xhr.status];
-        body.firstChild.innerText += JSON.stringify(response, null, 2);
+        status.firstElementChild.innerText = 'Status: ' + statuses[xhr.status];
+        body.firstElementChild.innerText += JSON.stringify(response, null, 2);
       }
     }, showRequestFailureMessage);
   }
@@ -93,7 +93,7 @@ function makeRequest(liveResponseTab) {
 
 /**
  * Toggles between the example response and the live response.
- * The first time the live response tab is clicked, a GET request is performed for the example.
+ * The content div for the live response is set to the window for showing errors.
  * @param {HTMLElement} tabClicked - The tab clicked, either the example response or the live response.
  * @param {number} randomId - The random ID associated with group of responses.
  */
@@ -102,7 +102,7 @@ function showResponse(tabClicked, randomId) {
   let responses = document.querySelectorAll(`[data-id="${randomId}"]`)[0].children;
 
   for (let i = 0; i < tabs.length; i++) {
-    tabs[i].firstChild.classList.remove('active');
+    tabs[i].firstElementChild.classList.remove('active');
   }
 
   tabClicked.classList.add('active');

--- a/static/js/request_button.js
+++ b/static/js/request_button.js
@@ -1,0 +1,121 @@
+const statuses = {
+  200: '200 OK',
+  201: '201 Created',
+  202: '202 Accepted',
+  204: '204 No Content',
+  205: '205 Reset Content',
+  301: '301 Moved Permanently',
+  302: '302 Found',
+  307: '307 Temporary Redirect',
+  304: '304 Not Modified',
+  400: '400 Bad Request',
+  401: '401 Unauthorized',
+  403: '403 Forbidden',
+  404: '404 Not Found',
+  405: '405 Method not allowed',
+  409: '409 Conflict',
+  422: '422 Unprocessable Entity',
+  500: '500 Server Error',
+  502: '502 Bad Gateway'
+};
+
+/**
+ * Displays a loading spinner while the request processes.
+ * @param {HTMLElement} responseBody - The <pre> element that the response will be displayed in.
+ */
+function displayLoadingSpinner(responseBody) {
+  let template = document.createElement('template');
+  let loadingSpinnerHTML = '<div class="loading-spinner"><div></div><div></div><div></div><div></div></div>';
+  template.innerHTML = loadingSpinnerHTML.trim();
+
+  let loadingSpinner = template.content.firstChild;
+  responseBody.appendChild(loadingSpinner);
+}
+
+/**
+ * Displays a failure message for calls that do not return a 200 or that return an empty bundle.
+ * @param {object} xhr - The response object returned from the request.
+ * @param {bool} emptyBundle - Whether or not the response returned an empty bundle.
+ */
+function showRequestFailureMessage(xhr = null, emptyBundle = false) {
+  let status = responseDiv.children[0];
+  let body = responseDiv.children[1];
+
+  if (!body.children[1].classList.contains('hide')) {
+    body.children[1].classList.add('hide');
+  }
+
+  status.firstChild.innerText = 'Status: ' + statuses[xhr.status];
+  body.firstChild.classList.add('example-failure-message');
+
+  if (emptyBundle) {
+    body.firstChild.innerText = 'Unfortunately, this request returned no results. To view what a request containing ' +
+                                'results might look like, please view the example response.\n' +
+                                `X-Request-Id: ${xhr.getResponseHeader('X-Request-Id')}`;
+  }
+  else {
+    body.firstChild.innerHTML = 'Failed to make this request: If this issue persists, please post to our ' +
+                                '<a href="https://groups.google.com/d/forum/cerner-fhir-developers">developer group' +
+                                `</a>.\nX-Request-Id: ${xhr.getResponseHeader('X-Request-Id')}`;
+  }
+}
+
+/**
+ * Makes a GET request using the provided URL and accept header associated with the live response tab.
+ * If the request fails or returns an empty bundle, an error message is displayed instead of the response.
+ * @param {HTMLElement} liveResponseTab - The live response tab for the current example.
+ */
+function makeRequest(liveResponseTab) {
+  let requestURL = liveResponseTab.dataset.url;
+  let header = { Accept: liveResponseTab.dataset.header };
+  let status = responseDiv.children[0];
+  let body = responseDiv.children[1];
+
+  if (body.children.length == 1) {
+    displayLoadingSpinner(body);
+
+    fetchData(requestURL, header, true, function(response, xhr) {
+      body.children[1].classList.add('hide');
+
+      if (liveResponseTab.dataset.status != xhr.status) {
+        showRequestFailureMessage(xhr, false);
+      }
+      else if (response.resourceType === 'Bundle' && !response.hasOwnProperty('entry')) {
+        showRequestFailureMessage(xhr, true);
+      }
+      else {
+        status.firstChild.innerText = 'Status: ' + statuses[xhr.status];
+        body.firstChild.innerText += JSON.stringify(response, null, 2);
+      }
+    }, showRequestFailureMessage);
+  }
+}
+
+/**
+ * Toggles between the example response and the live response.
+ * The first time the live response tab is clicked, a GET request is performed for the example.
+ * @param {HTMLElement} tabClicked - The tab clicked, either the example response or the live response.
+ * @param {number} randomId - The random ID associated with group of responses.
+ */
+function showResponse(tabClicked, randomId) {
+  let tabs = document.getElementById(randomId).children;
+  let responses = document.querySelectorAll(`[data-id="${randomId}"]`)[0].children;
+
+  for (let i = 0; i < tabs.length; i++) {
+    tabs[i].firstChild.classList.remove('active');
+  }
+
+  tabClicked.classList.add('active');
+
+  if (tabClicked.textContent === 'Example Response') {
+    responses[0].classList.remove('hide');
+    responses[1].classList.add('hide');
+  }
+  else {
+    responses[0].classList.add('hide');
+    responses[1].classList.remove('hide');
+
+    window.responseDiv = responses[1];
+    makeRequest(tabClicked);
+  }
+}

--- a/static/js/request_button.js
+++ b/static/js/request_button.js
@@ -97,7 +97,7 @@ function makeRequest(liveResponseTab) {
  * @param {HTMLElement} tabClicked - The tab clicked, either the example response or the live response.
  * @param {number} randomId - The random ID associated with group of responses.
  */
-function showResponse(tabClicked, randomId) {
+function showTab(tabClicked, randomId) {
   let tabs = document.getElementById(randomId).children;
   let responses = document.querySelectorAll(`[data-id="${randomId}"]`)[0].children;
 

--- a/static/js/request_button.js
+++ b/static/js/request_button.js
@@ -107,15 +107,15 @@ function showResponse(tabClicked, randomId) {
 
   tabClicked.classList.add('active');
 
-  if (tabClicked.textContent === 'Example Response') {
-    responses[0].classList.remove('hide');
-    responses[1].classList.add('hide');
-  }
-  else {
-    responses[0].classList.add('hide');
-    responses[1].classList.remove('hide');
-
-    window.responseDiv = responses[1];
-    makeRequest(tabClicked);
+  for (let i = 0; i < responses.length; i++) {
+    if (responses[i].dataset.content === tabClicked.dataset.tab) {
+      if (responses[i].dataset.content === 'live-response-tab') {
+        window.responseDiv = responses[i];
+      }
+      responses[i].classList.remove('hide');
+    }
+    else {
+      responses[i].classList.add('hide');
+    }
   }
 }


### PR DESCRIPTION
Description
----
Added tabs to the examples on metadata and on the Device resource. Clicking the live response tab fires a request and displays the result. The example requests have been replaced with cURL commands. 

PR Checklist
----
- [ ] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.
