### PR TITLE
R4 Practitioner add patient access sample urls

### DIFF
--- a/content/millennium/r4/individuals/practitioner.md
+++ b/content/millennium/r4/individuals/practitioner.md
@@ -54,12 +54,21 @@ Search for Practitioners that meet supplied query parameters:
 
 #### Request
 
-    GET https://fhir-open.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/Practitioner?_id=4122622
+    GET https://fhir-open.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/Practitioner?_id=109413936
 
 #### Response
 
 <%= headers status: 200 %>
 <%= json(:r4_practitioner_bundle) %>
+
+#### Patient Authorization Request
+
+    GET https://fhir-myrecord.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/Practitioner?_id=109413936
+
+#### Response
+
+<%= headers status: 200 %>
+<%= json(:r4_practitioner_patient_access_bundle) %>
 
 ### Errors
 
@@ -89,6 +98,15 @@ List an individual Practitioner by its id:
 
 <%= headers status: 200 %>
 <%= json(:r4_practitioner_entry) %>
+
+#### Patient Authorization Request
+
+    GET https://fhir-myrecord.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/Practitioner/109413936
+
+#### Response
+
+<%= headers status: 200 %>
+<%= json(:r4_practitioner_patient_access_entry) %>
 
 ### Errors
 

--- a/lib/resources/example_json/r4_examples_practitioner.rb
+++ b/lib/resources/example_json/r4_examples_practitioner.rb
@@ -5,16 +5,16 @@ module Cerner
 
     R4_PRACTITIONER_ENTRY ||= {
       'resourceType': 'Practitioner',
-      'id': '4122622',
+      'id': '109413936',
       'meta': {
-        'versionId': '18',
-        'lastUpdated': '2016-04-28T15:01:59.000Z'
+        'versionId': '0',
+        'lastUpdated': '2019-03-07T20:40:34.000Z'
       },
       'text': {
         'status': 'generated',
-        'div': '<div xmlns="http://www.w3.org/1999/xhtml"><p><b>Practitioner</b></p><p><b>Name</b>: Cerner Test, '\
-               'Physician - Hospitalist Cerner</p><p><b>Identifiers</b>: MESSAGING: 4122622, EXTERNALID: '\
-               'CERNERPHYSHOSP, NPI: 1111111111</p><p><b>Status</b>: Active</p></div>'
+        'div': '<div xmlns=\'http://www.w3.org/1999/xhtml\'><p><b>Practitioner</b></p><p><b>Name</b>: Lombardi, '\
+        'Falco Shine</p><p><b>Identifiers</b>: DOCUPIN: F88788, DOCDEA: 887887887, SPI: 16611661, NPI: 6656656, '\
+        'PRSNLPRIMID: 12332122</p><p><b>Gender</b>: Male</p><p><b>Status</b>: Active</p></div>'
       },
       'identifier': [
         {
@@ -23,11 +23,11 @@ module Cerner
             'coding': [
               {
                 'system': 'http://terminology.hl7.org/CodeSystem/v2-0203',
-                'code': 'U',
-                'display': 'Unspecified identifier'
+                'code': 'PRN',
+                'display': 'Provider number'
               }
             ],
-            'text': 'Messaging'
+            'text': 'DOCUPIN'
           },
           '_system': {
             'extension': [
@@ -37,27 +37,45 @@ module Cerner
               }
             ]
           },
-          'value': '4122622',
+          'value': 'F88788',
           'period': {
-            'start': '2015-08-18T05:00:00.000Z'
+            'start': '2019-03-07T20:40:35.000Z'
           }
         },
         {
           'use': 'usual',
           'type': {
-            'text': 'External Identifier'
-          },
-          '_system': {
-            'extension': [
+            'coding': [
               {
-                'url': 'http://hl7.org/fhir/StructureDefinition/data-absent-reason',
-                'valueCode': 'unknown'
+                'system': 'http://terminology.hl7.org/CodeSystem/v2-0203',
+                'code': 'DEA',
+                'display': 'Drug Enforcement Administration registration number'
               }
-            ]
+            ],
+            'text': 'DOCDEA'
           },
-          'value': 'CERNERPHYSHOSP',
+          'system': 'urn:oid:2.16.840.1.113883.4.814',
+          'value': '887887887',
           'period': {
-            'start': '2016-04-28T15:01:59.000Z'
+            'start': '2019-03-07T20:40:35.000Z'
+          }
+        },
+        {
+          'use': 'usual',
+          'type': {
+            'coding': [
+              {
+                'system': 'http://terminology.hl7.org/CodeSystem/v2-0203',
+                'code': 'PRN',
+                'display': 'Provider number'
+              }
+            ],
+            'text': 'SureScripts Prescriber Index'
+          },
+          'system': 'urn:oid:2.16.840.1.113883.3.2054',
+          'value': '16611661',
+          'period': {
+            'start': '2019-04-12T18:24:23.000Z'
           }
         },
         {
@@ -72,17 +90,21 @@ module Cerner
             ],
             'text': 'National Provider Identifier'
           },
