### PR TITLE
search by encounter filters patient level document

### DIFF
--- a/content/millennium/r4/foundation/documents/document-reference.md
+++ b/content/millennium/r4/foundation/documents/document-reference.md
@@ -64,6 +64,9 @@ _Implementation Notes_
   * It must be provided twice, once with the `ge` prefix, and once with the `lt` prefix.
   * If one `period` parameter includes a time, both must include a time.
 
+* When searching with the `encounter` parameter:
+  * Patient level documents are filtered out from responses when the encounter id is zero/blank.
+
 ### Headers
 
 <%= headers %>
@@ -80,6 +83,20 @@ _Implementation Notes_
 <%= json(:R4_DOCUMENT_REFERENCE_BUNDLE) %>
 
 <%= disclaimer %>
+
+### Example: search by encounter filters patients level documents
+
+#### Request
+
+    GET https://fhir-ehr.cerner.com/r4/2c400054-42d8-4e74-87b7-80b5bd5fde9f/DocumentReference?patient=823932&encounter=863887
+
+#### Response
+
+<%= headers status: 200 %>
+<%= json(:R4_DOCUMENT_REFERENCE_SEARCH_BY_ENCOUNTER_FILTER_PATIENT_DOCUMENTS) %>
+
+<%= disclaimer %>
+
 
 #### Patient Authorization Request
 

--- a/content/millennium/r4/foundation/documents/document-reference.md
+++ b/content/millennium/r4/foundation/documents/document-reference.md
@@ -88,7 +88,7 @@ _Implementation Notes_
 
 #### Request
 
-    GET https://fhir-ehr.cerner.com/r4/2c400054-42d8-4e74-87b7-80b5bd5fde9f/DocumentReference?patient=823932&encounter=863887
+    GET https://fhir-ehr.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/DocumentReference?patient=823932&encounter=863887
 
 #### Response
 

