### PR TITLE
[ChargeItem] [R4] Add 'replacing' custom extension 

### DIFF
--- a/content/millennium/r4/conformance/structure-definition.md
+++ b/content/millennium/r4/conformance/structure-definition.md
@@ -106,6 +106,7 @@ Authorization is not required.
  [`related-person-encounter`]                                | Reference to the Encounter associated to the encounter level RelatedPerson.
  [`relationship-level`]                                      | The resource's relationship to either the patient or encounter level.
  [`replaced-by`]                                             | The resource containing this link must no longer be used. The link points forward to another resource that must be used in lieu of the resource that contains this link.
+ [`replacing`]                                                | A reference to a resource that this resource is replacing.
  [`reply-to`]                                                | A link to a resource that the reply should be directed to.
  [`revenue-code`]                                            | The type of revenue or cost center providing the product and/or service.
  [`transmitting-organization`]                               | An organization that transmitted or participated in the creation of a resource, but not the author.
@@ -146,6 +147,7 @@ Authorization is not required.
 [`related-person-encounter`]: https://fhir-ehr.cerner.com/r4/StructureDefinition/related-person-encounter?_format=json
 [`relationship-level`]: https://fhir-ehr.cerner.com/r4/StructureDefinition/relationship-level?_format=json
 [`replaced-by`]: https://fhir-ehr.cerner.com/r4/StructureDefinition/replaced-by?_format=json
+[`replacing`]: https://fhir-ehr.cerner.com/r4/StructureDefinition/replacing?_format=json
 [`reply-to`]: https://fhir-ehr.cerner.com/r4/StructureDefinition/reply-to?_format=json
 [`revenue-code`]: https://fhir-ehr.cerner.com/r4/StructureDefinition/revenue-code?_format=json
 [`transmitting-organization`]: https://fhir-ehr.cerner.com/r4/StructureDefinition/transmitting-organization?_format=json

--- a/content/millennium/r4/conformance/structure-definition.md
+++ b/content/millennium/r4/conformance/structure-definition.md
@@ -106,7 +106,7 @@ Authorization is not required.
  [`related-person-encounter`]                                | Reference to the Encounter associated to the encounter level RelatedPerson.
  [`relationship-level`]                                      | The resource's relationship to either the patient or encounter level.
  [`replaced-by`]                                             | The resource containing this link must no longer be used. The link points forward to another resource that must be used in lieu of the resource that contains this link.
- [`replacing`]                                                | A reference to a resource that this resource is replacing.
+ [`replacing`]                                               | A reference to a resource that this resource is replacing.
  [`reply-to`]                                                | A link to a resource that the reply should be directed to.
  [`revenue-code`]                                            | The type of revenue or cost center providing the product and/or service.
  [`transmitting-organization`]                               | An organization that transmitted or participated in the creation of a resource, but not the author.

--- a/content/millennium/r4/financial/charge-item.md
+++ b/content/millennium/r4/financial/charge-item.md
@@ -61,8 +61,8 @@ All URLs for custom extensions are defined as `https://fhir-ehr.cerner.com/r4/St
  `offset-by`            | [`Reference`]                     | Indicates a resource that this resource is offset by. This resource is no longer active when offset.
  `performing-location`  | [`Reference`]                     | A location where the resource was performed.
  `procedure`            | None (contains nested extensions) | Procedure performed on the patient associated to the resource.
+  `replacing`           | [`Reference`]                     | A reference to a resource that this resource is replacing.
  `revenue-code`         | None (contains nested extensions) | The type of revenue or cost center providing the product and/or service.
- `replacing`            | [`Reference`]                     | A reference to a resource that this resource is replacing.
  `unit-price`           | [`Money`]                         | The price of a single unit for the resource.
 
 ## Retrieve by id

--- a/content/millennium/r4/financial/charge-item.md
+++ b/content/millennium/r4/financial/charge-item.md
@@ -45,6 +45,7 @@ The following fields are returned if valued:
 * [Performing Location]
 * [Procedure]
 * [Revenue Code]
+* [Replacing]
 * [Unit Price]
 
 ### Custom Extensions
@@ -61,6 +62,7 @@ All URLs for custom extensions are defined as `https://fhir-ehr.cerner.com/r4/St
  `performing-location`  | [`Reference`]                     | A location where the resource was performed.
  `procedure`            | None (contains nested extensions) | Procedure performed on the patient associated to the resource.
  `revenue-code`         | None (contains nested extensions) | The type of revenue or cost center providing the product and/or service.
