### PR TITLE
Fix R4 Coverage Search typo

### DIFF
--- a/content/millennium/r4/financial/coverage.md
+++ b/content/millennium/r4/financial/coverage.md
@@ -48,7 +48,7 @@ All URLs for custom extensions are defined as `https://fhir-ehr.cerner.com/r4/St
 
 Search for Patient-level or Encounter-level Coverages that meet supplied query parameters:
 
-    GET /Coverages?:parameters
+    GET /Coverage?:parameters
     
 _Implementation Notes_
   


### PR DESCRIPTION
Description
----
Fix typo in Coverage Search endpoint.

Pre-merge changes:
![image](https://user-images.githubusercontent.com/32784540/101807231-80049e80-3ada-11eb-9274-e7819ef2577a.png)

PR Checklist
----
- [x] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.
