### PR TITLE
Added R4 Patient Phone Extension

### DIFF
--- a/lib/resources/example_json/r4_examples_patient.rb
+++ b/lib/resources/example_json/r4_examples_patient.rb
@@ -313,8 +313,12 @@ module Cerner
             {
               "valueUrl": '(816) 888 8886',
               "url": 'http://hl7.org/fhir/StructureDefinition/iso21090-TEL-address'
+            },
+            {
+              "valueString": "12345",
+              "url": "http://hl7.org/fhir/StructureDefinition/contactpoint-extension"
             }
-          ],
+          ],  
           'system': 'phone',
           'value': '8168888886',
           'use': 'home',
@@ -497,6 +501,13 @@ module Cerner
           'system': 'phone',
           'value': '8168229121',
           'use': 'home',
+          'id': 'CI-PH-29811920-0',
+          "extension": [
+            {
+              "valueString": "1234",
+              "url": "http://hl7.org/fhir/StructureDefinition/contactpoint-extension"
+            }
+          ],  
           'period': {
             'start': '2012-05-17T15:33:18.000Z'
           }

--- a/lib/resources/example_json/r4_examples_patient.rb
+++ b/lib/resources/example_json/r4_examples_patient.rb
@@ -315,10 +315,10 @@ module Cerner
               "url": 'http://hl7.org/fhir/StructureDefinition/iso21090-TEL-address'
             },
             {
-              "valueString": "12345",
-              "url": "http://hl7.org/fhir/StructureDefinition/contactpoint-extension"
+              "valueString": '12345',
+              "url": 'http://hl7.org/fhir/StructureDefinition/contactpoint-extension'
             }
-          ],  
+          ],
           'system': 'phone',
           'value': '8168888886',
           'use': 'home',
@@ -504,10 +504,10 @@ module Cerner
           'id': 'CI-PH-29811920-0',
           "extension": [
             {
-              "valueString": "1234",
-              "url": "http://hl7.org/fhir/StructureDefinition/contactpoint-extension"
+              "valueString": '12345',
+              "url": 'http://hl7.org/fhir/StructureDefinition/contactpoint-extension'
             }
-          ],  
+          ],
           'period': {
             'start': '2012-05-17T15:33:18.000Z'
           }

--- a/lib/resources/r4/patient.yaml
+++ b/lib/resources/r4/patient.yaml
@@ -226,6 +226,12 @@ fields:
           "system": "phone",
           "value": "8168229121",
           "use": "home",
+          "extension": [
+            {
+              "valueString": "12345",
+              "url": "http://hl7.org/fhir/StructureDefinition/contactpoint-extension"
+            }
+          ],  
           "period": {
             "start": "2012-05-17T15:33:18.000Z"
           }
@@ -236,7 +242,9 @@ fields:
     <ul>
       <li>Each telecom must contain the `system`, `use`, and `value` fields.</li>
       <li>When specifying a `period`, the fields must include a time component with a timezone.</li>
-      <li>The `value` field has a character limit of 100.</li>
+      <li>The `value` and `extension.valueString` fields have a character limit of 100.</li>
+      <li>When specifying an `extension`, the `system` field must be 'phone'.</li>
+      <li>When specifying an `extension`, the `extension.url` field must be 'http://hl7.org/fhir/StructureDefinition/contactpoint-extension'.</li>
     </ul>
   url: http://hl7.org/fhir/R4/patient-definitions.html#Patient.telecom
 

--- a/lib/resources/r4/patient_patch.yaml
+++ b/lib/resources/r4/patient_patch.yaml
@@ -240,6 +240,12 @@ operations:
         "system": "phone",
         "value": "8168229121",
         "use": "home",
+        "extension": [
+          {
+            "valueString": "12345",
+            "url": "http://hl7.org/fhir/StructureDefinition/contactpoint-extension"
+          }
+        ],  
         "period": {
           "start": "2012-05-17T15:33:18.000Z"
         }
@@ -307,6 +313,30 @@ operations:
   note: >
     <ul>
       <li>Requires a <a href="#test-telecom-id">test operation</a> to be provided for the `ContactPoint.id` of the telecom whose `rank` is intended to be replaced.</li>
+    </ul>
+- name: replace-telecom-extension
+  path: /telecom/{index}/extension
+  operation: replace
+  type: Extension
+  url: https://hl7.org/fhir/R4/domainresource-definitions.html#DomainResource.extension
+  description: Replaces the phone extension of the telecom at the given <code>{index}</code> in the list of patient telecoms.
+  example: |
+    {
+      "path": "/telecom/1/extension",
+      "op": "replace",
+      "value": [
+        {
+          "valueString": "12345",
+          "url": "http://hl7.org/fhir/StructureDefinition/contactpoint-extension"
+        }
+      ]
+    }
+  note: >
+    <ul>
+      <li>Requires a <a href="#test-telecom-id">test operation</a> to be provided for the `ContactPoint.id` of the telecom whose `extension` value is intended to be replaced.</li>
+      <li>The `system` field of the telecom whose `extension` is intended to be replaced must be 'phone'.</li>
+      <li>If no `valueString` is provided, the phone extension will be unset.</li>
+      <li>The url must be 'http://hl7.org/fhir/StructureDefinition/contactpoint-extension'.</li>
     </ul>
 - name: replace-telecom-period
   path: /telecom/{index}/period


### PR DESCRIPTION
Description
----
The documentation for the R4 Patient.telecom additions for the phone extensions. This shows an example of the phone extension returned through the Patient.telecom.extension field. A phone extension value was also added to show how to write the data when creating a patient, and also for the PATCH operation to add a new telecom. Lastly, the telecom/extension replace operation is described, which is the capability to replace the phone extension on an existing telecom.

PR Checklist
----
- [x] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.

Screenshots
----
<img width="931" alt="Screen Shot 2021-03-12 at 3 10 19 PM" src="https://user-images.githubusercontent.com/26021721/110998940-3def3100-8345-11eb-9845-fe1acfe4b9ba.png">
<img width="889" alt="Screen Shot 2021-03-12 at 3 10 01 PM" src="https://user-images.githubusercontent.com/26021721/110998957-434c7b80-8345-11eb-8bc4-969e93fe8343.png">
<img width="898" alt="Screen Shot 2021-03-12 at 3 09 45 PM" src="https://user-images.githubusercontent.com/26021721/110999020-58290f00-8345-11eb-84bf-4803abd29b00.png">

