### PR TITLE
Fix Millennium Overview Table Sorting; Add CarePlan and Contract configuration

### DIFF
--- a/static/js/millennium_diff_table.js
+++ b/static/js/millennium_diff_table.js
@@ -21,6 +21,11 @@ const resourceConfig = {
       dstu2Resources: ["ProcedureRequest"],
       r4Resources: ["ServiceRequest"],
       notes: "The DSTU 2 ProcedureRequest resource was renamed to ServiceRequest in R4."
+    },
+    {
+      dstu2Resources: ["Contract"],
+      r4Resources: ["Consent"],
+      notes: "Cerner's DSTU 2 implementation of Contract resource was shifted to Consent in R4."
     }
   ],
   basicResources: [
@@ -243,8 +248,9 @@ function matchResources(conformanceData, capabilityStatementData) {
  */
 function mergeSortedArrays(includesR4, dstu2Only) {
   let result = [];
+  let includesR4Length = includesR4.length;
 
-  for(let x = 0; x < includesR4.length; x += 1) {
+  for(let x = 0; x < includesR4Length; x += 1) {
     let r4Record = includesR4[x];
 
     for (let y = 0; y < dstu2Only.length; y += 1) {

--- a/static/js/millennium_diff_table.js
+++ b/static/js/millennium_diff_table.js
@@ -25,7 +25,12 @@ const resourceConfig = {
     {
       dstu2Resources: ["Contract"],
       r4Resources: ["Consent"],
-      notes: "Cerner's DSTU 2 implementation of Contract resource was shifted to Consent in R4."
+      notes: "The resource used to represent people who are authorized to view a patient's data shifted from DSTU2 Contract to R4 Consent."
+    },
+    {
+      dstu2Resources: ["CarePlan"],
+      r4Resources: ["CarePlan", "CareTeam"],
+      notes: "DSTU2 CarePlan was split into R4 CarePlan and CareTeam."
     }
   ],
   basicResources: [

--- a/static/js/millennium_diff_table.js
+++ b/static/js/millennium_diff_table.js
@@ -235,38 +235,29 @@ function matchResources(conformanceData, capabilityStatementData) {
 }
 
 /**
- * Merges the two sorted arrays alphabetically.
+ * Merges the two sorted arrays alphabetically. Entries are ordered by their R4 name first, if no R4 resource
+ * exists then the DSTU2 is used.
  * @param {array} includesR4 - The array of resource objects that contain R4 resources.
  * @param {array} dstu2Only - The array of resource objects that only contain DSTU2 resources.
  * @returns {array} The resultant array after merging.
  */
 function mergeSortedArrays(includesR4, dstu2Only) {
   let result = [];
-  let i = 0;
-  let j = 0;
 
-  while (i < includesR4.length && j < dstu2Only.length) {
-    if (includesR4[i].hasOwnProperty('r4Resources') && !includesR4[i].hasOwnProperty('dstu2Resources')) {
-      if (includesR4[i].r4Resources[0].resourceName < dstu2Only[j].dstu2Resources[0].resourceName) {
-        result.push(includesR4[i]);
-        i += 1;
-      }
-      else {
-        result.push(dstu2Only[j]);
-        j += 1;
-      }
-    }
-    else {
-      if (includesR4[i].dstu2Resources[0].resourceName < dstu2Only[j].dstu2Resources[0].resourceName) {
-        result.push(includesR4[i]);
-        i += 1;
-      }
-      else {
-        result.push(dstu2Only[j]);
-        j += 1;
+  for(let x = 0; x < includesR4.length; x += 1) {
+    let r4Record = includesR4[x];
+
+    for (let y = 0; y < dstu2Only.length; y += 1) {
+      if (r4Record.r4Resources[0].resourceName > dstu2Only[y].dstu2Resources[0].resourceName) {
+        result.push(dstu2Only[y]);
+        dstu2Only.splice(y, 1);
+        y -= 1;
       }
     }
+
+    result.push(r4Record);
   }
+
   return result;
 }
 


### PR DESCRIPTION
Description
----
Due to the way sorting of both of the arrays together was accomplished previously, the loop was prematurely ended as DSTU2 resources were completely parsed through. The alterations to the function should now properly sort through the array and reduce the potential future risks of omitting resources as we are using a `for` loop rather than a `while` loop. Resources are sorted, as the documentation states, first by the R4 resource name, if it exists, then the DSTU2 resource (if. there is no matched R4 resource).


<img width="805" alt="Screen Shot 2020-12-17 at 9 08 32 AM" src="https://user-images.githubusercontent.com/8973530/102505356-800b1e00-4047-11eb-8e3b-2de0ff3170ee.png">
<img width="716" alt="Screen Shot 2020-12-17 at 9 08 39 AM" src="https://user-images.githubusercontent.com/8973530/102505353-7ed9f100-4047-11eb-8d81-bc07ea07ee66.png">

PR Checklist
----
- [x] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.
