### PR TITLE
Encounter r4 Custom-Attribute Extension Terminology Binding Update

### DIFF
--- a/content/millennium/r4/proprietary-codes-and-systems.md
+++ b/content/millennium/r4/proprietary-codes-and-systems.md
@@ -100,6 +100,7 @@ The Encounter Resource supports proprietary codes for:
 * Encounter.hospitalization.dietPreference codes are maintained in [Code Set 18 Diet](#code-set-18-diet)
 * Encounter.hospitalization.specialCourtesy codes are maintained in [Code Set 67 VIP](#code-set-67-vip) and [Code Set 16 Courtesy](#code-set-16-courtesy)
 * Encounter.hospitalization.dischargeDisposition codes are maintained in [Code Set 19 Discharge Disposition](#code-set-19-discharge-disposition)
+* Custom Attribute extensions on Encounter may contain Custom Attribute Value codes. These codes may be from [any Code Set](#list-of-code-sets)
 
 ### Entities
 
@@ -199,7 +200,7 @@ The Appointment Resource supports proprietary codes for:
 
 * Appointment.participant.type codes are maintained in [Code Set 14250 Scheduling Resource Roles](#code-set-14250-scheduling-resource-roles)
 
-### List of Code Sets
+#### List of Code Sets
 
 ##### Code Set 2 Admission Source
 

--- a/content/millennium/r4/proprietary-codes-and-systems.md
+++ b/content/millennium/r4/proprietary-codes-and-systems.md
@@ -716,17 +716,6 @@ This code set includes the statuses that reflect the current status of a corresp
       "userSelected": true
     }
 
-#### Code Set Nomenclature
-
-This code set contains all nomenclature values configured in the domain.
-
-    {
-      "system": "https://fhir.cerner.com/<EHR source id>/nomenclature,
-      "code": "19177939",
-      "display": "Delivered",
-      "userSelected": false,
-    }
-
 ## Proprietary Systems
 
 ### Overview
@@ -782,4 +771,15 @@ This system is the synonym id for an order and the ingredients.
       'code': '2762111',
       'display': 'lidocaine topical',
       'userSelected': true
+    }
+
+##### Nomenclature
+
+This system contains all nomenclature values configured in the domain.
+
+    {
+      "system": "https://fhir.cerner.com/{tenant}/nomenclature",
+      "code": " 4573",
+      "display": "Appointment type test",
+      "userSelected": false
     }

--- a/content/millennium/r4/proprietary-codes-and-systems.md
+++ b/content/millennium/r4/proprietary-codes-and-systems.md
@@ -778,8 +778,8 @@ This system is the synonym id for an order and the ingredients.
 This system contains all nomenclature values configured in the domain.
 
     {
-      "system": "https://fhir.cerner.com/{tenant}/nomenclature",
-      "code": " 4573",
-      "display": "Appointment type test",
-      "userSelected": false
+      'system': 'https://fhir.cerner.com/ec2458f2-1e24-41c8-b71b-0e701af7583d/nomenclature',
+      'code': '13249579',
+      'display': 'Tension-type headache',
+      'userSelected': false
     }

--- a/content/millennium/r4/proprietary-codes-and-systems.md
+++ b/content/millennium/r4/proprietary-codes-and-systems.md
@@ -200,7 +200,7 @@ The Appointment Resource supports proprietary codes for:
 
 * Appointment.participant.type codes are maintained in [Code Set 14250 Scheduling Resource Roles](#code-set-14250-scheduling-resource-roles)
 
-#### List of Code Sets
+### List of Code Sets
 
 ##### Code Set 2 Admission Source
 

--- a/content/millennium/r4/proprietary-codes-and-systems.md
+++ b/content/millennium/r4/proprietary-codes-and-systems.md
@@ -100,7 +100,7 @@ The Encounter Resource supports proprietary codes for:
 * Encounter.hospitalization.dietPreference codes are maintained in [Code Set 18 Diet](#code-set-18-diet)
 * Encounter.hospitalization.specialCourtesy codes are maintained in [Code Set 67 VIP](#code-set-67-vip) and [Code Set 16 Courtesy](#code-set-16-courtesy)
 * Encounter.hospitalization.dischargeDisposition codes are maintained in [Code Set 19 Discharge Disposition](#code-set-19-discharge-disposition)
-* Custom Attribute extensions on Encounter may contain Custom Attribute Value codes. These codes may be from [any Code Set](#list-of-code-sets)
+* Custom Attribute extensions on Encounter may contain Custom Attribute Value codes when Custom Attribute Value is of type CodeableConcept. These codes may be from [any Code Set](#list-of-code-sets)
 
 ### Entities
 

--- a/content/millennium/r4/proprietary-codes-and-systems.md
+++ b/content/millennium/r4/proprietary-codes-and-systems.md
@@ -716,6 +716,17 @@ This code set includes the statuses that reflect the current status of a corresp
       "userSelected": true
     }
 
+#### Code Set Nomenclature
+
+This code set contains all nomenclature values configured in the domain.
+
+    {
+      "system": "https://fhir.cerner.com/<EHR source id>/nomenclature,
+      "code": "19177939",
+      "display": "Delivered",
+      "userSelected": false,
+    }
+
 ## Proprietary Systems
 
 ### Overview

--- a/lib/resources/example_json/r4_examples_encounter.rb
+++ b/lib/resources/example_json/r4_examples_encounter.rb
@@ -23,16 +23,16 @@ module Cerner
         {
           "url": "https://fhir-ehr.cerner.com/r4/StructureDefinition/custom-attribute",
           "extension": [
-              {
-                "url": "custom-attribute-name",
-                "id": "ENCNTR:3339152",
-                "valueString": "Self-Pay Follow Up Date"
-              },
-              {
-                "url": "custom-attribute-value",
-                "valueDateTime": "2020-07-03T12:00:00.000Z"
-              }
-            ]
+            {
+              "id": "ENCNTR:17368048",
+              "url": "custom-attribute-name",
+              "valueString": "Full Reg Date/Time"
+            },
+            {
+              "url": "custom-attribute-value",
+              "valueDateTime": "2020-03-04T18:12:22.000Z"
+            }
+          ]
         },
         {
           "url": "https://fhir-ehr.cerner.com/r4/StructureDefinition/client-organization",

--- a/lib/resources/example_json/r4_examples_encounter.rb
+++ b/lib/resources/example_json/r4_examples_encounter.rb
@@ -19,7 +19,27 @@ module Cerner
                '</b>: Jan  7, 2020  6:00 A.M. UTC</p><p><b>Reason For Visit</b>: Illness</p><p><b>Attending '\
                'Physician</b>: Cerner Test, Physician - Hospitalist Cerner</p></div>'
       },
-      'extension': [
+      "extension": [
+        {
+          "url": "https://fhir-ehr.cerner.com/r4/StructureDefinition/custom-attribute",
+          "extension": [
+              {
+                "url": "custom-attribute-name",
+                "id": "ENCNTR:3339152",
+                "valueString": "Self-Pay Follow Up Date"
+              },
+              {
+                "url": "custom-attribute-value",
+                "valueDateTime": "2020-07-03T12:00:00.000Z"
+              }
+            ]
+        },
+        {
+          "url": "https://fhir-ehr.cerner.com/r4/StructureDefinition/client-organization",
+          "valueReference": {
+            "reference": "Organization/675844"
+          }
+        },
         {
           'extension': [
             {

--- a/lib/resources/example_json/r4_examples_encounter.rb
+++ b/lib/resources/example_json/r4_examples_encounter.rb
@@ -21,34 +21,38 @@ module Cerner
       },
       'extension': [
         {
-          'url': 'https://fhir-ehr.cerner.com/r4/StructureDefinition/custom-attribute',
           'extension': [
             {
-              'id': 'ENCNTR:17368048',
-              'url': 'custom-attribute-name',
-              'valueString': 'Full Reg Date/Time'
-            },
-            {
-              'url': 'custom-attribute-value',
-              'valueDateTime': '2020-03-04T18:12:22.000Z'
-            }
-          ]
-        },
-        {
-          'url': 'https://fhir-ehr.cerner.com/r4/StructureDefinition/client-organization',
-          'valueReference': {
-            'reference': 'Organization/675844'
-          }
-        },
-        {
-          'extension': [
-            {
-              'id': 'ENCNTR:17368048',
-              'valueString': 'Full Reg Date/Time',
+              'id': 'ENCNTR:2572582111',
+              'valueString': 'Date Purchased',
               'url': 'custom-attribute-name'
             },
             {
-              'valueDateTime': '2020-03-04T18:12:22.000Z',
+              'valueDateTime': '2020-04-25T05:00:00.000Z',
+              'url': 'custom-attribute-value'
+            }
+          ],
+          'url': 'https://fhir-ehr.cerner.com/r4/StructureDefinition/custom-attribute'
+        },
+        {
+          'extension': [
+            {
+              'id': 'ENCNTR:2572582103',
+              'valueString': 'Driving Dx',
+              'url': 'custom-attribute-name'
+            },
+            {
+              'valueCodeableConcept': {
+                'coding': [
+                  {
+                    'system': 'https://fhir.cerner.com/ec2458f2-1e24-41c8-b71b-0e701af7583d/nomenclature',
+                    'code': '13249579',
+                    'display': 'Tension-type headache',
+                    'userSelected': false
+                  }
+                ],
+                'text': 'Tension-type headache'
+              },
               'url': 'custom-attribute-value'
             }
           ],

--- a/lib/resources/example_json/r4_examples_encounter.rb
+++ b/lib/resources/example_json/r4_examples_encounter.rb
@@ -23,12 +23,12 @@ module Cerner
         {
           'extension': [
             {
-              'id': 'ENCNTR:2572582111',
-              'valueString': 'Date Purchased',
+              'id': 'ENCNTR:17368048',
+              'valueString': 'Full Reg Date/Time',
               'url': 'custom-attribute-name'
             },
             {
-              'valueDateTime': '2020-04-25T05:00:00.000Z',
+              'valueDateTime': '2019-12-26T15:41:52.000Z',
               'url': 'custom-attribute-value'
             }
           ],
@@ -46,12 +46,12 @@ module Cerner
                 'coding': [
                   {
                     'system': 'https://fhir.cerner.com/ec2458f2-1e24-41c8-b71b-0e701af7583d/nomenclature',
-                    'code': '13249579',
-                    'display': 'Tension-type headache',
+                    'code': '13249728',
+                    'display': 'Primary stabbing headache',
                     'userSelected': false
                   }
                 ],
-                'text': 'Tension-type headache'
+                'text': 'Primary stabbing headache'
               },
               'url': 'custom-attribute-value'
             }

--- a/lib/resources/example_json/r4_examples_encounter.rb
+++ b/lib/resources/example_json/r4_examples_encounter.rb
@@ -7,8 +7,8 @@ module Cerner
       'resourceType': 'Encounter',
       'id': '97939518',
       'meta': {
-        'versionId': '0',
-        'lastUpdated': '2020-01-07T06:00:00.000Z'
+        'versionId': '1',
+        'lastUpdated': '2020-10-02T00:08:17.000Z'
       },
       'text': {
         'status': 'generated',

--- a/lib/resources/example_json/r4_examples_encounter.rb
+++ b/lib/resources/example_json/r4_examples_encounter.rb
@@ -19,7 +19,7 @@ module Cerner
                '</b>: Jan  7, 2020  6:00 A.M. UTC</p><p><b>Reason For Visit</b>: Illness</p><p><b>Attending '\
                'Physician</b>: Cerner Test, Physician - Hospitalist Cerner</p></div>'
       },
-        'extension': [
+      'extension': [
         {
           'url': 'https://fhir-ehr.cerner.com/r4/StructureDefinition/custom-attribute',
           'extension': [
@@ -37,7 +37,7 @@ module Cerner
         {
           'url': 'https://fhir-ehr.cerner.com/r4/StructureDefinition/client-organization',
           'valueReference': {
-              'reference': 'Organization/675844'
+            'reference': 'Organization/675844'
           }
         },
         {

--- a/lib/resources/example_json/r4_examples_encounter.rb
+++ b/lib/resources/example_json/r4_examples_encounter.rb
@@ -19,25 +19,25 @@ module Cerner
                '</b>: Jan  7, 2020  6:00 A.M. UTC</p><p><b>Reason For Visit</b>: Illness</p><p><b>Attending '\
                'Physician</b>: Cerner Test, Physician - Hospitalist Cerner</p></div>'
       },
-      "extension": [
+        'extension': [
         {
-          "url": "https://fhir-ehr.cerner.com/r4/StructureDefinition/custom-attribute",
-          "extension": [
+          'url': 'https://fhir-ehr.cerner.com/r4/StructureDefinition/custom-attribute',
+          'extension': [
             {
-              "id": "ENCNTR:17368048",
-              "url": "custom-attribute-name",
-              "valueString": "Full Reg Date/Time"
+              'id': 'ENCNTR:17368048',
+              'url': 'custom-attribute-name',
+              'valueString': 'Full Reg Date/Time'
             },
             {
-              "url": "custom-attribute-value",
-              "valueDateTime": "2020-03-04T18:12:22.000Z"
+              'url': 'custom-attribute-value',
+              'valueDateTime': '2020-03-04T18:12:22.000Z'
             }
           ]
         },
         {
-          "url": "https://fhir-ehr.cerner.com/r4/StructureDefinition/client-organization",
-          "valueReference": {
-            "reference": "Organization/675844"
+          'url': 'https://fhir-ehr.cerner.com/r4/StructureDefinition/client-organization',
+          'valueReference': {
+              'reference': 'Organization/675844'
           }
         },
         {

--- a/lib/resources/r4/encounter.yaml
+++ b/lib/resources/r4/encounter.yaml
@@ -388,6 +388,7 @@ fields:
       }
     }
   note: Only the admitSource and dischargeDisposition fields are supported on write.
+
   children:
 
   - name: admitSource
@@ -551,14 +552,13 @@ fields:
   url: https://fhir.cerner.com/millennium/r4/encounters/encounter/#extensions
   terminology_name: extension[x].extension[x].valueCodeableConcept
   type: CodeableConcept
+  note: The value of the custom attribute is not limited to a single codeSet.
   description: The value of the client defined custom attribute. This extension is nested under a <code>custom-attribute</code> extension.
-  note:
-    - The value of the custom attribute is not limited to a single codeSet.
   binding:
     description: The value of the client defined custom attribute. This binding is used for the <code>custom-attribute-value</code> extension nested under <code>customm-attribute</code> extensions.
     terminology:
       - display: Custom Attribute Value
-        system: https://fhir.cerner.com/&lt;EHR source id&gt;/codeSet/&lt;codeSet&gt;
+        system: https://fhir.cerner.com/&lt;EHR source id&gt;/codeSet/x&lt;codeSet&gt;/
         info_link: https://fhir.cerner.com/millennium/r4/proprietary-codes-and-systems/#proprietary-codes
 
 - name: Estimated Financial Responsibility Amount Extension

--- a/lib/resources/r4/encounter.yaml
+++ b/lib/resources/r4/encounter.yaml
@@ -552,12 +552,14 @@ fields:
   terminology_name: extension[x].extension[x].valueCodeableConcept
   type: CodeableConcept
   description: The value of the client defined custom attribute. This extension is nested under a <code>custom-attribute</code> extension.
+  note:
+    - The value of the custom attribute is not limited to a single codeSet.
   binding:
     description: The value of the client defined custom attribute. This binding is used for the <code>custom-attribute-value</code> extension nested under <code>customm-attribute</code> extensions.
     terminology:
       - display: Custom Attribute Value
-        system: https://fhir.cerner.com/&lt;EHR source id&gt;/codeSet/<code-set>
-        info_link: https://fhir.cerner.com/millennium/r4/proprietary-codes-and-systems/#<code-set>
+        system: https://fhir.cerner.com/&lt;EHR source id&gt;/codeSet/&lt;codeSet&gt;
+        info_link: https://fhir.cerner.com/millennium/r4/proprietary-codes-and-systems/#proprietary-codes
 
 - name: Estimated Financial Responsibility Amount Extension
   url: https://fhir.cerner.com/millennium/r4/encounters/encounter/#extensions

--- a/lib/resources/r4/encounter.yaml
+++ b/lib/resources/r4/encounter.yaml
@@ -547,6 +547,18 @@ fields:
         info_link: http://hl7.org/fhir/r4/v3/ObservationValue/cs.html
     note: Encounters created with meta.security set with code 'UNCERTREL' will be returned with an external encounter type.
 
+- name: Custom Attribute Extension
+  url: https://fhir.cerner.com/millennium/r4/encounters/encounter/#extensions
+  terminology_name: extension[x].extension[x].valueCodeableConcept
+  type: CodeableConcept
+  description: The value of the client defined custom attribute. This extension is nested under a <code>custom-attribute</code> extension.
+  binding:
+    description: The value of the client defined custom attribute. This binding is used for the <code>custom-attribute-value</code> extension nested under <code>customm-attribute</code> extensions.
+    terminology:
+      - display: Custom Attribute Value
+        system: https://fhir.cerner.com/&lt;EHR source id&gt;/codeSet/<code-set>
+        info_link: https://fhir.cerner.com/millennium/r4/proprietary-codes-and-systems/#<code-set>
+
 - name: Estimated Financial Responsibility Amount Extension
   url: https://fhir.cerner.com/millennium/r4/encounters/encounter/#extensions
   terminology_name: extension[x].valueMoney.currency

--- a/lib/resources/r4/encounter.yaml
+++ b/lib/resources/r4/encounter.yaml
@@ -265,7 +265,6 @@ fields:
         }
       ]
     }
-
   children:
 
   - name: type
@@ -388,7 +387,6 @@ fields:
       }
     }
   note: Only the admitSource and dischargeDisposition fields are supported on write.
-
   children:
 
   - name: admitSource
@@ -552,13 +550,13 @@ fields:
   url: https://fhir.cerner.com/millennium/r4/encounters/encounter/#extensions
   terminology_name: extension[x].extension[x].valueCodeableConcept
   type: CodeableConcept
-  note: The value of the custom attribute is not limited to a single codeSet.
   description: The value of the client defined custom attribute. This extension is nested under a <code>custom-attribute</code> extension.
   binding:
     description: The value of the client defined custom attribute. This binding is used for the <code>custom-attribute-value</code> extension nested under <code>customm-attribute</code> extensions.
+    note: The value of the custom attribute is not limited to a single codeSet.
     terminology:
       - display: Custom Attribute Value
-        system: https://fhir.cerner.com/&lt;EHR source id&gt;/codeSet/x&lt;codeSet&gt;/
+        system: https://fhir.cerner.com/&lt;EHR source id&gt;/codeSet/&lt;codeSet&gt;
         info_link: https://fhir.cerner.com/millennium/r4/proprietary-codes-and-systems/#proprietary-codes
 
 - name: Estimated Financial Responsibility Amount Extension

--- a/lib/resources/r4/encounter.yaml
+++ b/lib/resources/r4/encounter.yaml
@@ -554,7 +554,7 @@ fields:
   description: The value of the client defined custom attribute. This extension is nested under a <code>custom-attribute</code> extension.
   action: terminology
   binding:
-    description: The value of the client defined custom attribute. This binding is used for the <code>custom-attribute-value</code> extension nested under <code>customm-attribute</code> extensions.
+    description: The value of the client defined custom attribute. This binding is used for the <code>custom-attribute-value</code> extension nested under <code>custom-attribute</code> extensions.
     terminology:
       - display: Custom Attribute Code Value
         system: https://fhir.cerner.com/&lt;EHR source id&gt;/codeSet/&lt;code set&gt;
@@ -565,7 +565,7 @@ fields:
     note: >
       <ul>
         <li>The terminology binding only applies when the <code>custom-attribute-value</code> extension is of type <code>CodeableConcept</code>.</li>
-        <li>The value of the custom attribute is not limited to a single codeSet.</li>
+        <li>The value of the custom attribute is not limited to a single Code Set or nomenclature.</li>
       </ul>
 
 - name: Estimated Financial Responsibility Amount Extension

--- a/lib/resources/r4/encounter.yaml
+++ b/lib/resources/r4/encounter.yaml
@@ -556,8 +556,11 @@ fields:
   binding:
     description: The value of the client defined custom attribute. This binding is used for the <code>custom-attribute-value</code> extension nested under <code>customm-attribute</code> extensions.
     terminology:
-      - display: Custom Attribute Value
+      - display: Custom Attribute Code Value
         system: https://fhir.cerner.com/&lt;EHR source id&gt;/codeSet/&lt;code set&gt;
+        info_link: https://fhir.cerner.com/millennium/r4/proprietary-codes-and-systems/#proprietary-codes
+      - display: Custom Attribute Nomenclature Value
+        system: https://fhir.cerner.com/&lt;EHR source id&gt;/nomenclature
         info_link: https://fhir.cerner.com/millennium/r4/proprietary-codes-and-systems/#proprietary-codes
     note: >
       <ul>

--- a/lib/resources/r4/encounter.yaml
+++ b/lib/resources/r4/encounter.yaml
@@ -561,7 +561,7 @@ fields:
         info_link: https://fhir.cerner.com/millennium/r4/proprietary-codes-and-systems/#proprietary-codes
       - display: Custom Attribute Nomenclature Value
         system: https://fhir.cerner.com/&lt;EHR source id&gt;/nomenclature
-        info_link: https://fhir.cerner.com/millennium/r4/proprietary-codes-and-systems/#proprietary-codes
+        info_link: https://fhir.cerner.com/millennium/r4/proprietary-codes-and-systems/#nomenclature
     note: >
       <ul>
         <li>The terminology binding only applies when the <code>custom-attribute-value</code> extension is of type <code>CodeableConcept</code>.</li>

--- a/lib/resources/r4/encounter.yaml
+++ b/lib/resources/r4/encounter.yaml
@@ -547,19 +547,23 @@ fields:
         info_link: http://hl7.org/fhir/r4/v3/ObservationValue/cs.html
     note: Encounters created with meta.security set with code 'UNCERTREL' will be returned with an external encounter type.
 
-- name: Custom Attribute Extension
-  url: https://fhir.cerner.com/millennium/r4/encounters/encounter/#extensions
+- name: Custom Attribute Value Extension
+  url: https://fhir-ehr.cerner.com/r4/StructureDefinition/custom-attribute?_format=json
   terminology_name: extension[x].extension[x].valueCodeableConcept
-  type: CodeableConcept
+  type: Extension
   description: The value of the client defined custom attribute. This extension is nested under a <code>custom-attribute</code> extension.
   action: terminology
   binding:
     description: The value of the client defined custom attribute. This binding is used for the <code>custom-attribute-value</code> extension nested under <code>customm-attribute</code> extensions.
-    note: The value of the custom attribute is not limited to a single codeSet.
     terminology:
       - display: Custom Attribute Value
         system: https://fhir.cerner.com/&lt;EHR source id&gt;/codeSet/&lt;codeSet&gt;
         info_link: https://fhir.cerner.com/millennium/r4/proprietary-codes-and-systems/#proprietary-codes
+    note: >
+      <ul>
+        <li>The terminology binding only applies when the <code>custom-attribute-value</code> extension is of type <code>CodeableConcept</code>.</li>
+        <li>The value of the custom attribute is not limited to a single codeSet.</li>
+      </ul>
 
 - name: Estimated Financial Responsibility Amount Extension
   url: https://fhir.cerner.com/millennium/r4/encounters/encounter/#extensions

--- a/lib/resources/r4/encounter.yaml
+++ b/lib/resources/r4/encounter.yaml
@@ -557,7 +557,7 @@ fields:
     description: The value of the client defined custom attribute. This binding is used for the <code>custom-attribute-value</code> extension nested under <code>customm-attribute</code> extensions.
     terminology:
       - display: Custom Attribute Value
-        system: https://fhir.cerner.com/&lt;EHR source id&gt;/codeSet/&lt;codeSet&gt;
+        system: https://fhir.cerner.com/&lt;EHR source id&gt;/codeSet/&lt;code set&gt;
         info_link: https://fhir.cerner.com/millennium/r4/proprietary-codes-and-systems/#proprietary-codes
     note: >
       <ul>

--- a/lib/resources/r4/encounter.yaml
+++ b/lib/resources/r4/encounter.yaml
@@ -265,6 +265,7 @@ fields:
         }
       ]
     }
+
   children:
 
   - name: type
@@ -551,6 +552,7 @@ fields:
   terminology_name: extension[x].extension[x].valueCodeableConcept
   type: CodeableConcept
   description: The value of the client defined custom attribute. This extension is nested under a <code>custom-attribute</code> extension.
+  action: terminology
   binding:
     description: The value of the client defined custom attribute. This binding is used for the <code>custom-attribute-value</code> extension nested under <code>customm-attribute</code> extensions.
     note: The value of the custom attribute is not limited to a single codeSet.


### PR DESCRIPTION
Description
----
Updating the encounter resource to include the custom-attribute extension terminology binding information.
This PR is a follow-up to these fhir.cerner.com updates found here: https://github.com/cerner/fhir.cerner.com/pull/471

Screenshots before changes merged
----
<img width="683" alt="Screen Shot 2020-09-29 at 2 21 01 PM" src="https://user-images.githubusercontent.com/62904679/94606119-a21eac80-025f-11eb-9172-f02437281a9b.png">
<img width="678" alt="Screen Shot 2020-10-02 at 8 48 44 AM" src="https://user-images.githubusercontent.com/62904679/94930543-2f464900-048c-11eb-8ac7-8769687e7211.png">
<img width="641" alt="Screen Shot 2020-09-29 at 2 22 37 PM" src="https://user-images.githubusercontent.com/62904679/94606147-ad71d800-025f-11eb-94fc-65aac5510dd7.png">
<img width="705" alt="Screen Shot 2020-09-29 at 2 23 21 PM" src="https://user-images.githubusercontent.com/62904679/94606199-bc588a80-025f-11eb-988a-b62b228cc102.png">

PR Checklist
----
- [x] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.