--- a/lib/resources/example_json/r4_examples_document_reference.rb
+++ b/lib/resources/example_json/r4_examples_document_reference.rb
@@ -127,7 +127,7 @@ module Cerner
       "type": {
         "coding": [
           {
-            "system": 'https://fhir.cerner.com/2c400054-42d8-4e74-87b7-80b5bd5fde9f/codeSet/72',
+            "system": 'https://fhir.cerner.com/ec2458f2-1e24-41c8-b71b-0e701af7583d/codeSet/72',
             "code": '4184837',
             "display": 'Bone Marrow Report',
             "userSelected": true
@@ -164,7 +164,7 @@ module Cerner
         {
           "attachment": {
             "contentType": 'application/pdf',
-            "url": 'https://fhir-ehr.devcerner.com/r4/2c400054-42d8-4e74-87b7-80b5bd5fde9f/Binary/XR-8676968',
+            "url": 'https://fhir-ehr.devcerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/Binary/XR-8676968',
             "title": 'Bone Marrow Final Report',
             "creation": '2014-12-08T21:04:50.000Z'
           }

--- a/lib/resources/example_json/r4_examples_document_reference.rb
+++ b/lib/resources/example_json/r4_examples_document_reference.rb
@@ -107,6 +107,78 @@ module Cerner
       }
     }.freeze
 
+    R4_DOCUMENT_REFERENCE_SEARCH_BY_ENCOUNTER_FILTER_PATIENT_DOCUMENTS ||= {
+      "resourceType": "DocumentReference",
+      "id": "8676968",
+      "meta": {
+          "versionId": "4",
+          "lastUpdated": "2014-12-08T21:18:56.000Z"
+      },
+      "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Document Reference</b></p><p><b>Patient Name</b>: Test, Blood Bank</p><p><b>Document Type</b>: Bone Marrow Report</p><p><b>Document Category</b>: Unknown</p><p><b>Document Title</b>: Bone Marrow Final Report</p><p><b>Service Start Date</b>: Dec  8, 2014  3:04 P.M. CST</p><p><b>Service End Date</b>: Dec  8, 2014  3:04 P.M. CST</p><p><b>Document Status</b>: Final</p><p><b>Verifying Provider</b>: Desani, Santosh</p></div>"
+      },
+      "status": "current",
+      "docStatus": "final",
+      "type": {
+          "coding": [
+              {
+                  "system": "https://fhir.cerner.com/2c400054-42d8-4e74-87b7-80b5bd5fde9f/codeSet/72",
+                  "code": "4184837",
+                  "display": "Bone Marrow Report",
+                  "userSelected": true
+              },
+              {
+                  "system": "http://terminology.hl7.org/CodeSystem/v3-NullFlavor",
+                  "code": "UNK",
+                  "display": "unknown"
+              }
+          ],
+          "text": "Bone Marrow Report"
+      },
+      "category": [
+          {
+              "coding": [
+                  {
+                      "system": "http://terminology.hl7.org/CodeSystem/data-absent-reason",
+                      "code": "unknown",
+                      "display": "Unknown"
+                  }
+              ],
+              "text": "Unknown"
+          }
+      ],
+      "subject": {
+          "reference": "Patient/823932",
+          "display": "Test, Blood Bank"
+      },
+      "authenticator": {
+          "reference": "Practitioner/1994008",
+          "display": "Desani, Santosh"
+      },
+      "content": [
+          {
+              "attachment": {
+                  "contentType": "application/pdf",
+                  "url": "https://fhir-ehr.devcerner.com/r4/2c400054-42d8-4e74-87b7-80b5bd5fde9f/Binary/XR-8676968",
+                  "title": "Bone Marrow Final Report",
+                  "creation": "2014-12-08T21:04:50.000Z"
+              }
+          }
+      ],
+      "context": {
+          "encounter": [
+              {
+                  "reference": "Encounter/863887"
+              }
+          ],
+          "period": {
+              "start": "2014-12-08T21:04:50.000Z",
+              "end": "2014-12-08T21:04:50.000Z"
+          }
+      }
+  }
+
     R4_DOCUMENT_REFERENCE_PATIENT_ACCESS ||= {
       'resourceType': 'DocumentReference',
       'id': '21961261',

--- a/lib/resources/example_json/r4_examples_document_reference.rb
+++ b/lib/resources/example_json/r4_examples_document_reference.rb
@@ -108,76 +108,80 @@ module Cerner
     }.freeze
 
     R4_DOCUMENT_REFERENCE_SEARCH_BY_ENCOUNTER_FILTER_PATIENT_DOCUMENTS ||= {
-      "resourceType": "DocumentReference",
-      "id": "8676968",
+      "resourceType": 'DocumentReference',
+      "id": '8676968',
       "meta": {
-          "versionId": "4",
-          "lastUpdated": "2014-12-08T21:18:56.000Z"
+        "versionId": '4',
+        "lastUpdated": '2014-12-08T21:18:56.000Z'
       },
       "text": {
-          "status": "generated",
-          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Document Reference</b></p><p><b>Patient Name</b>: Test, Blood Bank</p><p><b>Document Type</b>: Bone Marrow Report</p><p><b>Document Category</b>: Unknown</p><p><b>Document Title</b>: Bone Marrow Final Report</p><p><b>Service Start Date</b>: Dec  8, 2014  3:04 P.M. CST</p><p><b>Service End Date</b>: Dec  8, 2014  3:04 P.M. CST</p><p><b>Document Status</b>: Final</p><p><b>Verifying Provider</b>: Desani, Santosh</p></div>"
+        "status": 'generated',
+        "div": '<div xmlns="http://www.w3.org/1999/xhtml"><p><b>Document Reference</b></p><p><b>Patient Name</b>: '\
+        'Test, Blood Bank</p><p><b>Document Type</b>: Bone Marrow Report</p><p><b>Document Category</b>: '\
+        'Unknown</p><p><b>Document Title</b>: Bone Marrow Final Report</p><p><b>Service Start Date</b>: '\
+        'Dec  8, 2014  3:04 P.M. CST</p><p><b>Service End Date</b>: Dec  8, 2014  3:04 P.M. '\
+        'CST</p><p><b>Document Status</b>: Final</p><p><b>Verifying Provider</b>: Desani, Santosh</p></div>'
       },
-      "status": "current",
-      "docStatus": "final",
+      "status": 'current',
+      "docStatus": 'final',
       "type": {
-          "coding": [
-              {
-                  "system": "https://fhir.cerner.com/2c400054-42d8-4e74-87b7-80b5bd5fde9f/codeSet/72",
-                  "code": "4184837",
-                  "display": "Bone Marrow Report",
-                  "userSelected": true
-              },
-              {
-                  "system": "http://terminology.hl7.org/CodeSystem/v3-NullFlavor",
-                  "code": "UNK",
-                  "display": "unknown"
-              }
-          ],
-          "text": "Bone Marrow Report"
+        "coding": [
+          {
+            "system": 'https://fhir.cerner.com/2c400054-42d8-4e74-87b7-80b5bd5fde9f/codeSet/72',
+            "code": '4184837',
+            "display": 'Bone Marrow Report',
+            "userSelected": true
+          },
+          {
+            "system": 'http://terminology.hl7.org/CodeSystem/v3-NullFlavor',
+            "code": 'UNK',
+            "display": 'unknown'
+          }
+        ],
+        "text": 'Bone Marrow Report'
       },
       "category": [
-          {
-              "coding": [
-                  {
-                      "system": "http://terminology.hl7.org/CodeSystem/data-absent-reason",
-                      "code": "unknown",
-                      "display": "Unknown"
-                  }
-              ],
-              "text": "Unknown"
-          }
+        {
+          "coding": [
+            {
+              "system": 'http://terminology.hl7.org/CodeSystem/data-absent-reason',
+              "code": 'unknown',
+              "display": 'Unknown'
+            }
+          ],
+          "text": 'Unknown'
+        }
       ],
       "subject": {
-          "reference": "Patient/823932",
-          "display": "Test, Blood Bank"
+        "reference": 'Patient/823932',
+        "display": 'Test, Blood Bank'
       },
       "authenticator": {
-          "reference": "Practitioner/1994008",
-          "display": "Desani, Santosh"
+        "reference": 'Practitioner/1994008',
+        "display": 'Desani, Santosh'
       },
       "content": [
-          {
-              "attachment": {
-                  "contentType": "application/pdf",
-                  "url": "https://fhir-ehr.devcerner.com/r4/2c400054-42d8-4e74-87b7-80b5bd5fde9f/Binary/XR-8676968",
-                  "title": "Bone Marrow Final Report",
-                  "creation": "2014-12-08T21:04:50.000Z"
-              }
+        {
+          "attachment": {
+            "contentType": 'application/pdf',
+            "url": 'https://fhir-ehr.devcerner.com/r4/2c400054-42d8-4e74-87b7-80b5bd5fde9f/Binary/XR-8676968',
+            "title": 'Bone Marrow Final Report',
+            "creation": '2014-12-08T21:04:50.000Z'
           }
+        }
       ],
       "context": {
-          "encounter": [
-              {
-                  "reference": "Encounter/863887"
-              }
-          ],
-          "period": {
-              "start": "2014-12-08T21:04:50.000Z",
-              "end": "2014-12-08T21:04:50.000Z"
+        "encounter": [
+          {
+            "reference": 'Encounter/863887'
           }
+        ],
+        "period": {
+          "start": '2014-12-08T21:04:50.000Z',
+          "end": '2014-12-08T21:04:50.000Z'
+        }
       }
-  }
+    }.freeze
 
     R4_DOCUMENT_REFERENCE_PATIENT_ACCESS ||= {
       'resourceType': 'DocumentReference',


### PR DESCRIPTION
Description
R4 DocumentReference search by encounter should not return patient level documents

Screenshots

<img width="891" alt="Screenshot 2021-07-16 at 3 08 13 PM" src="https://user-images.githubusercontent.com/55026048/125927361-15a88b15-55a3-461c-9235-0112ef831a0c.png">


<img width="1289" alt="Screenshot 2021-07-16 at 10 51 05 AM" src="https://user-images.githubusercontent.com/55026048/125896259-c453abc3-fcc1-4eee-81f9-f9860311c764.png">

PR Checklist
----
- [X] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.