+ `replacing`            | [`Reference`]                     | A reference to a resource that this resource is replacing.
  `unit-price`           | [`Money`]                         | The price of a single unit for the resource.
 
 ## Retrieve by id
@@ -113,3 +115,4 @@ The common [errors] and [OperationOutcomes] may be returned.
 [Offset By]: #custom-extensions
 [Description]: #custom-extensions
 [Performing Location]: #custom-extensions
+[Replacing]: #custom-extensions

--- a/content/millennium/r4/financial/charge-item.md
+++ b/content/millennium/r4/financial/charge-item.md
@@ -29,7 +29,7 @@ The following fields are returned if valued:
 * [Entered Date](https://hl7.org/fhir/r4/chargeitem-definitions.html#ChargeItem.enteredDate){:target="_blank"}
 * [Reason](https://hl7.org/fhir/r4/chargeitem-definitions.html#ChargeItem.reason){:target="_blank"}
 * [Account](https://hl7.org/fhir/r4/chargeitem-definitions.html#ChargeItem.account){:target="_blank"}
-* [Extensions including custom attribute, description, modifier, net price, offset by, performing location, procedure, revenue code, and unit price](#extensions){:target="_blank"}
+* [Extensions including custom attribute, description, modifier, net price, offset by, performing location, procedure, replacing, revenue code, and unit price](#extensions){:target="_blank"}
 
 ## Terminology Bindings
 

--- a/content/millennium/r4/financial/charge-item.md
+++ b/content/millennium/r4/financial/charge-item.md
@@ -44,8 +44,8 @@ The following fields are returned if valued:
 * [Offset By]
 * [Performing Location]
 * [Procedure]
-* [Revenue Code]
 * [Replacing]
+* [Revenue Code]
 * [Unit Price]
 
 ### Custom Extensions
@@ -61,7 +61,7 @@ All URLs for custom extensions are defined as `https://fhir-ehr.cerner.com/r4/St
  `offset-by`            | [`Reference`]                     | Indicates a resource that this resource is offset by. This resource is no longer active when offset.
  `performing-location`  | [`Reference`]                     | A location where the resource was performed.
  `procedure`            | None (contains nested extensions) | Procedure performed on the patient associated to the resource.
-  `replacing`           | [`Reference`]                     | A reference to a resource that this resource is replacing.
+ `replacing`            | [`Reference`]                     | A reference to a resource that this resource is replacing.
  `revenue-code`         | None (contains nested extensions) | The type of revenue or cost center providing the product and/or service.
  `unit-price`           | [`Money`]                         | The price of a single unit for the resource.
 


### PR DESCRIPTION
Description
----
This pr adds a new custom extension 'replacing' to the structure definition and charge Item structure definition list
<img width="1003" alt="Screen Shot 2021-04-22 at 9 44 10 AM" src="https://user-images.githubusercontent.com/32521644/115735013-c18e3b80-a34f-11eb-9031-921a52e3e95e.png">
<img width="921" alt="Screen Shot 2021-04-22 at 10 19 31 AM" src="https://user-images.githubusercontent.com/32521644/115740348-57c46080-a354-11eb-81ed-1625fde2ecec.png">
<img width="1009" alt="Screen Shot 2021-04-22 at 10 12 56 AM" src="https://user-images.githubusercontent.com/32521644/115740377-5dba4180-a354-11eb-93d0-5b074bee1392.png">
<img width="760" alt="Screen Shot 2021-04-22 at 11 56 32 AM" src="https://user-images.githubusercontent.com/32521644/115754691-13d85800-a362-11eb-8562-d2eb65a8f4c8.png">



PR Checklist
----
- [x] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.
