### PR TITLE
[Appointment][R4] Documentation update for search by _count parameter

### DIFF
--- a/content/millennium/r4/scheduling/appointment.md
+++ b/content/millennium/r4/scheduling/appointment.md
@@ -89,7 +89,6 @@ Notes:
   * twice with the prefixes `ge` and `lt` to indicate a specific range. The date and prefix pairs must define an upper and lower bound. (e.g. `&date=ge2019-12-07T22:22:16.270Z&date=lt2019-12-14T22:22:16.270Z`)
 * Search by `date` returns appointments with a status other than `proposed` that start and end within the date range provided.
 * Search by `-date-or-req-period` returns the same appointments as the `date` parameter, but also returns appointments with a status of `proposed` that either are requested to start or are requested to end between the dates provided.
-* The `_count` parameter must be a number between 5 and 100 inclusive when provided.
 * The retrieved appointments are sorted first by `start` date ascending (earliest first), followed by the provided search parameter (`patient`, `practitioner` or `location`) and `start` time ascending (earliest first).
 
 ### Headers


### PR DESCRIPTION
Description
----
Removing the [5-100] count param range in appointment search.
Evidence captured [here](https://gist.github.com/sujanb12/f608585e8223f1b6930feaf5f7bce759) to ensure that  Appointment search with count parameter outside of [5-100] is not throwing 400 Bad request. 

<img width="940" alt="Screen Shot 2021-04-21 at 10 28 49 PM" src="https://user-images.githubusercontent.com/32521644/115651698-4c8c1900-a2f1-11eb-953d-2e2118889f70.png">

PR Checklist
----
- [x] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.
