### PR TITLE
Slot status patch

### DIFF
--- a/content/millennium/r4/scheduling/slot.md
+++ b/content/millennium/r4/scheduling/slot.md
@@ -193,6 +193,63 @@ List an individual Slot by its id:
 
 The common [errors] and [OperationOutcomes] may be returned.
 
+## Patch
+
+Patch an existing Slot.
+
+    PATCH /Slot/:id
+
+_Implementation Notes_
+
+* This implementation follows the [JSON Patch](https://tools.ietf.org/html/rfc6902) spec.
+* Only operations on the paths listed below are supported.
+
+### Authorization Types
+
+<%= authorization_types(provider: true, system: true) %>
+
+### Headers
+
+<%= headers head: {Authorization: '&lt;OAuth2 Bearer Token>', 'Accept': 'application/fhir+json',
+                   'Content-Type': 'application/json-patch+json', 'If-Match': 'W/"&lt;Current version of the Slot resource>"'} %>
+
+
+### Patch Operations
+
+<%= patch_definition_table(:slot_patch, :r4) %>
+
+### Example
+
+#### Request
+
+    PATCH https://fhir-ehr.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/Slot/4047611-32216049-61518614-0
+
+#### Body
+
+<%= json(:r4_slot_patch) %>
+
+#### Response
+
+<%= headers status: 200 %>
+<pre class="terminal">
+Cache-Control: no-cache
+Content-Length: 20
+Content-Type: text/html
+Date: Tue, 06 Apr 2021 15:36:47 GMT
+Etag: W/"410v795030969834"
+Last-Modified: Tue, 06 Apr 2021 15:36:47 GMT
+Vary: Origin
+X-Request-Id: 6801a2c5-bf2d-414b-9f6a-7bcf39cc69d9
+</pre>
+
+<%= disclaimer %>
+
+The `ETag` response header indicates the current `If-Match` version to use on subsequent updates.
+
+### Errors
+
+The common [errors] and [OperationOutcomes] may be returned.
+
 [`reference`]: http://hl7.org/fhir/r4/search.html#reference
 [`token`]: http://hl7.org/fhir/r4/search.html#token
 [`date`]: http://hl7.org/fhir/r4/search.html#date

--- a/content/millennium/r4/scheduling/slot.md
+++ b/content/millennium/r4/scheduling/slot.md
@@ -195,7 +195,7 @@ The common [errors] and [OperationOutcomes] may be returned.
 
 ## Patch
 
-<%= beta_tag(action:true, known_issues: ["A 500 Internal Server Error is thrown when an invalid version id is used in the If-Match Header"]) %>
+<%= beta_tag(action: true, known_issues: ["A 500 Internal Server Error is thrown when an invalid version id is used in the If-Match Header"]) %>
 
 Patch an existing Slot.
 

--- a/content/millennium/r4/scheduling/slot.md
+++ b/content/millennium/r4/scheduling/slot.md
@@ -195,7 +195,7 @@ The common [errors] and [OperationOutcomes] may be returned.
 
 ## Patch
 
-<%= beta_tag(action: true, known_issues: 'A 500 Internal Server Error is thrown when an invalid version id is used in the If-Match Header.') %>
+<%= beta_tag(known_issues: ["A 500 Internal Server Error is thrown when an invalid version id is used in the If-Match Header", "keifer is thur"]) %>
 
 Patch an existing Slot.
 

--- a/content/millennium/r4/scheduling/slot.md
+++ b/content/millennium/r4/scheduling/slot.md
@@ -195,11 +195,7 @@ The common [errors] and [OperationOutcomes] may be returned.
 
 ## Patch
 
-<%= beta_tag(action: true) %>
-
-Known Issues:
-
-* A 500 Internal Server Error is thrown when an invalid version id is used in the If-Match Header
+<%= beta_tag(action: true, known_issues: 'A 500 Internal Server Error is thrown when an invalid version id is used in the If-Match Header.') %>
 
 Patch an existing Slot.
 

--- a/content/millennium/r4/scheduling/slot.md
+++ b/content/millennium/r4/scheduling/slot.md
@@ -195,7 +195,7 @@ The common [errors] and [OperationOutcomes] may be returned.
 
 ## Patch
 
-<%= beta_tag(known_issues: ["A 500 Internal Server Error is thrown when an invalid version id is used in the If-Match Header"]) %>
+<%= beta_tag(action:true, known_issues: ["A 500 Internal Server Error is thrown when an invalid version id is used in the If-Match Header"]) %>
 
 Patch an existing Slot.
 

--- a/content/millennium/r4/scheduling/slot.md
+++ b/content/millennium/r4/scheduling/slot.md
@@ -197,6 +197,10 @@ The common [errors] and [OperationOutcomes] may be returned.
 
 <%= beta_tag(action: true) %>
 
+Known Issues:
+
+* A 500 Internal Server Error is thrown when an invalid version id is used in the If-Match Header
+
 Patch an existing Slot.
 
     PATCH /Slot/:id
@@ -215,7 +219,6 @@ _Implementation Notes_
 <%= headers head: {Authorization: '&lt;OAuth2 Bearer Token>', 'Accept': 'application/fhir+json',
                    'Content-Type': 'application/json-patch+json', 'If-Match': 'W/"&lt;Current version of the Slot resource>"'} %>
 
-
 ### Patch Operations
 
 <%= patch_definition_table(:slot_patch, :r4) %>
@@ -224,7 +227,7 @@ _Implementation Notes_
 
 #### Request
 
-    PATCH https://fhir-ehr.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/Slot/4047611-32216049-61518614-0
+    PATCH https://fhir-ehr-code.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/Slot/4047611-32216049-61518614-0
 
 #### Body
 

--- a/content/millennium/r4/scheduling/slot.md
+++ b/content/millennium/r4/scheduling/slot.md
@@ -195,7 +195,7 @@ The common [errors] and [OperationOutcomes] may be returned.
 
 ## Patch
 
-<%= beta_tag(known_issues: ["A 500 Internal Server Error is thrown when an invalid version id is used in the If-Match Header", "keifer is thur"]) %>
+<%= beta_tag(known_issues: ["A 500 Internal Server Error is thrown when an invalid version id is used in the If-Match Header"]) %>
 
 Patch an existing Slot.
 

--- a/content/millennium/r4/scheduling/slot.md
+++ b/content/millennium/r4/scheduling/slot.md
@@ -195,6 +195,8 @@ The common [errors] and [OperationOutcomes] may be returned.
 
 ## Patch
 
+<%= beta_tag(action: true) %>
+
 Patch an existing Slot.
 
     PATCH /Slot/:id

--- a/lib/resources.rb
+++ b/lib/resources.rb
@@ -2,6 +2,7 @@
 
 require 'cgi'
 require 'yajl/json_gem'
+require 'pry'
 
 module Cerner
   module Resources
@@ -143,14 +144,21 @@ module Cerner
         "guaranteed to yield the results shown on the site.</p>\n"
       end
 
-      def beta_tag(action: false)
-        "<div class=\"beta-tag\"></div>This Resource#{' Action' if action} is still under development."
+      def beta_tag(action: false, known_issues: nil)
+        beta = "<div class=\"beta-tag\"></div>This Resource#{' Action' if action} is still under development.\n"\
+        "- test1\n\n - test2"
+
+
+        # if known_issues
+        #   beta += "<br /> Known Issues:<br /> <ul> <li> #{known_issues} </li> </ul>"
+        # end
+
+        beta
       end
 
       def deep_transform_values(value)
         return CGI.escape_html(value) if value.is_a?(String)
         return value unless value.is_a?(Hash)
-
         value.transform_values do |val|
           if val.is_a?(Array)
             val.map! { |array_value| deep_transform_values(array_value) }

--- a/lib/resources.rb
+++ b/lib/resources.rb
@@ -146,12 +146,10 @@ module Cerner
 
       def beta_tag(action: false, known_issues: nil)
         beta = "<div class=\"beta-tag\"></div>This Resource#{' Action' if action} is still under development.\n"\
-        "- test1\n\n - test2"
-
-
-        # if known_issues
-        #   beta += "<br /> Known Issues:<br /> <ul> <li> #{known_issues} </li> </ul>"
-        # end
+        
+        if known_issues
+          beta += "<br /> Known Issues:<br /> <ul> <li> #{known_issues} </li> </ul>"
+        end
 
         beta
       end

--- a/lib/resources.rb
+++ b/lib/resources.rb
@@ -148,7 +148,7 @@ module Cerner
       # @param action [boolean] flag to denote if a resource action is under development. Defaults to false.
       # @param known_issues [Array<String>] an array of known issues for the resource/action.
       #
-      # @returns an HTML div for beta tag.
+      # @return [String] an HTML div for beta tag.
       def beta_tag(action: false, known_issues: nil)
         beta = "<div class=\"beta-tag\"><p>This Resource#{' Action' if action} is still under development.</p>"
 

--- a/lib/resources.rb
+++ b/lib/resources.rb
@@ -145,18 +145,23 @@ module Cerner
       end
 
       def beta_tag(action: false, known_issues: nil)
-        beta = "<div class=\"beta-tag\"></div>This Resource#{' Action' if action} is still under development.\n"\
-        
+        beta = "<div class=\"beta-tag\"><p>This Resource#{' Action' if action} is still under development.</p>"
+
         if known_issues
-          beta += "<br /> Known Issues:<br /> <ul> <li> #{known_issues} </li> </ul>"
+          beta += '<p>Known Issues:</p><ul>'
+          known_issues.each do |issue|
+            beta += "<li>#{issue}</li>"
+          end
+          beta += '</ul>'
         end
 
-        beta
+        beta + '</div>'
       end
 
       def deep_transform_values(value)
         return CGI.escape_html(value) if value.is_a?(String)
         return value unless value.is_a?(Hash)
+
         value.transform_values do |val|
           if val.is_a?(Array)
             val.map! { |array_value| deep_transform_values(array_value) }

--- a/lib/resources.rb
+++ b/lib/resources.rb
@@ -2,7 +2,6 @@
 
 require 'cgi'
 require 'yajl/json_gem'
-require 'pry'
 
 module Cerner
   module Resources

--- a/lib/resources.rb
+++ b/lib/resources.rb
@@ -143,6 +143,12 @@ module Cerner
         "guaranteed to yield the results shown on the site.</p>\n"
       end
 
+      # Public: Helper method to create a tag to denote if a resource/action is still under development.
+      #
+      # @param action [boolean] flag to denote if a resource action is under development. Defaults to false.
+      # @param known_issues [Array<String>] an array of known issues for the resource/action.
+      #
+      # @returns an HTML div for beta tag.
       def beta_tag(action: false, known_issues: nil)
         beta = "<div class=\"beta-tag\"><p>This Resource#{' Action' if action} is still under development.</p>"
 

--- a/lib/resources/example_json/r4_examples_slot.rb
+++ b/lib/resources/example_json/r4_examples_slot.rb
@@ -411,5 +411,13 @@ module Cerner
         }
       ]
     }.freeze