-          '_system': {
-            'extension': [
-              {
-                'url': 'http://hl7.org/fhir/StructureDefinition/data-absent-reason',
-                'valueCode': 'unknown'
-              }
-            ]
-          },
-          'value': '1111111111',
+          'system': 'http://hl7.org/fhir/sid/us-npi',
+          'value': '6656656',
           'period': {
-            'start': '2015-10-14T05:00:00.000Z'
+            'start': '2019-03-07T20:40:35.000Z'
+          }
+        },
+        {
+          'use': 'usual',
+          'type': {
+            'text': 'Personnel Primary Identifier'
+          },
+          'system': 'urn:oid:1.2.243.58',
+          'value': '12332122',
+          'period': {
+            'start': '2019-04-12T18:24:23.000Z'
           }
         }
       ],
@@ -90,34 +112,159 @@ module Cerner
       'name': [
         {
           'use': 'usual',
-          'text': 'Cerner Test, Physician - Hospitalist Cerner',
-          'family': 'Cerner Test',
+          'text': 'Lombardi, Falco Shine',
+          'family': 'Lombardi',
           'given': [
-            'Physician - Hospitalist',
-            'Cerner'
+            'Falco',
+            'Shine'
+          ],
+          'prefix': [
+            'Dr.'
+          ],
+          'suffix': [
+            'M.D.'
           ],
           'period': {
-            'start': '2016-04-28T15:01:59.000Z'
+            'start': '2019-03-07T20:40:35.000Z'
           }
         }
-      ]
+      ],
+      'telecom': [
+        {
+          'system': 'phone',
+          'value': '7861231234',
+          'use': 'work'
+        },
+        {
+          'system': 'email',
+          'value': 'falco.lombardi@sfox.com',
+          'use': 'work'
+        }
+      ],
+      'address': [
+        {
+          'use': 'work',
+          'text': '111 Corneria Dr.\nTallahassee, FL 32304\nUSA',
+          'line': [
+            '111 Corneria Dr.'
+          ],
+          'city': 'Tallahassee',
+          'district': 'Leon',
+          'state': 'FL',
+          'postalCode': '32304',
+          'country': 'USA'
+        }
+      ],
+      'gender': 'male'
+    }.freeze
+
+    R4_PRACTITIONER_PATIENT_ACCESS_ENTRY ||= {
+      'resourceType': 'Practitioner',
+      'id': '109413936',
+      'meta': {
+        'versionId': '0',
+        'lastUpdated': '2019-03-07T20:40:34.000Z'
+      },
+      'text': {
+        'status': 'generated',
+        'div': '<div xmlns=\'http://www.w3.org/1999/xhtml\'><p><b>Practitioner</b></p><p><b>Name</b>: Lombardi, '\
+        'Falco Shine</p><p><b>Identifiers</b>: SPI: 16611661, NPI: 6656656</p><p><b>Gender</b>: Male'\
+        '</p><p><b>Status</b>: Active</p></div>'
+      },
+      'identifier': [
+        {
+          'use': 'usual',
+          'type': {
+            'text': 'SureScripts Prescriber Index'
+          },
+          'system': 'urn:oid:2.16.840.1.113883.3.2054',
+          'value': '16611661',
+          'period': {
+            'start': '2019-04-12T18:24:23.000Z'
+          }
+        },
+        {
+          'use': 'usual',
+          'type': {
+            'coding': [
+              {
+                'system': 'http://terminology.hl7.org/CodeSystem/v2-0203',
+                'code': 'NPI',
+                'display': 'National provider identifier'
+              }
+            ],
+            'text': 'National Provider Identifier'
+          },
+          'system': 'http://hl7.org/fhir/sid/us-npi',
+          'value': '6656656',
+          'period': {
+            'start': '2019-03-07T20:40:35.000Z'
+          }
+        }
+      ],
+      'active': true,
+      'name': [
+        {
+          'use': 'usual',
+          'text': 'Lombardi, Falco Shine',
+          'family': 'Lombardi',
+          'given': [
+            'Falco',
+            'Shine'
+          ],
+          'prefix': [
+            'Dr.'
+          ],
+          'suffix': [
+            'M.D.'
+          ],
+          'period': {
+            'start': '2019-03-07T20:40:35.000Z'
+          }
+        }
+      ],
+      'telecom': [
+        {
+          'value': 'falco.lombardi@sfox.com'
+        }
+      ],
+      'gender': 'male'
     }.freeze
 
     R4_PRACTITIONER_BUNDLE ||= {
       'resourceType': 'Bundle',
-      'id': '129834f7-c7d2-4d34-b247-97ebb3e42b4d',
+      'id': '7ec264d2-c7c7-49b2-8478-22351c82db73',
       'type': 'searchset',
       'total': 1,
       'link': [
         {
           'relation': 'self',
-          'url': 'https://fhir-open.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/Practitioner?_id=4122622'
+          'url': 'https://fhir-open.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/Practitioner?_id=109413936'
         }
       ],
       'entry': [
         {
-          'fullUrl': 'https://fhir-open.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/Practitioner/4122622',
+          'fullUrl': 'https://fhir-open.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/Practitioner/109413936',
           'resource': R4_PRACTITIONER_ENTRY
+        }
+      ]
+    }.freeze
+
+    R4_PRACTITIONER_PATIENT_ACCESS_BUNDLE ||= {
+      'resourceType': 'Bundle',
+      'id': '13230afb-0bbd-45a6-a7c9-9c6d286a2f4c',
+      'type': 'searchset',
+      'total': 1,
+      'link': [
+        {
+          'relation': 'self',
+          'url': 'https://fhir-myrecord.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/Practitioner?_id=109413936'
+        }
+      ],
+      'entry': [
+        {
+          'fullUrl': 'https://fhir-myrecord.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/Practitioner/109413936',
+          'resource': R4_PRACTITIONER_PATIENT_ACCESS_ENTRY
         }
       ]
     }.freeze


### PR DESCRIPTION
Description
----
Add sample url calls to search and retrieve by id of R4 Practitioner to showcase Patient Access response. In addition, update previous examples to show more fields in the response to better differentiate between Provider, System access and Patient access.

Validatoin
----
Search:
<img width="663" alt="Search_Example" src="https://user-images.githubusercontent.com/18171913/91475569-61e39d00-e861-11ea-971d-9d1495e18b27.png">
<img width="587" alt="Search_Example_Patient_Access" src="https://user-images.githubusercontent.com/18171913/91475573-6445f700-e861-11ea-86c9-82da2388c907.png">

Retrieve by Id
<img width="565" alt="Read_Example" src="https://user-images.githubusercontent.com/18171913/91475589-69a34180-e861-11ea-8011-16990eec81fe.png">
<img width="559" alt="Read_Example_Patient_Access" src="https://user-images.githubusercontent.com/18171913/91475614-7031b900-e861-11ea-8ef0-68cd48de8fac.png">


PR Checklist
----
- [x] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.
