### PR TITLE
Remove beta tag for health-cards

### DIFF
--- a/content/millennium/r4/foundation/other/health-cards.md
+++ b/content/millennium/r4/foundation/other/health-cards.md
@@ -4,8 +4,6 @@ title: Health Cards | R4 API
 
 # Health-Cards
 
-<%= beta_tag %>
-
 * TOC
 {:toc}
 
@@ -96,8 +94,6 @@ _Authorization Types_
 The OAuth2 token must include `Patient.read` and `Observation.read` scopes.
 
 ## $health-cards-issue 
-
-<%= beta_tag(action: true) %>
 
 Issues Health Cards for an existing Patient that meet the supplied request:
 


### PR DESCRIPTION
Description
----
Removed beta tag for health-cards
<img width="787" alt="Screen Shot 2021-09-08 at 10 26 12 AM" src="https://user-images.githubusercontent.com/12742905/132539047-d7d876a8-20af-49ac-9922-d279a61c3f7a.png">
<img width="816" alt="Screen Shot 2021-09-08 at 10 26 28 AM" src="https://user-images.githubusercontent.com/12742905/132539049-618e123d-7d33-4ca4-9525-fb83d62bc225.png">

PR Checklist
----
- [X] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.