+
+    R4_SLOT_PATCH ||= [
+      {
+        'op': 'replace',
+        'path': '/status',
+        'value': 'busy-tentative'
+      }
+    ].freeze
   end
 end

--- a/lib/resources/r4/slot_patch.yaml
+++ b/lib/resources/r4/slot_patch.yaml
@@ -2,7 +2,7 @@
 name: Slot
 field_name_base_url: https://hl7.org/fhir/r4/slot-definitions.html#Slot
 operations:
-  - name: replace-status
+  - name: status
     path: /status
     operation: replace
     type: code

--- a/lib/resources/r4/slot_patch.yaml
+++ b/lib/resources/r4/slot_patch.yaml
@@ -2,14 +2,19 @@
 name: Slot
 field_name_base_url: https://hl7.org/fhir/r4/slot-definitions.html#Slot
 operations:
-  - name: status
+  - name: replace-status
     path: /status
     operation: replace
     type: code
     url: https://hl7.org/fhir/R4/slot-definitions.html#Slot.status
-    description: Replace the slot status.
+    description: The status of the slot.
     example: |
       {
+        "op": "replace",
+        "path": "/status"
         "status": "free"
       }
-    note: Currently supports only `free` and `busy tentative`.
+    note: >
+      <ul>
+      <li>Only `free` and `busy tentative`.</li>
+      </ul>

