### PR TITLE
R4 Coverage Public Healthcare delete

### DIFF
--- a/content/millennium/r4/financial/coverage.md
+++ b/content/millennium/r4/financial/coverage.md
@@ -211,8 +211,8 @@ _Implementation Notes_
 
 * This implementation follows the [JSON Patch](https://tools.ietf.org/html/rfc6902) spec.
 * Only operations on the paths listed below are supported.
-* For Private Coverages, only Encounter-level Coverages may be patched. For Public Coverages,
-both Encounter-level and Patient-level Coverages may be patched, with the caveat of only supporting the `/period` and `/class/0/value` operations.
+* For Private Coverages, only Encounter-level Coverages may be patched.
+* For Public Coverages, both Encounter-level and Patient-level Coverages may be patched, with the caveat of only supporting the `/period` and `/class/0/value` operations.
 
 ### Authorization Types
 
@@ -267,7 +267,8 @@ Delete an existing Encounter-level Coverage.
 
 _Implementation Notes_
 
-* Only Encounter-level Coverages may be deleted. Deletes are not currently supported for Patient-level Coverages.
+* For Private Coverages, only Encounter-level Coverages may be deleted.
+* For Public Coverages, both Encounter-level and Patient-level Coverages may be deleted.
 
 ### Authorization Types
 

--- a/content/millennium/r4/financial/coverage.md
+++ b/content/millennium/r4/financial/coverage.md
@@ -52,7 +52,7 @@ Search for Patient-level or Encounter-level Coverages that meet supplied query p
     
 _Implementation Notes_
   
-* Public Healthcare represents an insurance policy funded by a public health system such as a provincial or national health plan. If there are any public healthcare coverages, they will return with an id prefixed with 'PH' or 'PHP' and will be returned in the payload with the rest of the coverages (private coverages).
+* Public Healthcare represents an insurance policy funded by a public health system such as a provincial or national health plan. If there are any public coverages, they will return with an id prefixed with 'PH' or 'PHP' and will be returned in the payload with the rest of the coverages (private coverages).
 
 ### Authorization Types
 
@@ -82,7 +82,7 @@ _Implementation Notes_
 
 <%= disclaimer %>
 
-### Example - Patient-level Public Healthcare Coverage
+### Example - Patient-level Public Coverage
 
 #### Request
 
@@ -108,7 +108,7 @@ _Implementation Notes_
 
 <%= disclaimer %>
 
-### Example - Encounter-level Public Healthcare Coverage
+### Example - Encounter-level Public Coverage
 
 #### Request
 
@@ -212,7 +212,7 @@ _Implementation Notes_
 * This implementation follows the [JSON Patch](https://tools.ietf.org/html/rfc6902) spec.
 * Only operations on the paths listed below are supported.
 * For Private Coverages, only Encounter-level Coverages may be patched.
-* For Public healthcare Coverages, both Encounter-level and Patient-level Coverages may be patched, with the caveat of only supporting the `/period` and `/class/0/value` operations.
+* For Public Coverages, both Encounter-level and Patient-level Coverages may be patched, with the caveat of only supporting the `/period` and `/class/0/value` operations.
 
 ### Authorization Types
 
@@ -268,7 +268,7 @@ Delete an existing Encounter-level Coverage.
 _Implementation Notes_
 
 * For Private Coverages, only Encounter-level Coverages may be deleted.
-* For Public healthcare Coverages, both Encounter-level and Patient-level Coverages may be deleted.
+* For Public Coverages, both Encounter-level and Patient-level Coverages may be deleted.
 
 ### Authorization Types
 

--- a/content/millennium/r4/financial/coverage.md
+++ b/content/millennium/r4/financial/coverage.md
@@ -52,7 +52,7 @@ Search for Patient-level or Encounter-level Coverages that meet supplied query p
     
 _Implementation Notes_
   
-* Public Healthcare represents an insurance policy funded by a public health system such as a provincial or national health plan.
+* Public Healthcare represents an insurance policy funded by a public health system such as a provincial or national health plan. If there are any public healthcare coverages, they will return with an id prefixed with 'PH' or 'PHP' and will be returned in the payload with the rest of the coverages (private coverages).
 
 ### Authorization Types
 
@@ -69,7 +69,7 @@ _Implementation Notes_
 
 <%= headers fhir_json: true %>
 
-### Example - Patient-level Coverage
+### Example - Patient-level Private Coverage
 
 #### Request
 
@@ -82,7 +82,7 @@ _Implementation Notes_
 
 <%= disclaimer %>
 
-#### Example - Patient-level Public Healthcare Coverage
+### Example - Patient-level Public Healthcare Coverage
 
 #### Request
 
@@ -95,7 +95,7 @@ _Implementation Notes_
 
 <%= disclaimer %>
 
-### Example - Encounter-level Coverage
+### Example - Encounter-level Private Coverage
 
 #### Request
 
@@ -108,7 +108,7 @@ _Implementation Notes_
 
 <%= disclaimer %>
 
-#### Example - Encounter-level Public Healthcare Coverage
+### Example - Encounter-level Public Healthcare Coverage
 
 #### Request
 
@@ -143,7 +143,7 @@ Create new Patient-level or Encounter-level Coverages.
 
 <%= definition_table(:coverage, :create, :r4) %>
 
-### Example - Patient-level Coverage
+### Example - Patient-level Private Coverage
 
 #### Request
 
@@ -170,7 +170,7 @@ X-Request-Id: ef7c0ee60a8cf431403fe82d9009640b
 
 <%= disclaimer %>
 
-### Example - Encounter-level Coverage
+### Example - Encounter-level Private Coverage
 
 #### Request
 
@@ -212,7 +212,7 @@ _Implementation Notes_
 * This implementation follows the [JSON Patch](https://tools.ietf.org/html/rfc6902) spec.
 * Only operations on the paths listed below are supported.
 * For Private Coverages, only Encounter-level Coverages may be patched.
-* For Public Coverages, both Encounter-level and Patient-level Coverages may be patched, with the caveat of only supporting the `/period` and `/class/0/value` operations.
+* For Public healthcare Coverages, both Encounter-level and Patient-level Coverages may be patched, with the caveat of only supporting the `/period` and `/class/0/value` operations.
 
 ### Authorization Types
 
@@ -268,7 +268,7 @@ Delete an existing Encounter-level Coverage.
 _Implementation Notes_
 
 * For Private Coverages, only Encounter-level Coverages may be deleted.
-* For Public Coverages, both Encounter-level and Patient-level Coverages may be deleted.
+* For Public healthcare Coverages, both Encounter-level and Patient-level Coverages may be deleted.
 
 ### Authorization Types
 


### PR DESCRIPTION
Description
----
Updating documentation to include Delete information on Public Healthcare coverages. Also clarifying the difference between private/public coverages more.

Before Merge Screenshots
----
![image](https://user-images.githubusercontent.com/18322861/117860282-bbf08b00-b255-11eb-9e3f-d460c422d296.png)
![image](https://user-images.githubusercontent.com/18322861/117860322-c6128980-b255-11eb-97b1-f1c2f666f491.png)
![image](https://user-images.githubusercontent.com/18322861/117860374-d6c2ff80-b255-11eb-97a9-2ce844030c5f.png)
![image](https://user-images.githubusercontent.com/18322861/117860411-e0e4fe00-b255-11eb-9573-a18eb8a2c913.png)

PR Checklist
----
- [x] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.
