### PR TITLE
Fix a few typos in R4 RelatedPerson

### DIFF
--- a/lib/resources/example_json/r4_examples_relatedperson.rb
+++ b/lib/resources/example_json/r4_examples_relatedperson.rb
@@ -476,8 +476,8 @@ module Cerner
       'text': {
         'status': 'extensions',
         'div': '<div xmlns="http://www.w3.org/1999/xhtml"><p><b>Related Person</b></p>'\
-        '<p><b>Name</b>: Li, Mike</p><p><b>DOB</b>: Dec 10, 1994</p>\'
-        <p><b>Gender</b>: male</p><p><b>Patient</b>: MARSTON, JACK</p>'\
+        '<p><b>Name</b>: Li, Mike</p><p><b>DOB</b>: Dec 10, 1994</p>'\
+        '<p><b>Gender</b>: male</p><p><b>Patient</b>: MARSTON, JACK</p>'\
         '<p><b>Status</b>: Active</p><p><b>Relationship</b>: Guardian</p>'\
         '<p><b>Relationship</b>: Unknown</p><p><b>Relationship Level</b>: Encounter</p>'\
         '<p><b>Encounter</b>: 51678301</p></div>'

--- a/lib/resources/r4/related_person_patch.yaml
+++ b/lib/resources/r4/related_person_patch.yaml
@@ -153,6 +153,7 @@ operations:
     note: >
       <ul>
         <li>Requires a <a href="#test-address-id">test operation</a> to be provided for the `Address.id` field of the address to be removed.</li>
+      </ul>
 
   - name: add-telecom
     path: /telecom/-


### PR DESCRIPTION
Description
----
The change in r4_examples_relatedperson.rb fixes an accidentally-escaped quote character

The change in lib/resources/r4/related_person_patch.yaml fixes a slew of rendering issues caused by that missing HTML tag

PR Checklist
----
- [x] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.
