### PR TITLE
fhir documention update for financial transaction

### DIFF
--- a/content/millennium/r4/financial/financial-transaction.md
+++ b/content/millennium/r4/financial/financial-transaction.md
@@ -39,7 +39,7 @@ All URLs for custom extensions are defined as `https://fhir-ehr.cerner.com/r4/St
  `financial-transaction-allocation`      | None (contains nested extensions) | Defines how the payment or adjustment is to be allocated across other resources.
  `financial-transaction-amount`          | [`Money`]                         | The total amount of the financial transaction.
  `financial-transaction-card-brand`      | [`string`]                        | Identifies the brand of credit card when credit card is used as a payment method.
- `financial-transaction-date`            | [`date`]                          | Represents the expiration date if method is card, check date if method is check.
+ `financial-transaction-date`            | [`date`]                          | Represents the expiration date if method is card or check date if method is check.
  `financial-transaction-location`        | [`string`]                        | Client configured value representing the location or workflow that the payment was received in.
  `financial-transaction-method`          | [`string`]                        | Describes the method of payment for the financial transaction.
  `financial-transaction-tendered-amount` | [`Money`]                         | The amount of cash originally tendered for payment. This value should be greater than or equal to the amount of the cash payment.

--- a/content/millennium/r4/financial/financial-transaction.md
+++ b/content/millennium/r4/financial/financial-transaction.md
@@ -35,7 +35,7 @@ All URLs for custom extensions are defined as `https://fhir-ehr.cerner.com/r4/St
  ID                                      | Value\[x] Type                    | Description
 -----------------------------------------|-----------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------
  `financial-transaction-account-number`  | [`string`]                        | A value associated to the specific payment method usually represented as the last four digits of a credit card, the check number, the EFT number or Lockbox number.
- `financial-transaction-alias`           | [`string`]                        | Client defined value to represent the combination of the type, subtype, and reason describing the financial transaction. The alias needs to be a valid alias in the client domain for the transaction type and that the alias determines the credit or debit impact on the accounts receivable.
+ `financial-transaction-alias`           | [`string`]                        | Client defined value to represent the combination of the type, subtype, and reason describing the financial transaction.
  `financial-transaction-allocation`      | None (contains nested extensions) | Defines how the payment or adjustment is to be allocated across other resources.
  `financial-transaction-amount`          | [`Money`]                         | The total amount of the financial transaction.
  `financial-transaction-card-brand`      | [`string`]                        | Identifies the brand of credit card when credit card is used as a payment method.

