### PR TITLE
Fixed the redirect on category 'Other'

### DIFF
--- a/content/millennium/r4/other.md
+++ b/content/millennium/r4/other.md
@@ -1,0 +1,10 @@
+---
+title: Other | R4 API
+layout: api
+---
+
+<%= render '/millennium/r4/other.*' %>
+
+<%= render '/millennium/r4/other/health-cards.*' %>
+
+* [HealthCards](../other/health-cards)

--- a/layouts/millennium/r4/other.html
+++ b/layouts/millennium/r4/other.html
@@ -1,0 +1,5 @@
+<h1 id="other">Other</h1>
+
+<p>Resources in the Other category include resources that are uncategorized on http://hl7.org/fhir/resourcelist.html.</p>
+
+<h3 id="implemented-resources">Implemented Resources</h3>

--- a/nanoc.yaml
+++ b/nanoc.yaml
@@ -276,8 +276,6 @@ redirects:
     url: /millennium/r4/clinical/medications/immunization
   /millennium/r4/medications/medication-request:
     url: /millennium/r4/clinical/medications/medication-request
-  /millennium/r4/other:
-    url: /millennium/r4/foundation/other
   /millennium/r4/other/binary:
     url: /millennium/r4/foundation/other/binary
   /millennium/r4/request-and-response:


### PR DESCRIPTION
Description
The 'Other' category on the Millennium R4 sidebar was linked to a redirect URL. This has been changed so that this category has its own URL. 

[Issue related to this PR](https://github.com/cerner/fhir.cerner.com/issues/698)

Screenshots of fhir.cerner.com before changes:
<img width="359" alt="Screen Shot 2021-07-14 at 9 20 41 AM" src="https://user-images.githubusercontent.com/85695386/125658623-814a8b6e-da29-4529-92ef-ad5fb71793d9.png">
<img width="1080" alt="Screen Shot 2021-07-14 at 11 31 15 AM" src="https://user-images.githubusercontent.com/85695386/125658666-b8a9b833-2bf2-457f-95a8-2cdae2c65d32.png">
Screenshots of fhir.cerner.com running changes locally: 
<img width="1147" alt="Screen Shot 2021-07-14 at 11 32 00 AM" src="https://user-images.githubusercontent.com/85695386/125658788-56ee8284-0958-41db-8c61-84484a8a6ac7.png">
----
PR Checklist
----
- [x] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.
