### PR TITLE
QuestionnaireResponse Supported Fields Update

### DIFF
--- a/content/millennium/r4/definitional-artifacts/questionnaire.md
+++ b/content/millennium/r4/definitional-artifacts/questionnaire.md
@@ -9,7 +9,7 @@ title: Questionnaire | R4 API
 
 ## Overview
 
-The Questionnaire resource defines and organizes questions and the allowed answers to the questions typically used to collect patient healthcare information.  A questionnaire is a snapshot in time and should be retrieved before each use. Examples of questionnaires are forms used to collect a patient's social history or family member history.  Currently, only social history is supported.
+The Questionnaire resource defines and organizes questions and the allowed answers to the questions typically used to collect patient healthcare information.  A questionnaire is a snapshot in time and should be retrieved before each use. Examples of questionnaires are forms used to collect a patient's social history or family member history. Currently, only social history is supported. In order to find a questionnaire for a specific patient, first search QuestionnaireResponse by patient. Then use the 'questionnaire' field from the QuestionnaireResponse to retrieve the original questionnaire.
 
 The following fields are returned if valued:
 

--- a/content/millennium/r4/diagnostic/questionnaire-response.md
+++ b/content/millennium/r4/diagnostic/questionnaire-response.md
@@ -11,11 +11,45 @@ title: QuestionnaireResponse | R4 API
 
 ## Overview
 