--- a/content/millennium/r4/financial/financial-transaction.md
+++ b/content/millennium/r4/financial/financial-transaction.md
@@ -35,11 +35,11 @@ All URLs for custom extensions are defined as `https://fhir-ehr.cerner.com/r4/St
  ID                                      | Value\[x] Type                    | Description
 -----------------------------------------|-----------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------
  `financial-transaction-account-number`  | [`string`]                        | A value associated to the specific payment method usually represented as the last four digits of a credit card, the check number, the EFT number or Lockbox number.
- `financial-transaction-alias`           | [`string`]                        | Client defined value to represent the combination of the type, subtype, and reason describing the financial transaction.
+ `financial-transaction-alias`           | [`string`]                        | Client defined value to represent the combination of the type, subtype, and reason describing the financial transaction. The alias needs to be a valid alias in the client domain for the transaction type and that the alias determines the credit or debit impact on the accounts receivable.
  `financial-transaction-allocation`      | None (contains nested extensions) | Defines how the payment or adjustment is to be allocated across other resources.
  `financial-transaction-amount`          | [`Money`]                         | The total amount of the financial transaction.
  `financial-transaction-card-brand`      | [`string`]                        | Identifies the brand of credit card when credit card is used as a payment method.
- `financial-transaction-date`            | [`date`]                          | Represents the expiration date if method is card, check date if method is check, EFT date if method is EFT or Lockbox date if method is lockbox.
+ `financial-transaction-date`            | [`date`]                          | Represents the expiration date if method is card, check date if method is check.
  `financial-transaction-location`        | [`string`]                        | Client configured value representing the location or workflow that the payment was received in.
  `financial-transaction-method`          | [`string`]                        | Describes the method of payment for the financial transaction.
  `financial-transaction-tendered-amount` | [`Money`]                         | The amount of cash originally tendered for payment. This value should be greater than or equal to the amount of the cash payment.
@@ -54,8 +54,8 @@ Create a FinancialTransaction.
 _Implementation Notes_
 
 * Only the body fields mentioned below are supported.
-* When integrating your application with a client's production environment, the client will have to provide the appropriate financial-transaction-alias values to send with the financial transaction.
-* Cerner's Revenue Cycle Patient Accounting application must be in use at a client site in order to create meaningful FinancialTransactions. A FinancialTransaction can only be targeted at a clinical Encounter that has related financial activity/encounters within the Cerner Revenue Cycle Patient Accounting system.
+* When integrating your application with a client's environment, the client will have to provide the appropriate financial-transaction-alias values to send with the financial transaction.
+* Cerner's Revenue Cycle Patient Accounting application must be in use at a client site in order to create meaningful FinancialTransactions.
 * When creating FinancialTransactions, a Basic OAuth2 token scope is required in addition to a FinancialTransaction Oauth2 token scope.
 
 ### Authorization Types

--- a/lib/resources/example_json/r4_examples_financial_transaction.rb
+++ b/lib/resources/example_json/r4_examples_financial_transaction.rb
@@ -37,7 +37,7 @@ module Cerner
             {
               'url': 'target',
               'valueReference': {
-                'reference': 'Encounter/31363178'
+                'reference': 'Encounter/97953536'
               }
             },
             {
@@ -117,7 +117,7 @@ module Cerner
             {
               'url': 'target',
               'valueReference': {
-                'reference': 'Encounter/31363178'
+                'reference': 'Encounter/97953536'
               }
             },
             {
@@ -131,11 +131,11 @@ module Cerner
         },
         {
           'url': 'https://fhir-ehr.cerner.com/r4/StructureDefinition/financial-transaction-alias',
-          'valueString': '1300'
+          'valueString': '0111'
         },
         {
           'url': 'https://fhir-ehr.cerner.com/r4/StructureDefinition/financial-transaction-location',
-          'valueString': '201802160003'
+          'valueString': '98920358'
         },
         {
           'url': 'https://fhir-ehr.cerner.com/r4/StructureDefinition/financial-transaction-amount',
@@ -213,7 +213,7 @@ module Cerner
             {
               'url': 'target',
               'valueReference': {
-                'reference': 'Encounter/31363178'
+                'reference': 'Encounter/97953536'
               }
             },
             {
@@ -227,11 +227,11 @@ module Cerner
         },
         {
           'url': 'https://fhir-ehr.cerner.com/r4/StructureDefinition/financial-transaction-alias',
-          'valueString': '1300'
+          'valueString': '0111'
         },
         {
           'url': 'https://fhir-ehr.cerner.com/r4/StructureDefinition/financial-transaction-location',
-          'valueString': '201802160003'
+          'valueString': '98920358'
         }
       ]
     }.freeze
@@ -291,7 +291,7 @@ module Cerner
             {
               'url': 'target',
               'valueReference': {
-                'reference': 'Encounter/31363178'
+                'reference': 'Encounter/97953536'
               }
             },
             {
@@ -305,11 +305,11 @@ module Cerner
         },
         {
           'url': 'https://fhir-ehr.cerner.com/r4/StructureDefinition/financial-transaction-alias',
-          'valueString': '1300'
+          'valueString': '0111'
         },
         {
           'url': 'https://fhir-ehr.cerner.com/r4/StructureDefinition/financial-transaction-location',
-          'valueString': '201802160003'
+          'valueString': '98920358'
         },
         {
           'url': 'https://fhir-ehr.cerner.com/r4/StructureDefinition/financial-transaction-amount',

--- a/lib/resources/r4/financial_transaction.yaml
+++ b/lib/resources/r4/financial_transaction.yaml
@@ -82,9 +82,9 @@ fields:
   example: |
     {
       "url": "https://fhir-ehr.cerner.com/r4/StructureDefinition/financial-transaction-alias",
-      "valueString": "3100"
+      "valueString": "0111"
     }
-  note: A value that correlates to a client defined name which represents the combination of the type, subtype, and reason describing the FinancialTransaction. Is required to create a FinancialTransaction resource.
+  note: A value that correlates to a client defined name which represents the combination of the type, subtype, and reason describing the FinancialTransaction. The alias determines the credit or debit impact on the accounts receivable. A valid alias from the tenant is required to create a FinancialTransaction resource.
   url: https://fhir-ehr.cerner.com/r4/StructureDefinition/financial-transaction-alias?_format=json
 
 - name: FinancialTransaction Location Extension
@@ -95,7 +95,7 @@ fields:
   example: |
     {
       "url": "https://fhir-ehr.cerner.com/r4/StructureDefinition/financial-transaction-location",
-      "valueString": "201802160003"
+      "valueString": "98920358"
     }
   note: These are client configured location values.
   url: https://fhir-ehr.cerner.com/r4/StructureDefinition/financial-transaction-location?_format=json
@@ -227,7 +227,7 @@ fields:
         {
           "url": "target",
           "valueReference": {
-            "reference": "Encounter/31363178"
+            "reference": "Encounter/97953536"
           }
         },
         {
@@ -255,7 +255,7 @@ fields:
       {
         "url": "target",
         "valueReference": {
-          "reference": "Encounter/31363178"
+          "reference": "Encounter/97953536"
         }
       }
     url: '#custom-extensions'


### PR DESCRIPTION
Description
----

- Updating examples to use real financial-transaction-location ids from C1941. location id 98920358
![image](https://user-images.githubusercontent.com/70215609/91754026-54465400-eb8e-11ea-97a7-60475fc711b7.png)
![image](https://user-images.githubusercontent.com/70215609/91754061-6922e780-eb8e-11ea-8e78-bc84706f4387.png)
![image](https://user-images.githubusercontent.com/70215609/91754067-6cb66e80-eb8e-11ea-80f4-2b561df42ef5.png)
![image](https://user-images.githubusercontent.com/70215609/91754077-7049f580-eb8e-11ea-80c9-e87aa7f91739.png)

- Updating examples to use real encounter ids for allocation.target from C1941. Encounter/97953536
![image](https://user-images.githubusercontent.com/70215609/91754121-85268900-eb8e-11ea-9152-c57485a2abf9.png)
![image](https://user-images.githubusercontent.com/70215609/91754141-8c4d9700-eb8e-11ea-8828-c2cd43166d48.png)
![image](https://user-images.githubusercontent.com/70215609/91754154-9079b480-eb8e-11ea-8789-13ae9ded0b7d.png)
![image](https://user-images.githubusercontent.com/70215609/91754164-940d3b80-eb8e-11ea-9750-8b6196299f84.png)
![image](https://user-images.githubusercontent.com/70215609/91754175-98395900-eb8e-11ea-95ad-feee1546294e.png)
![image](https://user-images.githubusercontent.com/70215609/91754110-7f30a800-eb8e-11ea-8b51-09052b71e023.png)

- Updating payment examples to use real financial-transaction-alias ids from C1941. alias 0111 (Note that the adjustment example should stay the same.)
![image](https://user-images.githubusercontent.com/70215609/91754232-b010dd00-eb8e-11ea-9ce6-8cfc415524fa.png)
![image](https://user-images.githubusercontent.com/70215609/91754246-b4d59100-eb8e-11ea-8a47-fbc7696493cc.png)
![image](https://user-images.githubusercontent.com/70215609/91754250-b7d08180-eb8e-11ea-94dd-5c4a87f39bec.png)
![image](https://user-images.githubusercontent.com/70215609/91754263-bc953580-eb8e-11ea-8c4a-92cf0522b8a4.png)

- Removing the implementation note of "A FinancialTransaction can only be targeted at a clinical Encounter that has related financial activity/encounters within the Cerner Revenue Cycle Patient Accounting system.”
- Removing the word "production" from the implementation note so it reads "When integrating your application with a client’s environment, the client will have to provide the appropriate financial-transaction-alias values to send with the financial transaction."
![image](https://user-images.githubusercontent.com/70215609/91754342-dcc4f480-eb8e-11ea-91f4-4626213695eb.png)

- Removing "EFT date if method is EFT or Lockbox date if method is lockbox." from the financial-transaction-date extension description.
![image](https://user-images.githubusercontent.com/70215609/91754400-f5350f00-eb8e-11ea-9b28-1d90ba9de8fd.png)

- Updating the body field Notes for the financial-transaction-alias extension to: A value that correlates to a client defined name which represents the combination of the type, subtype, and reason describing the FinancialTransaction. The alias determines the credit or debit impact on the accounts receivable. A valid alias from the tenant is required to create a FinancialTransaction resource.
![image](https://user-images.githubusercontent.com/70215609/91754447-054cee80-eb8f-11ea-9e36-3baffbe5e679.png)


PR Checklist
----
- [x] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.
