### PR TITLE
Add note that DSTU 2Condition.encounter is required for diagnoses to the body fields table

### DIFF
--- a/content/millennium/dstu2/general-clinical/condition.md
+++ b/content/millennium/dstu2/general-clinical/condition.md
@@ -127,13 +127,13 @@ Create a new condition.
 
 _Implementation Notes_
 
-* A few restrictions are in place based on `Condition.category`
+* The following restrictions are in place based on `Condition.category`:
   * For Conditions with a category code of [diagnosis](http://hl7.org/fhir/dstu2/valueset-condition-category.html):
-    * `Condition.encounter` is required
-    * `Condition.abatementDateTime` is not supported
+    * `Condition.encounter` is required.
+    * `Condition.abatementDateTime` is not supported.
   * For Conditions with a category code of [problem](https://argonautwiki.hl7.org/Argonaut_Condition_Category_Codes):
-    * If `Condition.dateRecorded` is set on the request body, its value will currently be ignored
-  * Creating Conditions with a category code of [health-concern](https://argonautwiki.hl7.org/Argonaut_Condition_Category_Codes) is not currently supported
+    * If `Condition.dateRecorded` is set on the request body, its value will currently be ignored.
+  * Creating Conditions with a category code of [health-concern](https://argonautwiki.hl7.org/Argonaut_Condition_Category_Codes) is not currently supported.
 
 ### Authorization Types
 

--- a/content/millennium/dstu2/general-clinical/condition.md
+++ b/content/millennium/dstu2/general-clinical/condition.md
@@ -127,7 +127,13 @@ Create a new condition.
 
 _Implementation Notes_
 
-* Currently, `health-concern` category code is not supported for writing conditions.
+* A few restrictions are in place based on `Condition.category`
+  * For Conditions with a category code of [diagnosis](http://hl7.org/fhir/dstu2/valueset-condition-category.html):
+    * `Condition.encounter` is required
+    * `Condition.abatementDateTime` is not supported
+  * For Conditions with a category code of [problem](https://argonautwiki.hl7.org/Argonaut_Condition_Category_Codes):
+    * If `Condition.dateRecorded` is set on the request body, its value will currently be ignored
+  * Creating Conditions with a category code of [health-concern](https://argonautwiki.hl7.org/Argonaut_Condition_Category_Codes) is not currently supported
 
 ### Authorization Types
 
@@ -138,12 +144,6 @@ _Implementation Notes_
 <%= headers head: {Authorization: '&lt;OAuth2 Bearer Token>', Accept: 'application/json+fhir', 'Content-Type': 'application/json+fhir'} %>
 
 ### Body fields
-
-Notes:
-
-* `dateRecorded` is currently not honored on a create for Conditions with a category of `problem`.
-* `abatementDateTime` is not supported for Conditions with a category of `diagnosis`.
-* `encounter` is required for Conditions with a category of `diagnosis`.
 
 <%= definition_table(:condition, :create, :dstu2) %>
 

--- a/lib/resources/dstu2/condition.yaml
+++ b/lib/resources/dstu2/condition.yaml
@@ -47,6 +47,7 @@ fields:
         "reference": "Encounter/1309819"
       }
     }
+  note: Encounter is required for Conditions with a category code of diagnosis.
 
 - name: asserter
   required: 'No'


### PR DESCRIPTION
Description
----
Duplicate information about Condition.encounter being required for diagnoses to increase clarity

Fixes #344

PR Checklist
----
- [x] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.
