### PR TITLE
Add Patient to Authorization Types of search and retrieve for R4 Prac…

### DIFF
--- a/content/millennium/r4/individuals/practitioner.md
+++ b/content/millennium/r4/individuals/practitioner.md
@@ -18,7 +18,7 @@ The following fields are returned if valued:
 * [Active (true/false)](https://hl7.org/fhir/r4/practitioner-definitions.html#Practitioner.active){:target="_blank"}
 * [Name](https://hl7.org/fhir/r4/practitioner-definitions.html#Practitioner.name){:target="_blank"}
 * [Telecom Information (secure email and phone)](https://hl7.org/fhir/r4/practitioner-definitions.html#Practitioner.telecom){:target="_blank"}
-* [Address](https://hl7.org/fhir/r4/practitioner-definitions.html#Practitioner.address){:target="_blank"}
+* [Address (Provider and System Authorization Only)](https://hl7.org/fhir/r4/practitioner-definitions.html#Practitioner.address){:target="_blank"}
 * [Gender](https://hl7.org/fhir/r4/practitioner-definitions.html#Practitioner.gender){:target="_blank"}
 
 ## Terminology Bindings

--- a/content/millennium/r4/individuals/practitioner.md
+++ b/content/millennium/r4/individuals/practitioner.md
@@ -33,7 +33,7 @@ Search for Practitioners that meet supplied query parameters:
 
 ### Authorization Types
 
-<%= authorization_types(provider: true, patient: false, system: true) %>
+<%= authorization_types(provider: true, patient: true, system: true) %>
 
 ### Parameters
 
@@ -73,7 +73,7 @@ List an individual Practitioner by its id:
 
 ### Authorization Types
 
-<%= authorization_types(provider: true, patient: false, system: true) %>
+<%= authorization_types(provider: true, patient: true, system: true) %>
 
 ### Headers
 


### PR DESCRIPTION
Description
----
Add Patient to the Authorization Types for Search and Retrieve by Id for Practitioner in R4

Validation
----
<img width="651" alt="retrieve_patient_access" src="https://user-images.githubusercontent.com/18171913/90674127-50294680-e21e-11ea-95ad-50b8de9a4ee1.png">

<img width="662" alt="search_patient_access" src="https://user-images.githubusercontent.com/18171913/90674150-53bccd80-e21e-11ea-9501-a0ea7eb62978.png">

__UPDATE__
Validation for mention that Address is only available for Provider and System access
<img width="685" alt="Screen Shot 2020-08-24 at 8 18 00 AM" src="https://user-images.githubusercontent.com/18171913/91051279-85021880-e5e5-11ea-92fc-fd35cdc94cbc.png">


PR Checklist
----
- [x] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.
