### PR TITLE
Questionnaire note-allowed extension

### DIFF
--- a/content/millennium/r4/definitional-artifacts/questionnaire.md
+++ b/content/millennium/r4/definitional-artifacts/questionnaire.md
@@ -22,6 +22,7 @@ The following fields are returned if valued:
 * [Patient Subject Type](https://hl7.org/fhir/R4/questionnaire-definitions.html#Questionnaire.subjectType){:target="_blank"}
 * [Item](https://hl7.org/fhir/R4/questionnaire-definitions.html#Questionnaire.item){:target="_blank"}
     * [Link id](https://hl7.org/fhir/R4/questionnaire-definitions.html#Questionnaire.item.linkId){:target="_blank"}
+    * [Extension](#extensions)
     * [Text](https://hl7.org/fhir/R4/questionnaire-definitions.html#Questionnaire.item.text){:target="_blank"}
     * [Type](https://hl7.org/fhir/R4/questionnaire-definitions.html#Questionnaire.item.type){:target="_blank"}
     * [Item](https://hl7.org/fhir/R4/questionnaire-definitions.html#Questionnaire.item){:target="_blank"}
@@ -31,7 +32,7 @@ The following fields are returned if valued:
         * [Required](https://hl7.org/fhir/R4/questionnaire-definitions.html#Questionnaire.item.required){:target="_blank"}
         * [Repeats](https://hl7.org/fhir/R4/questionnaire-definitions.html#Questionnaire.item.repeats){:target="_blank"}
         * [Max Length](https://hl7.org/fhir/R4/questionnaire-definitions.html#Questionnaire.item.maxLength){:target="_blank"}
-        * [Extension](https://hl7.org/fhir/R4/extension-maxdecimalplaces.html){:target="_blank"}
+        * [Extension](#extensions)
         * [Answer Option](https://hl7.org/fhir/R4/questionnaire-definitions.html#Questionnaire.item.answerOption){:target="_blank"}
     
 ## Terminology Bindings
@@ -41,6 +42,15 @@ The following fields are returned if valued:
 ## Extensions
 
 * [Max Decimal Places]
+* [Note Allowed]
+
+### Custom Extensions
+
+URLs for custom extensions are defined as `https://fhir-ehr.cerner.com/r4/StructureDefinition/{id}`
+
+ ID             | Value\[x] Type                                              | Description                   
+----------------|-------------------------------------------------------------|-------------------------------
+ `note-allowed` | [`Boolean`](https://hl7.org/fhir/r4/datatypes.html#boolean) | Whether a comment is allowed.
 
 ## Search
 
@@ -115,6 +125,7 @@ List an individual Questionnaire by its id:
 The common [errors] and [OperationOutcomes] may be returned.
 
 [`token`]: https://hl7.org/fhir/R4/search.html#token
+[Note Allowed]: #custom-extensions
 [Max Decimal Places]: https://hl7.org/fhir/R4/extension-maxdecimalplaces.html
 [errors]: ../../#client-errors
 [OperationOutcomes]: ../../#operation-outcomes

--- a/lib/resources/example_json/r4_examples_questionnaire.rb
+++ b/lib/resources/example_json/r4_examples_questionnaire.rb
@@ -14,6 +14,12 @@ module Cerner
       'item': [
         {
           'linkId': '93',
+          'extension': [
+            {
+              'valueBoolean': true,
+              'url': 'https://fhir-ehr.cerner.com/r4/StructureDefinition/note-allowed'
+            }
+          ],
           'text': 'Tobacco',
           'type': 'group',
           'item': [
@@ -113,13 +119,6 @@ module Cerner
               'required': false,
               'repeats': false,
               'maxLength': 6
-            },
-            {
-              'linkId': '93-comment',
-              'text': 'Comment:',
-              'type': 'text',
-              'required': false,
-              'repeats': false
             }
           ]
         }


### PR DESCRIPTION
Description
----
Questionnaire now exposes the note-allowed extension on the item instead of the comment question

<img width="1680" alt="Screen Shot 2021-04-19 at 8 13 07 AM" src="https://user-images.githubusercontent.com/56039503/115242163-3b6fbc00-a0e7-11eb-800e-3d8ace1cf318.png">
<img width="1252" alt="Screen Shot 2021-04-19 at 8 13 55 AM" src="https://user-images.githubusercontent.com/56039503/115242172-3d397f80-a0e7-11eb-9266-1b8521643a0f.png">

PR Checklist
----
- [x] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.
