### PR TITLE
Prevent numbers inside square brackets in yaml files from being activated as links. Fixes #418

### DIFF
--- a/lib/definition_table_generator.rb
+++ b/lib/definition_table_generator.rb
@@ -194,7 +194,10 @@ class DefinitionTableGenerator
     end
 
     # Activate local links
-    results = results.gsub(/\[(\w+)\]/) do |match|
+    # This regex used to use \w, but now it assumes that only letters will be inside links to be activated
+    # If we want to maintain more of the functionality of \w, something like this could be used:
+    # /(?!\[\d+\])\[\w+\]/
+    results = results.gsub(/\[([A-Za-z]+)\]/) do |match|
       tag = match.tr('[]', '')
       "<a href=\"##{@table_name}-#{tag}\">#{tag}</a>"
     end

--- a/lib/resources/r4/coverage_encounter_patch.yaml
+++ b/lib/resources/r4/coverage_encounter_patch.yaml
@@ -35,7 +35,7 @@ operations:
       <ul>
         <li>This path should be used only to replace the policy group number.</li>
         <li>The `Coverage.class` at index 1 represents the group for the Coverage.</li>
-        <li>When no value is provided for this patch operation, `Coverage.class[1].value` will be unset.</li>
+        <li>When no value is provided for this patch operation, <code>Coverage.class[1].value</code> will be unset.</li>
       </ul>
 
   - name: replace-class-name
@@ -53,7 +53,7 @@ operations:
     note: >
       <ul>
         <li>The `Coverage.class` at index 1 represents the group for the Coverage.</li>
-        <li>When no value is provided for this patch operation, `Coverage.class[1].name` will be unset.</li>
+        <li>When no value is provided for this patch operation, <code>Coverage.class[1].name</code> will be unset.</li>
       </ul>
 
   - name: replace-dependent


### PR DESCRIPTION
Description
----
Update our custom yaml processing to allow fhirpath array indices to pass through

Fixes #418 

PR Checklist
----
- [x] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.
