### PR TITLE
Appointment Patch URL Length Limit Notes

### DIFF
--- a/content/millennium/r4/scheduling/appointment.md
+++ b/content/millennium/r4/scheduling/appointment.md
@@ -322,6 +322,7 @@ The common [errors] and [OperationOutcomes] may be returned.
 
 In addition, the following errors may be returned:
 
+* If either the patient URL or the provider URLs are longer than 255 characters, it will return a `422 Unprocessable Entity` response.
 * Updating an Appointment resource with the incorrect version will result in a `409 Conflict` response.
 * Updating an Appointment resource without sending the `If-Match` header will result in a `412 Precondition Failed` response.
 * Updating an Appointment resource which is currently being modified will result in a `423 Locked` response.

--- a/lib/resources/r4/appointment_patch.yaml
+++ b/lib/resources/r4/appointment_patch.yaml
@@ -79,6 +79,7 @@ operations:
       <ul>
         <li>This patch operation may be used only for Video Visit appointments</li>
         <li>This patch operation must be accompanied by all other Video Visit link patch operations with an op of add</li>
+        <li>The URL length must be less than or equal to 255 characters</li>
       </ul>
   - name: add-patient-vmr
     path: /contained/1/telecom/0/value
@@ -96,6 +97,7 @@ operations:
       <ul>
         <li>This patch operation may be used only for Video Visit appointments</li>
         <li>This patch operation must be accompanied by all other Video Visit link patch operations with an op of add</li>
+        <li>The URL length must be less than or equal to 255 characters</li>
       </ul>
   - name: add-period-start
     path: /contained/0/telecom/0/period/start
@@ -114,6 +116,7 @@ operations:
         <li>This patch operation may be used only for Video Visit appointments</li>
         <li>The value for this patch operation will be applied to both the provider Video Visit link and the patient Video Visit link</li>
         <li>This patch operation must be accompanied by all other Video Visit link patch operations with an op of add</li>
+        <li>The URL length must be less than or equal to 255 characters</li>
       </ul>
   - name: add-period-end
     path: /contained/0/telecom/0/period/end
@@ -132,6 +135,7 @@ operations:
         <li>This patch operation may be used only for Video Visit appointments</li>
         <li>The value for this patch operation will be applied to both the provider Video Visit link and the patient Video Visit link</li>
         <li>This patch operation must be accompanied by all other Video Visit link patch operations with an op of add</li>
+        <li>The URL length must be less than or equal to 255 characters</li>
       </ul>
   - name: replace-provider-vmr
     path: /contained/0/telecom/0/value


### PR DESCRIPTION
Description
----
It was discovered that the Cerner Video's database for appointments requires all strings to be 255 characters or less. This was tested via Postman calls to Cerner Video's code and to FHIR through PATCH requests. FHIR code will be modified to return a 422 response in this case.


Before Change
----
Add Patch
<img width="777" alt="Screen Shot 2020-08-04 at 5 28 07 PM" src="https://user-images.githubusercontent.com/45053146/89351564-e33b7b80-d677-11ea-926b-570b44b5ca76.png">

Replace Patch
<img width="777" alt="Screen Shot 2020-08-04 at 5 28 00 PM" src="https://user-images.githubusercontent.com/45053146/89351568-e59dd580-d677-11ea-83fc-02dbcdba8108.png">

Potential Errors
<img width="777" alt="Screen Shot 2020-08-04 at 5 27 52 PM" src="https://user-images.githubusercontent.com/45053146/89351576-e7679900-d677-11ea-84f9-4ed95f64be0c.png">

After Change
----
Add Patch
<img width="777" alt="Screen Shot 2020-08-04 at 5 13 07 PM" src="https://user-images.githubusercontent.com/45053146/89351654-1120c000-d678-11ea-9e34-efd7d58c0f17.png">

Replace Patch
<img width="777" alt="Screen Shot 2020-08-04 at 5 13 14 PM" src="https://user-images.githubusercontent.com/45053146/89351646-0cf4a280-d678-11ea-9cd6-4d43fc6f4d28.png">

Potential Errors
<img width="702" alt="Screen Shot 2020-08-11 at 3 58 36 PM" src="https://user-images.githubusercontent.com/45053146/89948439-c0ffab80-dbeb-11ea-8f3b-4defca7de303.png">




PR Checklist
----
- [x] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.
