### PR TITLE
Fix R4 Observation Create/Update examples' valueQuantity.value to numeric instead of string

### DIFF
--- a/lib/resources/example_json/r4_examples_observation.rb
+++ b/lib/resources/example_json/r4_examples_observation.rb
@@ -499,7 +499,7 @@ module Cerner
         }
       ],
       "valueQuantity": {
-        "value": '13.2',
+        "value": 13.2,
         "unit": 'mg/dL',
         "system": 'http://unitsofmeasure.org',
         "code": 'mg/dL'
@@ -587,7 +587,7 @@ module Cerner
         }
       ],
       "valueQuantity": {
-        "value": '13.2',
+        "value": 13.2,
         "unit": 'mg/dL',
         "system": 'http://unitsofmeasure.org',
         "code": 'mg/dL'


### PR DESCRIPTION
Description
----
The R4 Observation lab Create and Update examples have a valueQuantity.value of `"13.2"`, but should be a numeric value of `13.2`.

PR Checklist
----
- [x] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.

Before merge:
Create
![image](https://user-images.githubusercontent.com/22381097/100802772-9da57a00-33ef-11eb-9720-3c860039e757.png)
Update
![image](https://user-images.githubusercontent.com/22381097/100802644-6a62eb00-33ef-11eb-92fe-f386d6d69fa5.png)