--- a/lib/resources/r4/slot_patch.yaml
+++ b/lib/resources/r4/slot_patch.yaml
@@ -1,0 +1,15 @@
+---
+name: Related Person
+field_name_base_url: https://hl7.org/fhir/r4/related-person-definitions.html#RelatedPerson
+operations:
+  - name: status
+    path: /status
+    operation: replace
+    type: code
+    url: https://hl7.org/fhir/R4/slot-definitions.html#Slot.status
+    description: Replace the slot status.
+    example: |
+      {
+        "status": "free"
+      }
+    note: Currently supports only `free` and `busy tentative`.

--- a/lib/resources/r4/slot_patch.yaml
+++ b/lib/resources/r4/slot_patch.yaml
@@ -16,5 +16,5 @@ operations:
       }
     note: >
       <ul>
-      <li>Only `free` and `busy tentative`.</li>
+        <li>Only `free` and `busy tentative` are supported.</li>
       </ul>

--- a/lib/resources/r4/slot_patch.yaml
+++ b/lib/resources/r4/slot_patch.yaml
@@ -16,5 +16,5 @@ operations:
       }
     note: >
       <ul>
-        <li>Only `free` and `busy tentative` are supported.</li>
+        <li>Only `free` and `busy-tentative` are supported.</li>
       </ul>

