### PR TITLE
Remove stale Q&A from authorization overview

### DIFF
--- a/content/authorization.md
+++ b/content/authorization.md
@@ -1138,14 +1138,6 @@ preceding documentation.
 > _NOTE_:  Cerner currently does not support
   offline_access support for such applications.
 
-- Can I require Cerner to force the use of client credentials
-  (also known as a "confidential client") when exchanging a
-  grant code for an access token?
-
-> No, Cerner currently does not have this capability.  It
-  is currently under construction and will be available in 
-  the future.
-
 - How can I embed my SMART<sup>®</sup> on FHIR<sup>®</sup>
   application in another application, such as inside of a web
   view or iframe and still orchestrate the authorization


### PR DESCRIPTION
Description
----
This Q&A is stale (and misleading) ever since the option for public vs. private client became available in the developer portal:
<img width="739" alt="screenshot" src="https://user-images.githubusercontent.com/467773/128734515-4a8ae906-8ead-4400-abb4-5575303a1959.png">

Before Changes:
<img width="607" alt="screenshot2" src="https://user-images.githubusercontent.com/467773/128734674-aa3963fd-9691-4e6f-8511-863331cc7a7b.png">

PR Checklist
----
- [X] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.
