### PR TITLE
[R4][Appointment] Update serviceType create example to not use proprietary code

### DIFF
--- a/lib/resources/r4/appointment.yaml
+++ b/lib/resources/r4/appointment.yaml
@@ -37,12 +37,6 @@ fields:
         {
           "coding": [
             {
-              "system": "https://fhir.cerner.com/ec2458f2-1e24-41c8-b71b-0e701af7583d/codeSet/14249",
-              "code": "667105",
-              "display": "Surgery",
-              "userSelected": true
-            },
-            {
               "system": "http://snomed.info/sct",
               "code": "394609007",
               "display": "Surgery-general",


### PR DESCRIPTION
Description
----
Update serviceType create example to not use proprietary code as this is not yet supported

<img width="703" alt="Screen Shot 2020-11-04 at 9 03 50 AM" src="https://user-images.githubusercontent.com/56039503/98127957-eb74a400-1e7c-11eb-932f-11254c4f9880.png">

PR Checklist
----
- [x] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.