--- a/lib/resources/r4/slot_patch.yaml
+++ b/lib/resources/r4/slot_patch.yaml
@@ -13,3 +13,4 @@ operations:
         "status": "free"
       }
     note: Currently supports only `free` and `busy tentative`.
+    

--- a/lib/resources/r4/slot_patch.yaml
+++ b/lib/resources/r4/slot_patch.yaml
@@ -2,7 +2,7 @@
 name: Slot
 field_name_base_url: https://hl7.org/fhir/r4/slot-definitions.html#Slot
 operations:
-  - name: status
+  - name: replace-status
     path: /status
     operation: replace
     type: code

--- a/lib/resources/r4/slot_patch.yaml
+++ b/lib/resources/r4/slot_patch.yaml
@@ -1,6 +1,6 @@
 ---
-name: Related Person
-field_name_base_url: https://hl7.org/fhir/r4/related-person-definitions.html#RelatedPerson
+name: Slot
+field_name_base_url: https://hl7.org/fhir/r4/slot-definitions.html#Slot
 operations:
   - name: status
     path: /status
@@ -13,4 +13,3 @@ operations:
         "status": "free"
       }
     note: Currently supports only `free` and `busy tentative`.
-    

--- a/spec/lib/resources_spec.rb
+++ b/spec/lib/resources_spec.rb
@@ -676,7 +676,7 @@ describe Cerner::Resources::Helpers do
             '<li>hi</li><li>hello</li></ul></div>'
           end
 
-          it 'returns the beta_tag div for a Resource' do
+          it 'returns the beta_tag div for a Resource with known issues' do
             expect(beta_tag_parameters).to eq(beta_tag_div)
           end
         end
@@ -699,7 +699,7 @@ describe Cerner::Resources::Helpers do
             '<li>hi</li><li>hello</li></ul></div>'
           end
 
-          it 'returns the beta_tag div for a Resource Action' do
+          it 'returns the beta_tag div for a Resource Action with known issues' do
             expect(beta_tag_parameters).to eq(beta_tag_action_div)
           end
         end

--- a/spec/lib/resources_spec.rb
+++ b/spec/lib/resources_spec.rb
@@ -636,10 +636,10 @@ describe Cerner::Resources::Helpers do
   describe '#beta_tag' do
     subject(:beta_tag) { Cerner::Resources::Helpers.beta_tag }
     let(:beta_tag_div) do
-      '<div class="beta-tag"></div>This Resource is still under development.'
+      '<div class="beta-tag"><p>This Resource is still under development.</p></div>'
     end
     let(:beta_tag_action_div) do
-      '<div class="beta-tag"></div>This Resource Action is still under development.'
+      '<div class="beta-tag"><p>This Resource Action is still under development.</p></div>'
     end
 
     context 'when no parameters are passed in' do
@@ -649,21 +649,59 @@ describe Cerner::Resources::Helpers do
     end
 
     context 'when parameters are passed in' do
