### PR TITLE
Added patient access for R4 Document Reference CCD search

### DIFF
--- a/content/millennium/r4/documents/document-reference.md
+++ b/content/millennium/r4/documents/document-reference.md
@@ -277,6 +277,8 @@ _Implementation Notes_
 <%= headers status: 200 %>
 <%= json(:R4_DOCUMENT_REFERENCE_CCD_BUNDLE) %>
 
+<%= disclaimer %>
+
 #### Patient Authorization Request
 
     GET https://fhir-ehr.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/DocumentReference/$docref?patient=13160351&type=http%3A%2F%2Floinc.org%7C34133-9

--- a/content/millennium/r4/documents/document-reference.md
+++ b/content/millennium/r4/documents/document-reference.md
@@ -246,7 +246,7 @@ US Core operation for querying DocumentReferences for the supplied parameters:
 
 ### Authorization Types
 
-<%= authorization_types(provider: true, patient: false, system: true) %>
+<%= authorization_types(provider: true, patient: true, system: true) %>
 
 ### Parameters
 
@@ -277,6 +277,16 @@ _Implementation Notes_
 <%= headers status: 200 %>
 <%= json(:R4_DOCUMENT_REFERENCE_CCD_BUNDLE) %>
 
+#### Patient Authorization Request
+
+    GET https://fhir-ehr.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/DocumentReference/$docref?patient=13160351&type=http%3A%2F%2Floinc.org%7C34133-9
+
+#### Response
+
+<%= headers status: 200 %>
+<%= json(:R4_DOCUMENT_REFERENCE_CCD_PATIENT_BUNDLE) %>
+
+<%= disclaimer %>
 ### Errors
 
 The common [errors] and [OperationOutcomes] may be returned.

--- a/lib/resources/example_json/r4_examples_document_reference.rb
+++ b/lib/resources/example_json/r4_examples_document_reference.rb
@@ -499,6 +499,7 @@ module Cerner
     }.freeze
     R4_DOCUMENT_REFERENCE_CCD ||= {
       'resourceType': 'DocumentReference',
+      'id': 'b79484c9-1170-44cd-9910-f9013ff2ea1f',
       'status': 'current',
       'type': {
         'coding': [
@@ -541,7 +542,13 @@ module Cerner
                 '/$docref?patient=13160351'
         }
       ],
-      'entry': [R4_DOCUMENT_REFERENCE_CCD]
+      'entry': [
+        {
+          'fullUrl': 'https://fhir-open.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d'\
+          '/DocumentReference/b79484c9-1170-44cd-9910-f9013ff2ea1f',
+          'resource': R4_DOCUMENT_REFERENCE_CCD
+        }
+      ]
     }.freeze
 
     R4_DOCUMENT_REFERENCE_CCD_PATIENT_BUNDLE ||= {
@@ -555,7 +562,13 @@ module Cerner
                 '/$docref?patient=13160351'
         }
       ],
-      'entry': [R4_DOCUMENT_REFERENCE_CCD]
+      'entry': [
+        {
+          'fullUrl': 'https://fhir-ehr.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d'\
+          '/DocumentReference/b79484c9-1170-44cd-9910-f9013ff2ea1f',
+          'resource': R4_DOCUMENT_REFERENCE_CCD
+        }
+      ]
     }.freeze
   end
 end

--- a/lib/resources/example_json/r4_examples_document_reference.rb
+++ b/lib/resources/example_json/r4_examples_document_reference.rb
@@ -543,5 +543,19 @@ module Cerner
       ],
       'entry': [R4_DOCUMENT_REFERENCE_CCD]
     }.freeze
+
+    R4_DOCUMENT_REFERENCE_CCD_PATIENT_BUNDLE ||= {
+      'resourceType': 'Bundle',
+      'id': '2cb9157f-0f05-4fe4-af14-95d5808a4070',
+      'type': 'searchset',
+      'link': [
+        {
+          'relation': 'self',
+          'url': 'https://fhir-ehr.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/DocumentReference'\
+                '/$docref?patient=13160351'
+        }
+      ],
+      'entry': [R4_DOCUMENT_REFERENCE_CCD]
+    }.freeze
   end
 end


### PR DESCRIPTION
Description
----
Added patient access for R4 Document Reference CCD search

Screenshot before merge
----

<img width="1792" alt="Header" src="https://user-images.githubusercontent.com/75377641/107646066-89a7af80-6c9f-11eb-8116-469c261aedbe.png">
<img width="1792" alt="Overview" src="https://user-images.githubusercontent.com/75377641/107646129-9e844300-6c9f-11eb-88b5-36a2babc6e99.png">
<img width="1792" alt="PatientAccess-enabled" src="https://user-images.githubusercontent.com/75377641/107646202-b360d680-6c9f-11eb-8f56-04962f5d419d.png">
<img width="1792" alt="DocRefCCD-response" src="https://user-images.githubusercontent.com/75377641/107927201-afcd9800-6f9c-11eb-804a-beda22d6c59d.png">
<img width="1792" alt="DocRefCCD-response-patient access" src="https://user-images.githubusercontent.com/75377641/107927252-bfe57780-6f9c-11eb-90fa-b8f723ce4563.png">




PR Checklist
----
- [x] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.                                                                                                
