### PR TITLE
Updated related person remove telecom operation

### DIFF
--- a/lib/resources/example_json/r4_examples_relatedperson.rb
+++ b/lib/resources/example_json/r4_examples_relatedperson.rb
@@ -1420,6 +1420,10 @@ module Cerner
         'value': 'Potter'
       },
       {
+        'op': 'remove',
+        'path': '/telecom/0'
+      },
+      {
         'op': 'replace',
         'path': '/name/0/prefix',
         'value': ['Mr.']

--- a/lib/resources/example_json/r4_examples_relatedperson.rb
+++ b/lib/resources/example_json/r4_examples_relatedperson.rb
@@ -1396,6 +1396,10 @@ module Cerner
         }
       },
       {
+        'op': 'remove',
+        'path': '/telecom/0'
+      },
+      {
         'op': 'test',
         'path': '/telecom/0/id',
         'value': 'CI-PH-29811920-0'
@@ -1418,10 +1422,6 @@ module Cerner
         'op': 'replace',
         'path': '/name/0/family',
         'value': 'Potter'
-      },
-      {
-        'op': 'remove',
-        'path': '/telecom/0'
       },
       {
         'op': 'replace',

--- a/lib/resources/example_json/r4_examples_relatedperson.rb
+++ b/lib/resources/example_json/r4_examples_relatedperson.rb
@@ -1396,13 +1396,13 @@ module Cerner
         }
       },
       {
-        'op': 'remove',
-        'path': '/telecom/0'
-      },
-      {
         'op': 'test',
         'path': '/telecom/0/id',
         'value': 'CI-PH-29811920-0'
+      },
+      {
+        'op': 'remove',
+        'path': '/telecom/0'
       },
       {
         'op': 'test',

--- a/lib/resources/r4/related_person_patch.yaml
+++ b/lib/resources/r4/related_person_patch.yaml
@@ -302,3 +302,19 @@ operations:
         <li>If no suffix value is provided, the suffix on the name will be unset.</li>
         <li>Only one suffix value may be provided.</li>
       </ul>
+
+  - name: remove-telecom
+      path: /telecom/{index}
+      operation: remove
+      type: N/A
+      url: https://hl7.org/fhir/R4/patient-definitions.html#related person.telecom
+      description: Remove the telecom at the given <code>{index}</code> in the list of related person telecoms.
+      example: |
+        {
+          "op": "remove"
+          "path": "/telecom/1"
+        }
+      note: >
+        <ul>
+          <li>Requires a <a href="#test-telecom-id">test operation</a> to be provided for the `ContactPoint.id` of the telecom intended to be removed.</li>
+        </ul>

--- a/lib/resources/r4/related_person_patch.yaml
+++ b/lib/resources/r4/related_person_patch.yaml
@@ -205,6 +205,22 @@ operations:
         "value": "CI-PH-2807950-0"
       }
 
+  - name: remove-telecom
+    path: /telecom/{index}
+    operation: remove
+    type: N/A
+    url: https://hl7.org/fhir/R4/relatedperson-definitions.html#RelatedPerson.telecom
+    description: Remove the telecom at the given <code>{index}</code> in the list of related person telecoms.
+    example: |
+      {
+        "op": "remove"
+        "path": "/telecom/0"
+      }
+    note: >
+      <ul>
+        <li>Requires a <a href="#test-telecom-id">test operation</a> to be provided for the `ContactPoint.id` of the telecom intended to be removed.</li>
+      </ul>
+
   - name: test-name-id
     path: /name/{index}/id
     operation: test
@@ -301,20 +317,4 @@ operations:
         <li>This operation is only supported for the first name in the list of related person names (<code>{index}</code> == 0).</li>
         <li>If no suffix value is provided, the suffix on the name will be unset.</li>
         <li>Only one suffix value may be provided.</li>
-      </ul>
-
-  - name: remove-telecom
-    path: /telecom/{index}
-    operation: remove
-    type: N/A
-    url: https://hl7.org/fhir/R4/relatedperson-definitions.html#RelatedPerson.telecom
-    description: Remove the telecom at the given <code>{index}</code> in the list of related person telecoms.
-    example: |
-      {
-        "op": "remove"
-        "path": "/telecom/0"
-      }
-    note: >
-      <ul>
-        <li>Requires a <a href="#test-telecom-id">test operation</a> to be provided for the `ContactPoint.id` of the telecom intended to be removed.</li>
       </ul>

--- a/lib/resources/r4/related_person_patch.yaml
+++ b/lib/resources/r4/related_person_patch.yaml
@@ -304,17 +304,17 @@ operations:
       </ul>
 
   - name: remove-telecom
-      path: /telecom/{index}
-      operation: remove
-      type: N/A
-      url: https://hl7.org/fhir/R4/patient-definitions.html#related person.telecom
-      description: Remove the telecom at the given <code>{index}</code> in the list of related person telecoms.
-      example: |
-        {
-          "op": "remove"
-          "path": "/telecom/1"
-        }
-      note: >
-        <ul>
-          <li>Requires a <a href="#test-telecom-id">test operation</a> to be provided for the `ContactPoint.id` of the telecom intended to be removed.</li>
-        </ul>
+    path: /telecom/{index}
+    operation: remove
+    type: N/A
+    url: https://hl7.org/fhir/R4/related-person-definitions.html#RelatedPerson.telecom
+    description: Remove the telecom at the given <code>{index}</code> in the list of related person telecoms.
+    example: |
+      {
+        "op": "remove"
+        "path": "/telecom/0"
+      }
+    note: >
+      <ul>
+        <li>Requires a <a href="#test-telecom-id">test operation</a> to be provided for the `ContactPoint.id` of the telecom intended to be removed.</li>
+      </ul>

--- a/lib/resources/r4/related_person_patch.yaml
+++ b/lib/resources/r4/related_person_patch.yaml
@@ -307,7 +307,7 @@ operations:
     path: /telecom/{index}
     operation: remove
     type: N/A
-    url: https://hl7.org/fhir/R4/related-person-definitions.html#RelatedPerson.telecom
+    url: https://hl7.org/fhir/R4/relatedperson-definitions.html#RelatedPerson.telecom
     description: Remove the telecom at the given <code>{index}</code> in the list of related person telecoms.
     example: |
       {


### PR DESCRIPTION
Description
----
Added remove operation for telecom field in related person patch capability.

PR Checklist
----
- [x] Screenshot(s) of changes attached before changes merged.
![image](https://user-images.githubusercontent.com/33324957/111659106-f419b580-8832-11eb-942d-8d9ddad26e39.png)
![image](https://user-images.githubusercontent.com/33324957/111669963-54155980-883d-11eb-9c13-0bb769621137.png)




- [ ] Screenshot(s) of changes attached after changes merged and published.
