### PR TITLE
Updating R4 Coverage with Patient and Encounter Level Public Healthcare Searches and Patches

### DIFF
--- a/content/millennium/r4/financial/coverage.md
+++ b/content/millennium/r4/financial/coverage.md
@@ -203,7 +203,7 @@ The common [errors] and [OperationOutcomes] may be returned.
 
 ## Patch
 
-Patch an existing Encounter-level Coverage.
+Patch an existing Encounter-level or Patient-level Coverage.
 
     PATCH /Coverage/:id
 

--- a/content/millennium/r4/financial/coverage.md
+++ b/content/millennium/r4/financial/coverage.md
@@ -82,6 +82,19 @@ _Implementation Notes_
 
 <%= disclaimer %>
 
+#### Example - Patient-level Public Healthcare Coverage
+
+#### Request
+
+    GET https://fhir-ehr-code.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/Coverage?patient=12724066
+
+#### Response
+
+<%= headers status: 200 %>
+<%= json(:r4_coverage_patient_social_healthcare_bundle) %>
+
+<%= disclaimer %>
+
 ### Example - Encounter-level Coverage
 
 #### Request
@@ -92,6 +105,8 @@ _Implementation Notes_
 
 <%= headers status: 200 %>
 <%= json(:r4_coverage_encounter_bundle) %>
+
+<%= disclaimer %>
 
 #### Example - Encounter-level Public Healthcare Coverage
 
@@ -196,7 +211,8 @@ _Implementation Notes_
 
 * This implementation follows the [JSON Patch](https://tools.ietf.org/html/rfc6902) spec.
 * Only operations on the paths listed below are supported.
-* Only Encounter-level Coverages may be patched. Patches are not currently supported for Patient-level Coverages.
+* For Private Coverages, only Encounter-level Coverages may be patched. For Public Coverages,
+both Encounter-level and Patient-level Coverages may be patched, with the caveat of only supporting the `/period` and `/class/0/value` operations.
 
 ### Authorization Types
 

--- a/lib/resources/example_json/r4_examples_coverage.rb
+++ b/lib/resources/example_json/r4_examples_coverage.rb
@@ -274,8 +274,8 @@ module Cerner
             'text': {
               'status': 'generated',
               'div': '<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Coverage</b></p><p><b>Status</b>: Active</p>'\
-              '<p><b>Beneficiary</b>: SMART, NANCY</p><p><b>Coverage Start Date</b>: Mar 16, 2021  8:04 P.M. UTC</p><p>'\
-              '<b>Payor</b>: Government</p><p><b>Class</b>:</p><dl><dt>Charging Category</dt><dd><b>Value</b>:'\
+              '<p><b>Beneficiary</b>: SMART, NANCY</p><p><b>Coverage Start Date</b>: Mar 16, 2021  8:04 P.M. UTC</p>'\
+              '<p><b>Payor</b>: Government</p><p><b>Class</b>:</p><dl><dt>Charging Category</dt><dd><b>Value</b>:'\
                '2572940471</dd><dd><b>Name</b>: 10-OPC, Class II</dd></dl><p><b>Type</b>: public healthcare</p></div>'
             },
             'status': 'active',

--- a/lib/resources/example_json/r4_examples_coverage.rb
+++ b/lib/resources/example_json/r4_examples_coverage.rb
@@ -187,7 +187,7 @@ module Cerner
             'resourceType': 'Coverage',
             'id': 'PH-98371617-97701467',
             'meta': {
-              'versionId': '2',
+              'versionId': '2-0',
               'lastUpdated': '2020-09-24T17:11:10.000Z'
             },
             'text': {
@@ -243,6 +243,71 @@ module Cerner
                 },
                 'value': '2572499881',
                 'name': 'Charging Category'
+              }
+            ]
+          }
+        }
+      ]
+    }.freeze
+
+    R4_COVERAGE_PATIENT_SOCIAL_HEALTHCARE_BUNDLE ||= {
+      'resourceType': 'Bundle',
+      'id': '8ff4481d-ce55-4b3f-ac2c-4d4fd3cad4c0',
+      'type': 'searchset',
+      'total': 1,
+      'link': [
+        {
+          'relation': 'self',
+          'url': 'https://fhir-ehr-code.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/Coverage?patient=12724066'
+        }
+      ],
+      'entry': [
+        {
+          'fullUrl': 'https://fhir-ehr-code.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/Coverage/PHP-490218084-12724066',
+          'resource': {
+            'resourceType': 'Coverage',
+            'id': 'PHP-490218084-12724066',
+            'meta': {
+              'versionId': '134-0',
+              'lastUpdated': '2021-03-16T20:04:11.000Z'
+            },
+            'text': {
+              'status': 'generated',
+              'div': '<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Coverage</b></p><p><b>Status</b>: Active</p>'\
+              '<p><b>Beneficiary</b>: SMART, NANCY</p><p><b>Coverage Start Date</b>: Mar 16, 2021  8:04 P.M. UTC</p><p>'\
+              '<b>Payor</b>: Government</p><p><b>Class</b>:</p><dl><dt>Charging Category</dt><dd><b>Value</b>:'\
+               '2572940471</dd><dd><b>Name</b>: 10-OPC, Class II</dd></dl><p><b>Type</b>: public healthcare</p></div>'
+            },
+            'status': 'active',
+            'type': {
+              'coding': [
+                {
+                  'system': 'http://terminology.hl7.org/CodeSystem/v3-ActCode',
+                  'code': 'PUBLICPOL',
+                  'display': 'public healthcare'
+                }
+              ],
+              'text': 'public healthcare'
+            },
+            'beneficiary': {
+              'reference': 'Patient/12462008',
+              'display': 'TRAUMA SURGERY, TESTONE'
+            },
+            'period': {
+              'start': '2021-03-16T20:04:11.000Z'
+            },
+            'payor': [
+              {
+                'display': 'Government'
+              }
+            ],
+            'class': [
+              {
+                'type': {
+                  'text': 'Charging Category'
+                },
+                'value': '2572940471',
+                'name': '10-OPC, Class II'
               }
             ]
           }

--- a/lib/resources/r4/coverage_encounter_patch.yaml
+++ b/lib/resources/r4/coverage_encounter_patch.yaml
@@ -16,7 +16,8 @@ operations:
       }
     note: >
       <ul>
-        <li>The `Coverage.class` at index 0 represents the plan for the Coverage.</li>
+        <li>For Private Coverages, the `Coverage.class` at index 0 represents the plan for the Coverage.</li>
+        <li>For Public Coverages, the `Coverage.class` at index 0 represents the charging category for the Coverage.</li>
       </ul>
 
   - name: replace-class-1-value


### PR DESCRIPTION
Description
----
Adding the patient/encounter level public healthcare searches and patches. Documentation that explains the changes, including examples of the public healthcare reads, and details of the patch capabilities, and limitations, for the public healthcare coverages.

PR Checklist
----
- [x] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.

Screenshots
----
<img width="1039" alt="Screen Shot 2021-03-18 at 3 00 07 PM" src="https://user-images.githubusercontent.com/26021721/111690116-d03a7d80-87fa-11eb-9c7f-a5d63a408de6.png">
<img width="931" alt="Screen Shot 2021-03-18 at 3 00 24 PM" src="https://user-images.githubusercontent.com/26021721/111690132-d3356e00-87fa-11eb-9395-ce084b354f35.png">
<img width="890" alt="Screen Shot 2021-03-18 at 3 00 54 PM" src="https://user-images.githubusercontent.com/26021721/111690143-d597c800-87fa-11eb-8564-a0f11d7f392a.png">

