### PR TITLE
Update SMART Open Source FHIR Client Libraries links

### DIFF
--- a/content/smart.md
+++ b/content/smart.md
@@ -124,8 +124,8 @@ To start development quickly, there is an open source [fhir-client JavaScript li
 
 Other additional FHIR clients are available:
 
-- Java: [http://hapifhir.io/doc_rest_client.html](http://hapifhir.io/doc_rest_client.html)
-- .NET: [https://github.com/ewoutkramer/fhir-net-api](https://github.com/ewoutkramer/fhir-net-api)
+- Java: [https://github.com/hapifhir/hapi-fhir](https://github.com/hapifhir/hapi-fhir)
+- .NET: [https://github.com/FirelyTeam/firely-net-sdk](https://github.com/FirelyTeam/firely-net-sdk)
 - Python: [https://github.com/smart-on-fhir/client-py](https://github.com/smart-on-fhir/client-py)
 - iOS: [https://github.com/smart-on-fhir/Swift-FHIR](https://github.com/smart-on-fhir/Swift-FHIR)
 


### PR DESCRIPTION
Description
----
Current link on this page to HAPI doc is dead, current link to .NET doc points to a redirected repo. Fixes #545 

PR Checklist
----
- [x] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.
