### PR TITLE
Added description for Condition.code field in DSTU2 and R4.

### DIFF
--- a/content/millennium/dstu2/general-clinical/condition.md
+++ b/content/millennium/dstu2/general-clinical/condition.md
@@ -134,6 +134,7 @@ _Implementation Notes_
   * For Conditions with a category code of [problem](https://argonautwiki.hl7.org/Argonaut_Condition_Category_Codes):
     * If `Condition.dateRecorded` is set on the request body, its value will currently be ignored.
   * Creating Conditions with a category code of [health-concern](https://argonautwiki.hl7.org/Argonaut_Condition_Category_Codes) is not currently supported.
+* The code.coding field can have at most 2 codings, one of which must be set as userSelected true and the other one must be set as userSelected false.
 
 ### Authorization Types
 
@@ -235,6 +236,7 @@ _Implementation Notes_
 
 * Any field which is missing will be interpreted as nulling out or removing data from the resource. See [FHIR<sup>®</sup> Update] for additional details about update operations.
 * Currently, `health-concern` category code is not supported for updating conditions.
+* The code.coding field can have at most 2 codings, one of which must be set as userSelected true and the other one must be set as userSelected false.
 
 ### Authorization Types
 

--- a/content/millennium/r4/general-clinical/condition.md
+++ b/content/millennium/r4/general-clinical/condition.md
@@ -121,6 +121,7 @@ _Implementation Notes_
 
 * Only the body fields mentioned below are supported. Unsupported fields will be ignored.
 * Modifier fields should not be provided, and will cause the transaction to fail.
+* The code.coding field can have at most 2 codings, one of which must be set as userSelected true and the other one must be set as userSelected false.
 
 ### Authorization Types
 
@@ -180,6 +181,7 @@ _Implementation Notes_
 
 * Currently `problem-list-item` and `encounter-diagnosis` are supported.
 * Any field which is missing will be interpreted as nulling out or removing data from the resource. See [FHIR<sup>®</sup> Update] for additional details about update operations.
+* The code.coding field can have at most 2 codings, one of which must be set as userSelected true and the other one must be set as userSelected false.
 
 ### Authorization Types
 


### PR DESCRIPTION
Description
----
Added description on the implementation note section for how code.coding field behaves in DSTU2 and R4

PR Checklist
----
- [x] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.
