### PR TITLE
RelatedPerson Encounter Read/Search Name.id Update

### DIFF
--- a/lib/resources/example_json/r4_examples_relatedperson.rb
+++ b/lib/resources/example_json/r4_examples_relatedperson.rb
@@ -385,7 +385,7 @@ module Cerner
             ],
             'name': [
               {
-                'id': 'CI-12724068-0',
+                'id': 'CI-12724069-0',
                 'use': 'official',
                 'text': 'SMART, TIMMY',
                 'family': 'SMART',

--- a/lib/resources/example_json/r4_examples_relatedperson.rb
+++ b/lib/resources/example_json/r4_examples_relatedperson.rb
@@ -502,6 +502,7 @@ module Cerner
       ],
       'name': [
         {
+          'id': 'CI-12724066-0',
           'use': 'official',
           'family': 'Doe',
           'given': [

--- a/lib/resources/example_json/r4_examples_relatedperson.rb
+++ b/lib/resources/example_json/r4_examples_relatedperson.rb
@@ -88,7 +88,7 @@ module Cerner
       ],
       'name': [
         {
-          'id': 'CI-12724068-12724066-0',
+          'id': 'CI-12724068-0',
           'use': 'official',
           'text': 'SMART, HAILEY',
           'family': 'SMART',
@@ -385,7 +385,7 @@ module Cerner
             ],
             'name': [
               {
-                'id': 'CI-12724069-12724066-0',
+                'id': 'CI-12724066-0',
                 'use': 'official',
                 'text': 'SMART, TIMMY',
                 'family': 'SMART',

--- a/lib/resources/example_json/r4_examples_relatedperson.rb
+++ b/lib/resources/example_json/r4_examples_relatedperson.rb
@@ -88,7 +88,7 @@ module Cerner
       ],
       'name': [
         {
-          'id': 'CI-12724068-0',
+          'id': 'CI-12724068-12724066-0',
           'use': 'official',
           'text': 'SMART, HAILEY',
           'family': 'SMART',
@@ -385,7 +385,7 @@ module Cerner
             ],
             'name': [
               {
-                'id': 'CI-12724069-0',
+                'id': 'CI-12724069-12724066-0',
                 'use': 'official',
                 'text': 'SMART, TIMMY',
                 'family': 'SMART',
@@ -502,7 +502,6 @@ module Cerner
       ],
       'name': [
         {
-          'id': 'CI-12724066-0',
           'use': 'official',
           'family': 'Doe',
           'given': [

--- a/lib/resources/example_json/r4_examples_relatedperson.rb
+++ b/lib/resources/example_json/r4_examples_relatedperson.rb
@@ -88,7 +88,7 @@ module Cerner
       ],
       'name': [
         {
-          'id': 'CI-12724068-12724066-0',
+          'id': 'CI-12724068-0',
           'use': 'official',
           'text': 'SMART, HAILEY',
           'family': 'SMART',
@@ -245,6 +245,7 @@ module Cerner
       ],
       'name': [
         {
+          'id': 'CI-12457994-0',
           'use': 'official',
           'text': 'MATERNITY, TESTTHREE',
           'family': 'MATERNITY',
@@ -384,7 +385,7 @@ module Cerner
             ],
             'name': [
               {
-                'id': 'CI-12724069-12724066-0',
+                'id': 'CI-12724069-0',
                 'use': 'official',
                 'text': 'SMART, TIMMY',
                 'family': 'SMART',
@@ -678,6 +679,7 @@ module Cerner
             ],
             'name': [
               {
+                'id': 'CI-12457994-0',
                 'use': 'official',
                 'text': 'MATERNITY, TESTTHREE',
                 'family': 'MATERNITY',

--- a/lib/resources/example_json/r4_examples_relatedperson.rb
+++ b/lib/resources/example_json/r4_examples_relatedperson.rb
@@ -385,7 +385,7 @@ module Cerner
             ],
             'name': [
               {
-                'id': 'CI-12724066-0',
+                'id': 'CI-12724068-0',
                 'use': 'official',
                 'text': 'SMART, TIMMY',
                 'family': 'SMART',


### PR DESCRIPTION
Description
----
Updating the name.id field on RelatedPerson Encounter read/search request examples after correcting a defect.

Screenshots before changes merged
----
<img width="823" alt="Screen Shot 2021-01-19 at 10 25 06 AM" src="https://user-images.githubusercontent.com/62904679/105064251-42345780-5a42-11eb-9ff7-e51cb62419e0.png">
<img width="857" alt="Screen Shot 2021-01-19 at 10 25 33 AM" src="https://user-images.githubusercontent.com/62904679/105064273-48c2cf00-5a42-11eb-889e-9fd3a16d4d37.png">
<img width="720" alt="Screen Shot 2021-01-19 at 3 54 38 PM" src="https://user-images.githubusercontent.com/62904679/105097821-d9170900-5a6e-11eb-86fc-3bd9a0b28be3.png">
<img width="729" alt="Screen Shot 2021-01-19 at 3 55 15 PM" src="https://user-images.githubusercontent.com/62904679/105097830-dcaa9000-5a6e-11eb-8fb2-2968e4a3e1fc.png">



PR Checklist
----
- [x] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.