-      subject(:beta_tag_parameters) { Cerner::Resources::Helpers.beta_tag(action: action) }
+      subject(:beta_tag_parameters) { Cerner::Resources::Helpers.beta_tag(action: action, known_issues: issues) }
+      let(:issues) { %w[hi hello] }
+      let(:beta_tag_div) do
+        '<div class="beta-tag"></div>This Resource is still under development.<p>Known Issues:</p><ul><li>hi</li>'\
+        '<li>hello</li></ul></p>'
+      end
 
       context 'when action is false' do
         let(:action) { false }
 
-        it 'returns the beta_tag div for a Resource' do
-          expect(beta_tag_parameters).to eq(beta_tag_div)
+        context 'when known issues are not present' do
+          let(:issues) { nil }
+          let(:beta_tag_div) do
+            '<div class="beta-tag"><p>This Resource is still under development.</p></div>'
+          end
+
+          it 'returns the beta_tag div for a Resource' do
+            expect(beta_tag_parameters).to eq(beta_tag_div)
+          end
+        end
+
+        context 'when known issues are present' do
+          let(:beta_tag_div) do
+            '<div class="beta-tag"><p>This Resource is still under development.</p><p>Known Issues:</p><ul>'\
+            '<li>hi</li><li>hello</li></ul></div>'
+          end
+
+          it 'returns the beta_tag div for a Resource' do
+            expect(beta_tag_parameters).to eq(beta_tag_div)
+          end
         end
       end
 
       context 'when action is true' do
         let(:action) { true }
 
-        it 'returns the beta_tag div for a Resource Action' do
-          expect(beta_tag_parameters).to eq(beta_tag_action_div)
+        context 'when known issues are not present' do
+          let(:issues) { nil }
+
+          it 'returns the beta_tag div for a Resource Action' do
+            expect(beta_tag_parameters).to eq(beta_tag_action_div)
+          end
+        end
+
+        context 'when known issues are present' do
+          let(:beta_tag_action_div) do
+            '<div class="beta-tag"><p>This Resource Action is still under development.</p><p>Known Issues:</p><ul>'\
+            '<li>hi</li><li>hello</li></ul></div>'
+          end
+
+          it 'returns the beta_tag div for a Resource Action' do
+            expect(beta_tag_parameters).to eq(beta_tag_action_div)
+          end
         end
       end
     end

--- a/static/css/documentation.css
+++ b/static/css/documentation.css
@@ -1749,6 +1749,17 @@ Beta tag
     font-size: 24px;
 }
 
+/* Known Issues Heading */
+.beta-tag p:nth-child(2) {
+  font-size: 16px;
+  margin-bottom: 5px;
+}
+
+/* Known Issues List */
+.beta-tag ul {
+  margin-top: 0px;
+  font-size: 14px;
+}
 /* @end */
 
 /* -----------------------------

--- a/static/css/documentation.css
+++ b/static/css/documentation.css
@@ -1732,7 +1732,7 @@ pre span.comment {color: #aaa;}
 Beta tag
 -------------------------------*/
 
-.beta-tag+p {
+.beta-tag {
     padding: 8px 35px 8px 14px;
     margin-bottom: 20px;
     border-radius: 4px;
@@ -1742,7 +1742,7 @@ Beta tag
     font-size: 20px;
 }
 
-.beta-tag+p:before {
+.beta-tag:before {
     content: "⚠ BETA";
     font-weight: bold;
     display: block;


### PR DESCRIPTION
Description
----
Added replace operation for R4 Slot

Screenshots
----

<img width="986" alt="Screen Shot 2021-04-15 at 4 12 29 PM" src="https://user-images.githubusercontent.com/28937462/114939010-73d07b00-9e05-11eb-9caa-38b3a4926dff.png">
<img width="721" alt="Screen Shot 2021-04-15 at 8 27 36 AM" src="https://user-images.githubusercontent.com/28937462/114877017-84143600-9dc4-11eb-9725-4da91f55bbb5.png">
<img width="1012" alt="Screen Shot 2021-04-15 at 8 27 42 AM" src="https://user-images.githubusercontent.com/28937462/114877022-85ddf980-9dc4-11eb-9981-12d5a02eef85.png">



PR Checklist
----
- [x] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.
