### PR TITLE
Update document-reference.md with plain and richtext Mime types

### DIFF
--- a/content/millennium/r4/documents/document-reference.md
+++ b/content/millennium/r4/documents/document-reference.md
@@ -119,7 +119,7 @@ _Implementation Notes_
 
 * Only the body fields mentioned below are supported. Unsupported fields will be ignored.
 * All provided dates must have a time component.
-* Supported MIME Types: application/pdf, text/plain, text/richtext, text/rtf, text/html, application/xml, and application/xhtml+xml
+* Supported MIME Types: application/pdf, text/rtf, text/html, application/xml, and application/xhtml+xml
 
 ### Authorization Types
 

--- a/content/millennium/r4/documents/document-reference.md
+++ b/content/millennium/r4/documents/document-reference.md
@@ -119,7 +119,7 @@ _Implementation Notes_
 
 * Only the body fields mentioned below are supported. Unsupported fields will be ignored.
 * All provided dates must have a time component.
-* Supported MIME Types: application/pdf, text/rtf, text/html, application/xml, and application/xhtml+xml
+* Supported MIME Types: application/pdf, text/plain, text/richtext, text/rtf, text/html, application/xml, and application/xhtml+xml
 
 ### Authorization Types
 

--- a/lib/resources/r4/document_reference.yaml
+++ b/lib/resources/r4/document_reference.yaml
@@ -194,7 +194,7 @@ fields:
   action:
     - create
   description: Identifies the type of the data in the attachment and allows a method to be chosen to interpret or render the data. Includes mime type parameters such as charset where appropriate.
-  note: Must be provided. Content Type must include a supported MIME type and character set. The supported values are `application/pdf`, `text/rtf;charset=utf-8`, `text/html;charset=utf-8`, `application/xml;charset=utf-8`, and `application/xhtml+xml;charset=utf-8`
+  note: Must be provided. Content Type must include a supported MIME type and character set. The supported values are `application/pdf`, `text/plain;charset=utf-8`, `text/richtext;charset=utf-8`, `text/rtf;charset=utf-8`, `text/html;charset=utf-8`, `application/xml;charset=utf-8`, and `application/xhtml+xml;charset=utf-8`
   url: https://www.hl7.org/fhir/datatypes-definitions.html#Attachment.contentType
   example: |
    {


### PR DESCRIPTION
DocumentReference add Mime types text/plain and text/richtext

Description
----
Add supported Mime types to content.attachment.content_type
PR Checklist
----
- [x] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.
