### PR TITLE
Remove beta tag from Questionnaire

### DIFF
--- a/content/millennium/r4/definitional-artifacts/questionnaire.md
+++ b/content/millennium/r4/definitional-artifacts/questionnaire.md
@@ -4,8 +4,6 @@ title: Questionnaire | R4 API
 
 # Questionnaire
 
-<%= beta_tag %>
-
 * TOC
 {:toc}
 
@@ -54,8 +52,6 @@ URLs for custom extensions are defined as `https://fhir-ehr.cerner.com/r4/Struct
 
 ## Search
 
-<%= beta_tag(action: true) %>
-
 Search for Questionnaires that meet supplied query parameters:
 
     GET /Questionnaire?:parameters
@@ -92,8 +88,6 @@ Search for Questionnaires that meet supplied query parameters:
 The common [errors] and [OperationOutcomes] may be returned.
 
 ## Retrieve by id
-
-<%= beta_tag(action: true) %>
 
 List an individual Questionnaire by its id:
 


### PR DESCRIPTION
Description
----
Remove beta tag from Questionnaire

<img width="1680" alt="Screen Shot 2021-05-27 at 8 58 17 AM" src="https://user-images.githubusercontent.com/56039503/119839364-bb98f680-bec9-11eb-91d0-ea6eb680bfe6.png">
<img width="1680" alt="Screen Shot 2021-05-27 at 8 58 21 AM" src="https://user-images.githubusercontent.com/56039503/119839388-bf2c7d80-bec9-11eb-9df4-ccd8179e472f.png">
<img width="1680" alt="Screen Shot 2021-05-27 at 8 58 24 AM" src="https://user-images.githubusercontent.com/56039503/119839393-bfc51400-bec9-11eb-9fdb-45ee5f1bbe68.png">


PR Checklist
----
- [x] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.
