### PR TITLE
Fix DocumentReference.type info when loinc is missing

### DIFF
--- a/lib/resources/example_json/dstu2_examples_document_reference.rb
+++ b/lib/resources/example_json/dstu2_examples_document_reference.rb
@@ -29,15 +29,9 @@ module Cerner
             'userSelected': true
           },
           {
-            'system': 'http://loinc.org',
-            '_code': {
-              'extension': [
-                {
-                  'url': 'http://hl7.org/fhir/StructureDefinition/data-absent-reason',
-                  'valueCode': 'unknown'
-                }
-              ]
-            }
+            'system': 'http://terminology.hl7.org/CodeSystem/v3-NullFlavor',
+            'code': 'UNK',
+            'display': 'unknown'
           }
         ],
         'text': 'Pregnancy Summary Document'

--- a/lib/resources/r4/document_reference.yaml
+++ b/lib/resources/r4/document_reference.yaml
@@ -80,7 +80,7 @@ fields:
     description: Specifies the particular kind of document referenced.
     terminology:
     - display: US Core DocumentReference Type
-      system: http://loinc.org
+      system: http://loinc.org, http://terminology.hl7.org/CodeSystem/v3-NullFlavor
       info_link: http://hl7.org/fhir/us/core/ValueSet/us-core-documentreference-type
     - display: Millennium Event Code
       system: https://fhir.cerner.com/&lt;EHR source id&gt;/codeSet/72
@@ -558,7 +558,7 @@ fields:
     description: Specifies the particular kind of document referenced.
     terminology:
       - display: US Core DocumentReference Type
-        system: http://loinc.org
+        system: http://loinc.org, http://terminology.hl7.org/CodeSystem/v3-NullFlavor
         info_link: http://hl7.org/fhir/us/core/ValueSet/us-core-documentreference-type
 
 - name: type

--- a/lib/resources/r4/document_reference.yaml
+++ b/lib/resources/r4/document_reference.yaml
@@ -80,7 +80,10 @@ fields:
     description: Specifies the particular kind of document referenced.
     terminology:
     - display: US Core DocumentReference Type
-      system: http://loinc.org, http://terminology.hl7.org/CodeSystem/v3-NullFlavor
+      system: http://loinc.org
+      info_link: http://hl7.org/fhir/us/core/ValueSet/us-core-documentreference-type
+    - display: US Core DocumentReference Type
+      system: http://terminology.hl7.org/CodeSystem/v3-NullFlavor (when type doesn't have a LOINC code)
       info_link: http://hl7.org/fhir/us/core/ValueSet/us-core-documentreference-type
     - display: Millennium Event Code
       system: https://fhir.cerner.com/&lt;EHR source id&gt;/codeSet/72


### PR DESCRIPTION

![Screenshot 2021-05-06 at 13 39 50](https://user-images.githubusercontent.com/80259466/117292795-e4047680-ae70-11eb-8cba-d573cd3ba455.png)
Description
----

PR Checklist
----
- [ ] Screenshot(s) of changes attached before changes merged.
- [x] Screenshot(s) of changes attached after changes merged and published.
