### PR TITLE
Update implementation notes for R4 Condition create

### DIFF
--- a/content/millennium/dstu2/general-clinical/condition.md
+++ b/content/millennium/dstu2/general-clinical/condition.md
@@ -133,7 +133,10 @@ _Implementation Notes_
   * For Conditions with a category code of [problem](https://argonautwiki.hl7.org/Argonaut_Condition_Category_Codes):
     * If `Condition.dateRecorded` is set on the request body, its value will currently be ignored.
   * Creating Conditions with a category code of [health-concern](https://argonautwiki.hl7.org/Argonaut_Condition_Category_Codes) is not currently supported.
-* The code.coding field can have at most 2 codings, one of which must be set as userSelected true and the other one must be set as userSelected false.
+* The code.coding field can have at most 2 codings.
+  * One of the codings must have userSelected: true
+  * The other coding must have userSelected: false
+* A Condition with a category code of diagnosis will be automatically prioritized to the least significant priority by the Cerner Millennium EHR.
 
 ### Authorization Types
 

--- a/content/millennium/r4/general-clinical/condition.md
+++ b/content/millennium/r4/general-clinical/condition.md
@@ -164,10 +164,13 @@ Create a new Condition.
 
 _Implementation Notes_
 
-* Only the body fields mentioned below are supported. Unsupported fields will be ignored.
+* The Condition Create API supports only the API fields mentioned below. Unsupported fields will be ignored.
 * Modifier fields should not be provided, and will cause the transaction to fail.
-* The code.coding field can have at most 2 codings, one of which must be set as userSelected true and the other one must be set as userSelected false.
-* Currently `problem-list-item` and `encounter-diagnosis` are supported.
+* The code.coding field can have at most 2 codings.
+  * One of the codings must have userSelected: true
+  * The other coding must have userSelected: false
+* The Condition Create API currently supports only Conditions with a category of `problem-list-item` or `encounter-diagnosis`.
+* An `encounter-diagnosis` Condition will be automatically prioritized to the least significant priority by the Cerner Millennium EHR.
 
 ### Authorization Types
 


### PR DESCRIPTION
Description
----
Adds a new R4 Condition create immplementation note:

```
An `encounter-diagnosis` Condition will be automatically prioritized to the least significant priority by the Cerner Millennium EHR
```

and rewords some of the others for clarity

PR Checklist
----
- [x] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.
