### PR TITLE
Vital Sign Create supports Provider Persona

### DIFF
--- a/content/millennium/r4/diagnostic/observation.md
+++ b/content/millennium/r4/diagnostic/observation.md
@@ -195,7 +195,7 @@ _Implementation Notes_
 
 _Note_: 
 
-* Vitals creates for a Provider persona requires an active relationship.
+* Vital Sign creates via a Provider persona requires an active relationship between the Provider and the Patient.
 
 ### Headers
 

--- a/content/millennium/r4/diagnostic/observation.md
+++ b/content/millennium/r4/diagnostic/observation.md
@@ -193,6 +193,10 @@ _Implementation Notes_
 
 <div class="auth-types"><a href="/authorization/#requesting-authorization-on-behalf-of-a-user" class="provider">Provider</a><i> (Vital Signs and Laboratory)</i> | <a href="/authorization/#requesting-authorization-on-behalf-of-a-system" class="system">System</a><i> (Vital Signs and Laboratory)</i></div>
 
+_Note_: 
+
+* Vitals creates for a Provider persona requires an active relationship.
+
 ### Headers
 
 <%= headers head: {Authorization: '&lt;OAuth2 Bearer Token>', 'Content-Type': 'application/fhir+json'} %>

--- a/content/millennium/r4/diagnostic/observation.md
+++ b/content/millennium/r4/diagnostic/observation.md
@@ -191,7 +191,7 @@ _Implementation Notes_
 
 ### Authorization Types
 
-<div class="auth-types"><a href="/authorization/#requesting-authorization-on-behalf-of-a-user" class="provider">Provider</a><i> </i> | <a href="/authorization/#requesting-authorization-on-behalf-of-a-system" class="system">System</a><i> </i></div>
+<div class="auth-types"><a href="/authorization/#requesting-authorization-on-behalf-of-a-user" class="provider">Provider</a><i> (Vital Signs and Laboratory)</i> | <a href="/authorization/#requesting-authorization-on-behalf-of-a-system" class="system">System</a><i> (Vital Signs and Laboratory)</i></div>
 
 ### Headers
 

--- a/content/millennium/r4/diagnostic/observation.md
+++ b/content/millennium/r4/diagnostic/observation.md
@@ -191,7 +191,7 @@ _Implementation Notes_
 
 ### Authorization Types
 
-<div class="auth-types"><a href="/authorization/#requesting-authorization-on-behalf-of-a-user" class="provider">Provider</a><i> (Laboratory only)</i> | <a href="/authorization/#requesting-authorization-on-behalf-of-a-system" class="system">System</a><i> (Vital Signs and Laboratory)</i></div>
+<div class="auth-types"><a href="/authorization/#requesting-authorization-on-behalf-of-a-user" class="provider">Provider</a><i> </i> | <a href="/authorization/#requesting-authorization-on-behalf-of-a-system" class="system">System</a><i> </i></div>
 
 ### Headers
 

--- a/lib/resources/r4/observation.yaml
+++ b/lib/resources/r4/observation.yaml
@@ -414,13 +414,39 @@ fields:
                 "text": "primary performer"
              },
              "url": "http://hl7.org/fhir/StructureDefinition/event-performerFunction"
+          },
+          {
+             "valueCodeableConcept":{
+                "coding":[
+                   {
+                      "system":"http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                      "code":"PRF",
+                      "display":"performer"
+                   }
+                ],
+                "text":"performer"
+             },
+             "url":"http://hl7.org/fhir/StructureDefinition/event-performerFunction"
+          },
+          {
+             "valueCodeableConcept":{
+                "coding":[
+                   {
+                      "system":"http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                      "code":"AUTHEN",
+                      "display":"authenticator"
+                   }
+                ],
+                "text":"authenticator"
+             },
+             "url":"http://hl7.org/fhir/StructureDefinition/event-performerFunction"
           }
        ]
     }
   note: |
     <ul>
-       <li> Vital Signs supports only `LA` extension. </li>
-       <li> Laboratory supports `LA` , `PPRF` and `OP` extensions. </li>
+       <li> Vital Signs supports `LA` and `PPRF` extension. The code must be 'LA' when only one performer is provided and when multiple performers are present then the code must be 'LA' for one of the performers.</li>
+       <li> Laboratory supports `LA` , `PPRF` , `PRF` , `OP` and `AUTHEN` extensions. </li>
     </ul>
   url: https://hl7.org/fhir/R4/extension-event-performerfunction-definitions.html
 

--- a/lib/resources/r4/observation.yaml
+++ b/lib/resources/r4/observation.yaml
@@ -445,8 +445,14 @@ fields:
     }
   note: |
     <ul>
-       <li> Vital Signs supports `LA` and `PPRF` extension. The code must be 'LA' when only one performer is provided and when multiple performers are present then the code must be 'LA' for one of the performers.</li>
-       <li> Laboratory supports `LA` , `PPRF` , `PRF` , `OP` and `AUTHEN` extensions. </li>
+       <li>
+          Vital Signs supports `LA` and `PPRF` codes.
+          <ul>
+             <li>When only one performer is provided, the code must be `LA`.</li>
+             <li>When multiple performers are provided, then the code must be `LA` for one of the performers.</li>
+          </ul>
+       </li>
+       <li> Laboratory supports `LA` , `PPRF` , `PRF` , `OP` and `AUTHEN` codes. </li>
     </ul>
   url: https://hl7.org/fhir/R4/extension-event-performerfunction-definitions.html
 


### PR DESCRIPTION
Description
----
Vital Sign creates support provider persona. Labs Creates support additional performers like PRF and AUTHEN whereas vitals   support PPRF.
<img width="824" alt="Screen Shot 2021-06-17 at 9 34 09 AM" src="https://user-images.githubusercontent.com/18075594/122418722-07324380-cf50-11eb-81e9-a90ceb6f1b02.png">
<img width="586" alt="Screen Shot 2021-06-17 at 9 34 38 AM" src="https://user-images.githubusercontent.com/18075594/122418759-0ef1e800-cf50-11eb-9d93-ee1c2422472c.png">
<img width="685" alt="Screen Shot 2021-06-17 at 9 40 46 AM" src="https://user-images.githubusercontent.com/18075594/122418840-1f09c780-cf50-11eb-9e1c-95d420f8c52b.png">

PR Checklist
----
- [X] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.
