### PR TITLE
Removed asserter field from Condition DSTU2

### DIFF
--- a/content/millennium/dstu2/general-clinical/condition.md
+++ b/content/millennium/dstu2/general-clinical/condition.md
@@ -19,7 +19,6 @@ The following fields are returned if valued:
 * [Id](http://hl7.org/fhir/DSTU2/resource-definitions.html#Resource.id){:target="_blank"}
 * [Patient](http://hl7.org/fhir/DSTU2/condition-definitions.html#Condition.patient){:target="_blank"}
 * [Patient encounter when first recorded (only applies to diagnoses)](http://hl7.org/fhir/DSTU2/condition-definitions.html#Condition.encounter){:target="_blank"}
-* [Who recorded the condition](http://hl7.org/fhir/DSTU2/condition-definitions.html#Condition.asserter){:target="_blank"}
 * [Date recorded](http://hl7.org/fhir/DSTU2/condition-definitions.html#Condition.dateRecorded){:target="_blank"}
 * [Condition code](﻿﻿http://hl7.org/fhir/DSTU2/condition-definitions.html#Condition.code){:target="_blank"}
 * [Status](http://hl7.org/fhir/DSTU2/condition-definitions.html#Condition.clinicalStatus){:target="_blank"}

--- a/lib/resources/dstu2/condition.yaml
+++ b/lib/resources/dstu2/condition.yaml
@@ -49,19 +49,6 @@ fields:
     }
   note: Encounter is required for Conditions with a category code of diagnosis.
 
-- name: asserter
-  required: 'No'
-  type: Reference (Practitioner)
-  description: Person who takes responsibility for asserting the existence of the condition as part of the electronic record.
-  note: Asserter must be a `Practitioner` reference.
-  example: |
-    {
-      "asserter": {
-        "reference": "Practitioner/2770007",
-        "display": "Song, River"
-      }
-    }
-
 - name: dateRecorded
   required: 'No'
   type: date

--- a/lib/resources/example_json/dstu2_examples_condition.rb
+++ b/lib/resources/example_json/dstu2_examples_condition.rb
@@ -21,10 +21,6 @@ module Cerner
         'reference': 'Patient/12724066',
         'display': 'SMART, NANCY'
       },
-      'asserter': {
-        'reference': 'Practitioner/683925',
-        'display': "Cerner Test, Women's Health - Nurse Cerner"
-      },
       'dateRecorded': '2020-03-05',
       'code': {
         'coding': [
@@ -74,10 +70,6 @@ module Cerner
         },
         'encounter': {
           'reference': 'Encounter/97953477'
-        },
-        'asserter': {
-          'reference': 'Practitioner/4122630',
-          'display': "Cerner Test, Physician - Women's Health Cerner"
         },
         'dateRecorded': '2020-06-11',
         'code': {
@@ -131,10 +123,6 @@ module Cerner
                   'Resolved</b>: False</p></div>'
         },
         'patient': {
-          'reference': 'Patient/12724066',
-          'display': 'SMART, NANCY'
-        },
-        'asserter': {
           'reference': 'Patient/12724066',
           'display': 'SMART, NANCY'
         },
@@ -277,9 +265,6 @@ module Cerner
       },
       'encounter': {
         'reference': 'Encounter/97953477'
-      },
-      'asserter': {
-        'reference': 'Practitioner/4122630'
       },
       'dateRecorded': '2020-06-11',
       'code': {


### PR DESCRIPTION
Description
----
Removed asserter field from Condition DSTU2 since it is now being deprecated

PR Checklist
----
- [x] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.
