### PR TITLE
Appointment request patch status field to 'fulfilled'

### DIFF
--- a/content/millennium/r4/scheduling/appointment.md
+++ b/content/millennium/r4/scheduling/appointment.md
@@ -24,7 +24,7 @@ When updating an appointment, the resource provides the ability to change the [A
 * From Proposed to Booked, or Cancelled
 * From Booked to Arrived, Checked-In, or Cancelled
 * From Arrived to Checked-In, or Cancelled
-* From Checked-In to Cancelled or Fulfilled
+* From Checked-In to Fulfilled, or Cancelled
 
 Video Visit functionality is available for supported vendors only, and requires additional configuration and application support.
 

--- a/content/millennium/r4/scheduling/appointment.md
+++ b/content/millennium/r4/scheduling/appointment.md
@@ -24,7 +24,7 @@ When updating an appointment, the resource provides the ability to change the [A
 * From Proposed to Booked, or Cancelled
 * From Booked to Arrived, Checked-In, or Cancelled
 * From Arrived to Checked-In, or Cancelled
-* From Checked-In to Cancelled
+* From Checked-In to Cancelled or Fulfilled
 
 Video Visit functionality is available for supported vendors only, and requires additional configuration and application support.
 

--- a/lib/resources/r4/appointment_patch.yaml
+++ b/lib/resources/r4/appointment_patch.yaml
@@ -16,7 +16,7 @@ operations:
       }
     note: >
       <ul>
-        <li>Only "arrived", "checked-in", "cancelled", and "booked" are supported</li>
+        <li>Only "arrived", "checked-in", "cancelled", "booked", and "fulfilled" are supported</li>
         <li>This patch operation must be accompanied by the add Slot patch operation when updating status to "booked"</li>
       </ul>
   - name: add-slot


### PR DESCRIPTION
Description
Updated the Appointment 'patch' request to have 'fulfilled' status
With this enhancement, the Appointment resource can support updating the status of an appointment from booked to fulfilled.
--------------------------------------------**Screenshot Before Merge:**---------------------------------------

![image](https://user-images.githubusercontent.com/33313942/93104019-f3a93200-f6ca-11ea-968e-3c38e92448f1.png)
![image](https://user-images.githubusercontent.com/33313942/93103721-9ad99980-f6ca-11ea-91ac-6ac9fdbafe8f.png)



--------------------------------------------**Expected Screenshot After Merge:**-------------------------------
(changes: a new status 'fulfilled' is added)
![image](https://user-images.githubusercontent.com/33313942/92931478-23550180-f461-11ea-8e2d-485954afaa00.png)
![image](https://user-images.githubusercontent.com/33313942/93174193-34489000-f74b-11ea-8b07-113e6374bf59.png)


----
PR Checklist
----
- [x] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.
