### PR TITLE
R4_docref_ccd_support

### DIFF
--- a/content/millennium/r4/documents/document-reference.md
+++ b/content/millennium/r4/documents/document-reference.md
@@ -9,9 +9,9 @@ title: DocumentReference | R4 API
 
 ## Overview
 
-The DocumentReference resource is used to reference a clinical document for a patient within the health system. This resource supports returning a list of clinical documents, and a reference to retrieve a document as a PDF.
+The DocumentReference resource is used to reference a clinical document for a patient within the health system. This resource supports reading Continuity of Care Documents (CCD), returning a list of clinical documents, and a reference to retrieve a document as a PDF.
 
-The following fields are returned if valued:
+The following fields are returned if valued for clinical documents:
 
 * [DocumentReference id](https://hl7.org/fhir/r4/resource-definitions.html#Resource.id){:target="_blank"}
 * [Status]( https://hl7.org/fhir/r4/documentreference-definitions.html#DocumentReference.status){:target="_blank"}
@@ -19,6 +19,7 @@ The following fields are returned if valued:
 * [Document type](https://hl7.org/fhir/r4/documentreference-definitions.html#DocumentReference.type){:target="_blank"}
 * [Document category](https://hl7.org/fhir/r4/documentreference-definitions.html#DocumentReference.category){:target="_blank"}
 * [Subject (Patient)](https://hl7.org/fhir/r4/documentreference-definitions.html#DocumentReference.subject){:target="_blank"}
+* [Created Date](http://hl7.org/fhir/r4/documentreference-definitions.html#DocumentReference.date){:target="_blank"}
 * [Author](https://hl7.org/fhir/r4/documentreference-definitions.html#DocumentReference.author){:target="_blank"}
 * [Authenticator/verifying provider](https://hl7.org/fhir/r4/documentreference-definitions.html#DocumentReference.authenticator){:target="_blank"}
 * [Document description/title]( https://hl7.org/fhir/r4/documentreference-definitions.html#DocumentReference.description){:target="_blank"}
@@ -27,6 +28,7 @@ The following fields are returned if valued:
   * [Created date/time](https://hl7.org/fhir/r4/datatypes-definitions.html#Attachment.creation){:target="_blank"}
   * [Title](https://hl7.org/fhir/r4/datatypes-definitions.html#Attachment.title){:target="_blank"}
   * [URL (fully qualified link to the document)](https://hl7.org/fhir/r4/datatypes-definitions.html#Attachment.url){:target="_blank"}
+  * [Format](http://hl7.org/fhir/r4/documentreference-definitions.html#DocumentReference.content.format){:target="_blank"}
 * [Patient encounter]( https://hl7.org/fhir/r4/documentreference-definitions.html#DocumentReference.context.encounter){:target="_blank"}
 * [Document period]( https://hl7.org/fhir/r4/documentreference-definitions.html#DocumentReference.context.period){:target="_blank"}
 
@@ -243,3 +245,54 @@ The common [errors] and [OperationOutcomes] may be returned.
 [errors]: ../../#client-errors
 [OperationOutcomes]: ../../#operation-outcomes
 [Update documentation]: https://www.hl7.org/fhir/r4/http.html#update
+
+## Operation: docref
+
+US Core operation for querying DocumentReferences for the supplied parameters:
+
+## Search
+
+Search for DocumentReferences that meet supplied query parameters:
+
+    GET /DocumentReference?:parameters
+
+### Terminology Bindings
+
+<%= terminology_table(:document_reference_docref, :r4) %>
+
+### Authorization Types
+
+<%= authorization_types(provider: true, patient: false, system: true) %>
+
+### Parameters
+
+ Name                     | Required?   | Type          | Description
+--------------------------|-------------|---------------|--------------------------------------------------------------------------------------------------------
+ `patient`                | Y           | [`reference`] | The specific patient to return DocumentReferences for. Example: `12345`
+ `type`                   | N           | [`token`]     | The document reference type, can be a list of comma separated values. Example: http://loinc.org\|34133-9
+ `start`                  | N           | [`number`]    | The start of the date range from which document reference records should be included. If not provided, then all records from the beginning of time are included. Example: 2014-09-24T12:00:00.000Z
+ `end`                    | N           | [`number`]    | The end of the date range till which document reference records should be included. If not provided, then all records up to the current date are included. Example: 2016-09-24T12:00:00.000Z
+
+_Implementation Notes_
+
+* The type parameter must include both a system and a code. (e.g. &type=http://loinc.org\|34133-9)
+* The start and end parameters must be valid dateTimes with a time component. They must have prefixes of eq or nothing.
+
+### Headers
+
+<%= headers %>
+
+### Example
+
+#### Request
+
+    GET https://fhir-open.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/DocumentReferenceDocumentReference/$docref?patient=13160351&type=http%3A%2F%2Floinc.org%7C34133-9
+
+#### Response
+
+<%= headers status: 200 %>
+<%= json(:R4_DOCUMENT_REFERENCE_CCD_BUNDLE) %>
+
+### Errors
+
+The common [errors] and [OperationOutcomes] may be returned.

--- a/lib/resources/example_json/r4_examples_document_reference.rb
+++ b/lib/resources/example_json/r4_examples_document_reference.rb
@@ -497,5 +497,53 @@ module Cerner
         }
       }
     }.freeze
+
+    R4_DOCUMENT_REFERENCE_CCD ||= {
+      'resourceType': 'DocumentReference',
+      'status': 'current',
+      'type': {
+        'coding': [
+          {
+            'system': 'http://loinc.org',
+            'code': '34133-9',
+            'display': 'Summary of episode note'
+          }
+        ],
+        'text': 'Summary of episode note'
+      },
+      'subject': {
+        'reference': 'Patient/13160351'
+      },
+      'date': '2020-12-14T08:20:26Z',
+      'content': [
+        {
+          'attachment': {
+            'contentType': 'application/xml',
+            'url': 'https://fhir.cerner.com/ec2458f2-1e24-41c8-b71b-0e701af7583d/Binary/$autogen-ccd-if?'\
+                   'patient=13160351'
+          },
+          'format': {
+            'system': 'urn:oid:1.3.6.1.4.1.19376.1.2.3',
+            'code': 'urn:hl7-org:sdwg:ccda-structuredBody:2.1',
+            'display': 'For documents following C-CDA constraints using a structured body.'
+          }
+        }
+      ]
+    }.freeze
+
+    R4_DOCUMENT_REFERENCE_CCD_BUNDLE ||= {
+      'resourceType': 'Bundle',
+      'id': '2cb9157f-0f05-4fe4-af14-95d5808a4070',
+      'type': 'searchset',
+      'link': [
+        {
+          'relation': 'self',
+          'url': 'https://fhir-open.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/DocumentReference'\
+                '/$docref?patient=13160351'
+        }
+      ],
+      'entry': [R4_DOCUMENT_REFERENCE_CCD]
+    }.freeze
+
   end
 end

--- a/lib/resources/r4/document_reference.yaml
+++ b/lib/resources/r4/document_reference.yaml
@@ -543,3 +543,34 @@ fields:
         "end": "2020-01-01T01:00:00.000Z"
       }
     }
+- name: type
+  required: 'Yes'
+  type: CodeableConcept
+  action:
+    - docrefccd
+  description: Precise type of clinical document.
+  note: The type must include a LOINC or a proprietary coding but not both together. Multiple LOINC codings or a single proprietary coding can be provided.
+    <br/><br/>
+    When providing proprietary code system, it should be of format 'https://fhir.cerner.com/&lt;your EHR source id&gt;/codeSet/&lt;code set&gt;' (where code set is Millennium codeset 72). Example&#58; 'https://fhir.cerner.com/ec2458f2-1e24-41c8-b71b-0e701af7583d/codeSet/72'.
+    <br/><br/>
+  url: http://hl7.org/fhir/r4/documentreference-definitions.html#DocumentReference.type
+  binding:
+    description: Specifies the particular kind of document referenced.
+    terminology:
+      - display: US Core DocumentReference Type
+        system: http://loinc.org
+        info_link: http://hl7.org/fhir/us/core/ValueSet/us-core-documentreference-type
+
+- name: type
+  required: 'Yes'
+  type: CodeableConcept
+  action:
+    - docrefccd
+  binding:
+    description: Precise type of clinical document.
+    terminology:
+      - display: LOINC
+        system: http://loinc.org
+        info_link: http://hl7.org/fhir/dstu2/loinc.html
+        values:
+          - 34133-9 - Summary of episode note

--- a/lib/resources/r4/document_reference_docref.yaml
+++ b/lib/resources/r4/document_reference_docref.yaml
@@ -1,0 +1,23 @@
+---
+name: DocumentReference
+field_name_base_url: http://hl7.org/fhir/DSTU2/documentreference-definitions.html#DocumentReference
+fields:
+  - name: type
+    binding:
+      description: Precise type of clinical document.
+      terminology:
+        - display: LOINC
+          system: http://loinc.org
+          info_link: http://hl7.org/fhir/r4/loinc.html
+          values:
+            - 34133-9 - Summary of episode note
+
+  - name: content
+    children:
+      - name: format
+        binding:
+          description: Document format codes.
+          terminology:
+            - display: DocumentReference Format Code Set
+              system: urn:oid:1.3.6.1.4.1.19376.1.2.3
+              info_link: http://hl7.org/fhir/r4/valueset-formatcodes.html


### PR DESCRIPTION
DocRefCcd support added for Document reference

Description
----
DocRefCcd support added for Document reference

PR Checklist
----
- [x] Screenshot(s) of changes attached before changes merged.
<img width="1259" alt="Screenshot 2020-12-14 at 11 49 01 PM" src="https://user-images.githubusercontent.com/3060097/102119848-c2760480-3e67-11eb-8732-3464d997dec0.png">

<img width="1092" alt="Screenshot 2020-12-14 at 11 48 50 PM" src="https://user-images.githubusercontent.com/3060097/102119830-bd18ba00-3e67-11eb-8fdc-86001c477b4f.png">

<img width="935" alt="Screenshot 2020-12-16 at 2 41 59 PM" src="https://user-images.githubusercontent.com/3060097/102328307-e858f180-3fac-11eb-9d1b-7a37af24fd6d.png">

<img width="1123" alt="Screenshot 2020-12-14 at 11 51 52 PM" src="https://user-images.githubusercontent.com/3060097/102119857-c3a73180-3e67-11eb-8ab9-9b7b5b99b796.png">
<img width="1004" alt="Screenshot 2020-12-14 at 11 52 10 PM" src="https://user-images.githubusercontent.com/3060097/102119859-c43fc800-3e67-11eb-9dcc-b0b2dff05856.png">

- [ ] Screenshot(s) of changes attached after changes merged and published.