-The QuestionnaireResponse resource is a collection of answers to a given questionnaire typically used to request patient healthcare information. An example of a questionnaire is a form used to collect a patient's social history. Currently, only social history is supported.
+The QuestionnaireResponse resource is a collection of answers to a given questionnaire typically used to request patient healthcare information. A given QuestionnaireResponse must belong to a corresponding Questionnaire. An example of a questionnaire is a form used to collect a patient's social history. Currently, only social history is supported.
 
 The following fields are returned if valued:
 
 * [Id](https://hl7.org/fhir/R4/resource-definitions.html#Resource.id){:target="_blank"}
+* [Questionnaire](https://hl7.org/fhir/r4/questionnaireresponse-definitions.html#QuestionnaireResponse.questionnaire){:target="_blank"}
+* [Status](https://hl7.org/fhir/r4/questionnaireresponse-definitions.html#QuestionnaireResponse.status){:target="_blank"}
+* [Subject](https://hl7.org/fhir/r4/questionnaireresponse-definitions.html#QuestionnaireResponse.subject){:target="_blank"}
+* [Authored](https://hl7.org/fhir/r4/questionnaireresponse-definitions.html#QuestionnaireResponse.authored){:target="_blank"}
+* [Item](https://hl7.org/fhir/r4/questionnaireresponse-definitions.html#QuestionnaireResponse.item){:target="_blank"}
+    * [Id](https://hl7.org/fhir/R4/element-definitions.html#Element.id){:target="_blank"}
+    * [Link id](https://hl7.org/fhir/r4/questionnaireresponse-definitions.html#QuestionnaireResponse.item.linkId){:target="_blank"}
+    * [Note Extension](#extensions){:target="_blank"}
+    * [Text](https://hl7.org/fhir/r4/questionnaireresponse-definitions.html#QuestionnaireResponse.item.text){:target="_blank"}
+    * [Item](https://hl7.org/fhir/r4/questionnaireresponse-definitions.html#QuestionnaireResponse.item.item){:target="_blank"}
+        * [Link id](https://hl7.org/fhir/r4/questionnaireresponse-definitions.html#QuestionnaireResponse.item.linkId){:target="_blank"}
+        * [Text](https://hl7.org/fhir/r4/questionnaireresponse-definitions.html#QuestionnaireResponse.item.text){:target="_blank"}
+        * [Choice Answer Extension](#extensions){:target="_blank"}
+        * [valueString Answers](https://hl7.org/fhir/r4/datatypes.html#string){:target="_blank"}
+        * [valueCoding Answers](https://hl7.org/fhir/r4/datatypes.html#Coding){:target="_blank"}
+        * [valueQuantity Answers](https://hl7.org/fhir/r4/datatypes.html#Quantity){:target="_blank"}
+
+## Terminology Bindings
+
+<%= terminology_table(:questionnaire_response, :r4) %>
+
+## Extensions
+
+* [Choice Answer]
+* [Note]
+
+### Custom Extensions
+
+URLs for custom extensions are defined as `https://fhir-ehr.cerner.com/r4/StructureDefinition/{id}`
+
+ ID              | Value\[x] Type                                                    | Description                   
+-----------------|-------------------------------------------------------------------|-----------------------------------------------
+ `choice-answer` | [`Boolean`](https://hl7.org/fhir/r4/datatypes.html#boolean)       | Indicates answers come from a list of options.
+ `note`          | [`Annotation`](https://hl7.org/fhir/r4/datatypes.html#annotation) | Additional details about a given QuestionnaireResponse group item. Includes author and date/time information.
 
 ## Search
 
@@ -25,15 +59,20 @@ Search for QuestionnaireResponses that meet supplied query parameters:
 
     GET /QuestionnaireResponse?:parameters
 
+_Implementation Notes_
+
+* QuestionnaireResponses are sometimes system generated without any answers. These may be updated with the correct responses at any time.
+
 ### Authorization Types
 
-<%= authorization_types(provider: true, patient: true, system: true) %>
+<%= authorization_types(provider: true, patient: false, system: true) %>
 
 ### Parameters
 
- Name      | Required? | Type          | Description
------------|-----------|---------------|--------------------------------------------------------
- `_id`     | Yes       | [`token`]     | The logical resource id associated with the resource.
+ Name      | Required?         | Type          | Description
+-----------|------------------ |---------------|--------------------------------------------------------------------------------------------
+ `_id`     | This or `patient` | [`token`]     | The logical resource id associated with the resource.
+ `patient` | This or `_id`     | [`reference`] | The subject (Patient) that the questionnaire response is about. Example: `patient=12345`
 
 ### Headers
 
@@ -59,6 +98,10 @@ Search for QuestionnaireResponses that meet supplied query parameters:
 List an individual QuestionnaireResponse by its id:
 
     GET /QuestionnaireResponse/:id
+
+_Implementation Notes_
+
+* QuestionnaireResponses are sometimes system generated without any answers. These may be updated with the correct responses at any time.
 
 ### Authorization Types
 
@@ -131,6 +174,9 @@ X-Request-Id: 1638e30e497b93ff4383b2ff0eaeea91
 
 The common [errors] and [OperationOutcomes] may be returned.
 
+[`reference`]: https://hl7.org/fhir/r4/search.html#reference
 [`token`]: https://hl7.org/fhir/R4/search.html#token
 [errors]: ../../#client-errors
+[Note]: #custom-extensions
+[Choice Answer]: #custom-extensions
 [OperationOutcomes]: ../../#operation-outcomes

--- a/lib/resources/example_json/r4_examples_questionnaire_response.rb
+++ b/lib/resources/example_json/r4_examples_questionnaire_response.rb
@@ -4,7 +4,77 @@ module Cerner
   module Resources
     R4_QUESTIONNAIRE_RESPONSE_ENTRY ||= {
       'resourceType': 'QuestionnaireResponse',
-      'id': 'SH-12508041'
+      'id': 'SH-12508041',
+      'questionnaire': 'https://fhir-open.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/Questionnaire/SH-12508041',
+      'status': 'in-progress',
+      'subject': {
+        'reference': 'Patient/12508041'
+      },
+      'authored': '2019-10-25T14:57:43Z',
+      'item': [
+        {
+          'id': '111',
+          'linkId': '93',
+          'text': 'Tobacco',
+          'extension': [
+            {
+              'url': 'https://fhir-ehr.cerner.com/r4/StructureDefinition/note',
+              'valueAnnotation': {
+                'authorReference': {
+                  'reference': 'Practitioner/109413936',
+                  'display': 'Lombardi, Falco Shine'
+                },
+                'time': '2021-06-15T22:15:26.000Z',
+                'text': 'category/group comment'
+              }
+            }
+          ],
+          'item': [
+            {
+              'linkId': '93-123',
+              'text': 'Number of years:',
+              'answer': [
+                {
+                  'valueQuantity': {
+                    'value': '20'
+                  }
+                }
+              ]
+            },
+            {
+              'linkId': '93-456',
+              'text': 'Tobacco use per day:',
+              'answer': [
+                {
+                  'valueString': 'Answer text'
+                }
+              ]
+            },
+            {
+              'linkId': '93-789',
+              'text': 'Ready to change:',
+              'extension': [
+                {
+                  'url': 'https://fhir-ehr.cerner.com/r4/StructureDefinition/choice-answer',
+                  'valueBoolean': true
+                }
+              ],
+              'answer': [
+                {
+                  'valueCoding': {
+                    'system': 'https://fhir.cerner.com/ec2458f2-1e24-41c8-b71b-0e701af7583d/nomenclature',
+                    'code': '960439',
+                    'display': 'Yes'
+                  }
+                },
+                {
+                  'valueString': 'Other answer text'
+                }
+              ]
+            }
+          ]
+        }
+      ]
     }.freeze
 
     R4_QUESTIONNAIRE_RESPONSE_BUNDLE ||= {
@@ -27,7 +97,66 @@ module Cerner
 
     R4_QUESTIONNAIRE_RESPONSE_UPDATE ||= {
       'resourceType': 'QuestionnaireResponse',
-      'id': 'SH-12508041'
+      'id': 'SH-12508041',
+      'questionnaire': 'https://fhir-ehr-code.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/Questionnaire/SH-12508041',
+      'status': 'in-progress',
+      'subject': {
+        'reference': 'Patient/12508041'
+      },
+      'item': [
+        {
+          'id': '111',
+          'linkId': '93',
+          'extension': [
+            {
+              'url': 'https://fhir-ehr.cerner.com/r4/StructureDefinition/note',
+              'valueAnnotation': {
+                'text': 'category/group comment'
+              }
+            }
+          ],
+          'item': [
+            {
+              'linkId': '93-123',
+              'answer': [
+                {
+                  'valueQuantity': {
+                    'value': '20'
+                  }
+                }
+              ]
+            },
+            {
+              'linkId': '93-456',
+              'answer': [
+                {
+                  'valueString': 'Answer text'
+                }
+              ]
+            },
+            {
+              'linkId': '93-789',
+              'extension': [
+                {
+                  'url': 'https://fhir-ehr.cerner.com/r4/StructureDefinition/choice-answer',
+                  'valueBoolean': true
+                }
+              ],
+              'answer': [
+                {
+                  'valueCoding': {
+                    'system': 'https://fhir.cerner.com/ec2458f2-1e24-41c8-b71b-0e701af7583d/nomenclature',
+                    'code': '960439'
+                  }
+                },
+                {
+                  'valueString': 'Other answer text'
+                }
+              ]
+            }
+          ]
+        }
+      ]
     }.freeze
   end
 end

--- a/lib/resources/r4/questionnaire_response.yaml
+++ b/lib/resources/r4/questionnaire_response.yaml
@@ -2,6 +2,19 @@
 name: QuestionnaireResponse
 field_name_base_url: https://hl7.org/implement/standards/fhir/R4/questionnaireresponse-definitions.html#QuestionnaireResponse
 fields:
+  - name: ValueCoding Answer
+    url: https://hl7.org/fhir/r4/questionnaireresponse-definitions.html#QuestionnaireResponse.item.answer.value_x_
+    terminology_name: answer.valueCoding
+    type: Coding
+    description: An answer from a list of available Coding answer options.
+    action: terminology
+    binding:
+      description: An answer from a list of available Coding answer options.
+      terminology:
+        - display: Nomenclature Value
+          system: https://fhir.cerner.com/&lt;EHR source id&gt;/nomenclature
+          info_link: https://fhir.cerner.com/millennium/r4/proprietary-codes-and-systems/#nomenclature
+
   - name: resourceType
     required: 'Yes'
     type: string
@@ -24,3 +37,212 @@ fields:
       {
         "id": "SH-12508041"
       }
+
+  - name: questionnaire
+    required: 'Yes'
+    type: Questionnaire
+    url: https://hl7.org/fhir/r4/questionnaireresponse-definitions.html#QuestionnaireResponse.questionnaire
+    description: The Questionnaire that defines and organizes the questions for which answers are being provided.
+    action: update
+    example: |
+      {
+        "questionnaire": "https://fhir-ehr-code.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/Questionnaire/SH-12508041"
+      }
+
+  - name: status
+    required: 'Yes'
+    type: code
+    url: https://hl7.org/fhir/r4/questionnaireresponse-definitions.html#QuestionnaireResponse.status
+    description: The position of the questionnaire response within its overall lifecycle.
+    action: update
+    example: |
+      {
+        "status": "in-progress"
+      }
+    note: Status must be 'in-progress'.
+  
+  - name: subject
+    required: 'Yes'
+    type: Reference
+    url: https://hl7.org/fhir/r4/questionnaireresponse-definitions.html#QuestionnaireResponse.subject
+    description: The subject of the questionnaire response. This is the patient the answers apply to, but is not necessarily the source of information.
+    action: update
+    example: |
+      {
+        "subject": {
+          "reference": "Patient/12508041"
+        }
+      }
+
+  - name: item
+    required: 'Yes'
+    type: List of BackboneElement
+    url: https://hl7.org/fhir/r4/questionnaireresponse-definitions.html#QuestionnaireResponse.item
+    description: A group or question item from the original questionnaire for which answers are provided.
+    action: update
+    example: |
+      {
+        "item": [
+          {
+            "id": "111",
+            "linkId": "93",
+            "extension": [
+              {​​​​​​​​​​​​
+                "url": "https://fhir-ehr.cerner.com/r4/StructureDefinition/note",
+                "valueAnnotation": {​​​​​​​​​​​​​​​​​​​
+                  "text": "category/group comment"
+                }​​​​​​​​​​​​​​​​​​​​​​​​​​
+              }​​​​​​​​​​​​​​​​​​​​​​​​​​
+            ],
+            "item": [
+              {
+                "linkId": "93-123",
+                "extension": [
+                  {​​​​​​​​​​​​
+                    "url": "https://fhir-ehr.cerner.com/r4/StructureDefinition/choice-answer",
+                    "valueBoolean": true
+                  }​​​​​​​​​​​​​​​​​​​​​​​​​​
+                ],
+                "answer": [
+                  {
+                    "valuestring": "Answer text"
+                  }
+                ]
+              }
+            ] 
+          }
+        ]
+      }
+
+  - name: item.id
+    required: 'No'
+    type: string
+    url: https://hl7.org/fhir/R4/element-definitions.html#Element.id
+    description: Unique id for inter-element referencing.
+    action: update
+    example: |
+      {
+        "id": "111"
+      }
+    note: If an item.id is returned on a read, it must be provided on an update.
+
+  - name: item.linkId
+    required: 'Yes'
+    type: string
+    url: https://hl7.org/fhir/r4/questionnaireresponse-definitions.html#QuestionnaireResponse.item.linkId
+    description: The item from the Questionnaire that corresponds to this item in the QuestionnaireResponse resource.
+    action: update
+    example: |
+      {
+        "linkId": "93"
+      }
+
+  - name: item.extension
+    required: 'No'
+    type: Extension
+    url: https://fhir-ehr.cerner.com/r4/StructureDefinition/note
+    description: Additional details about a given QuestionnaireResponse group item.
+    action: update
+    example: |
+      {
+        "extension": [
+          {​​​​​​​​​​​​
+            "url": "https://fhir-ehr.cerner.com/r4/StructureDefinition/note",
+            "valueAnnotation": {​​​​​​​​​​​​​​​​​​​
+              "text": "category/group comment"
+            }​​​​​​​​​​​​​​​​​​​​​​​​​​
+          }​​​​​​​​​​​​​​​​​​​​​​​​​​
+        ]
+      }
+    note: Only the 'note' extension is supported for this field. Notes can only be added, not replaced or deleted.
+
+  - name: item.item
+    required: 'No'
+    type: List of BackboneElement
+    url: https://hl7.org/fhir/r4/questionnaireresponse-definitions.html#QuestionnaireResponse.item.item
+    description: Questions nested beneath a group.
+    action: update
+    example: |
+      {
+        "item": [
+          {
+            "linkId": "93-123",
+            "extension": [
+              {​​​​​​​​​​​​
+                "url": "https://fhir-ehr.cerner.com/r4/StructureDefinition/choice-answer",
+                "valueBoolean": true
+              }​​​​​​​​​​​​​​​​​​​​​​​​​​
+            ],
+            "answer": [
+              {
+                "valuestring": "Answer text"
+              }
+            ]
+          }
+        ]
+      }
+
+  - name: item.item.linkId
+    required: 'Yes'
+    type: string
+    url: https://hl7.org/fhir/r4/questionnaireresponse-definitions.html#QuestionnaireResponse.item.linkId
+    description: The item from the Questionnaire that corresponds to this item in the QuestionnaireResponse resource.
+    action: update
+    example: |
+      {
+        "linkId": "93-123"
+      }
+
+  - name: item.item.extension
+    required: 'No'
+    type: Extension
+    url: https://fhir-ehr.cerner.com/r4/StructureDefinition/choice-answer
+    description: Whether the answers come from a list of options.
+    action: update
+    example: |
+      {
+        "extension": [
+          {​​​​​​​​​​​​
+            "url": "https://fhir-ehr.cerner.com/r4/StructureDefinition/choice-answer",
+            "valueBoolean": true
+          }​​​​​​​​​​​​​​​​​​​​​​​​​​
+        ]
+      }
+    note: Only the 'choice-answer' extension is supported for this field. Extension must be provided and true when answering a question of type choice or open choice.
+
+  - name: item.item.answer
+    required: 'Yes'
+    type: string | Coding | Quantity
+    url: https://hl7.org/fhir/r4/questionnaireresponse-definitions.html#QuestionnaireResponse.item.answer
+    description: The respondent's answer(s) to the question.
+    action: update
+    example: |
+      {
+        "answer": [
+          {
+            "valueString": "Answer text"
+          }
+        ]
+      }
+    example2: |
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "system": "https://fhir.cerner.com/ec2458f2-1e24-41c8-b71b-0e701af7583d/nomenclature",
+              "code": "960439"
+            }
+          }
+        ]
+      }
+    example3: |
+      {
+        "answer": [
+          {
+            "valueQuantity": {
+              "value": 20
+            }
+          }
+        ]
+      }
+    note: Only answer value types of String, Quantity, and Coding are supported.

--- a/lib/resources/r4/types.yaml
+++ b/lib/resources/r4/types.yaml
@@ -6,6 +6,7 @@ BackboneElement: https://hl7.org/fhir/R4/backboneelement.html
 boolean: https://hl7.org/fhir/R4/datatypes.html#boolean
 code: https://hl7.org/fhir/R4/datatypes.html#code
 CodeableConcept: https://hl7.org/fhir/R4/datatypes.html#CodeableConcept
+Coding: https://hl7.org/fhir/R4/datatypes.html#Coding
 ContactPoint: https://hl7.org/fhir/R4/datatypes.html#ContactPoint
 date: https://hl7.org/fhir/R4/datatypes.html#date
 dateTime: https://hl7.org/fhir/R4/datatypes.html#dateTime
@@ -31,6 +32,7 @@ Period: https://hl7.org/fhir/R4/datatypes.html#Period
 performerFunction: https://hl7.org/fhir/R4/extension-event-performerfunction.html
 positiveInt: https://hl7.org/fhir/R4/datatypes.html#positiveInt
 Quantity: https://hl7.org/fhir/R4/datatypes.html#Quantity
+Questionnaire: https://hl7.org/fhir/R4/questionnaire.html
 RelatedPerson: https://hl7.org/fhir/R4/relatedperson.html
 Resource: https://hl7.org/fhir/R4/resource.html
 SimpleQuantity: https://hl7.org/fhir/R4/datatypes.html#SimpleQuantity


### PR DESCRIPTION
Description
----
QuestionnaireResponse read/search are no longer mocked out, we need to update fhir.cerner.com to show the supported fields

We need to mention:

QR comes back even when they have no data (as long as the patient exists)

The workflow should be (for social history questionnaires):

Search QR by patient
Get the ‘questionnaire’ field from the QR
Retrieve that Questionnaire
We only support answer value types of: String, Quantity, and Coding

How do QRs relate to Observations?

Before Merge Screenshots
----
<img width="580" alt="Screen Shot 2021-06-17 at 8 41 06 AM" src="https://user-images.githubusercontent.com/40574651/122410100-414c1700-cf49-11eb-936e-6ba13c0063e4.png">
<img width="580" alt="Screen Shot 2021-06-17 at 8 41 17 AM" src="https://user-images.githubusercontent.com/40574651/122410105-41e4ad80-cf49-11eb-9784-dbf1bb56f257.png">
<img width="580" alt="Screen Shot 2021-06-17 at 8 42 06 AM" src="https://user-images.githubusercontent.com/40574651/122410106-427d4400-cf49-11eb-90ef-29731f80f5fa.png">
<img width="580" alt="Screen Shot 2021-06-17 at 8 42 43 AM" src="https://user-images.githubusercontent.com/40574651/122410109-4315da80-cf49-11eb-999e-390e17b71b2e.png">
<img width="580" alt="Screen Shot 2021-06-17 at 8 43 01 AM" src="https://user-images.githubusercontent.com/40574651/122410111-43ae7100-cf49-11eb-8b9c-3f3641fc6191.png">
<img width="580" alt="Screen Shot 2021-06-17 at 8 43 47 AM" src="https://user-images.githubusercontent.com/40574651/122410115-43ae7100-cf49-11eb-94cf-410c5301d544.png">
<img width="580" alt="Screen Shot 2021-06-17 at 8 44 02 AM" src="https://user-images.githubusercontent.com/40574651/122410119-44470780-cf49-11eb-9737-b65ab19cd27b.png">
<img width="580" alt="Screen Shot 2021-06-17 at 8 44 19 AM" src="https://user-images.githubusercontent.com/40574651/122410121-44df9e00-cf49-11eb-8ba1-06a6575e4b7f.png">
<img width="580" alt="Screen Shot 2021-06-17 at 8 44 30 AM" src="https://user-images.githubusercontent.com/40574651/122410123-44df9e00-cf49-11eb-8c1c-11a97637b288.png">
<img width="580" alt="Screen Shot 2021-06-17 at 9 10 42 AM" src="https://user-images.githubusercontent.com/40574651/122413579-1adbab00-cf4c-11eb-9cce-8f2ff71700e9.png">
<img width="580" alt="Screen Shot 2021-06-17 at 9 11 22 AM" src="https://user-images.githubusercontent.com/40574651/122413583-1c0cd800-cf4c-11eb-8b81-4594656f2317.png">
<img width="580" alt="Screen Shot 2021-06-17 at 8 44 59 AM" src="https://user-images.githubusercontent.com/40574651/122410127-45783480-cf49-11eb-8187-77bcba44942d.png">
<img width="580" alt="Screen Shot 2021-06-17 at 8 45 16 AM" src="https://user-images.githubusercontent.com/40574651/122409882-1d88d100-cf49-11eb-9536-3cb46060e434.png">




PR Checklist
----
- [x] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.
