### PR TITLE
[R4 Coverage] Documentation update to support patient-level delete private coverages

### DIFF
--- a/content/millennium/r4/financial/support/coverage.md
+++ b/content/millennium/r4/financial/support/coverage.md
@@ -315,13 +315,13 @@ The common [errors] and [OperationOutcomes] may be returned.
 
 ## Delete
 
-Delete an existing Encounter-level Coverage.
+Delete an existing Patient-Level or Encounter-level Coverage.
 
     DELETE /Coverage/:id
 
 _Implementation Notes_
 
-* For Private Coverages, only Encounter-level Coverages may be deleted.
+* For Private Coverages, both Encounter-level and Patient-level Coverages may be deleted.
 * For Public Coverages, both Encounter-level and Patient-level Coverages may be deleted.
 
 ### Authorization Types


### PR DESCRIPTION
Description
----
Updating Coverage documentation to support patient-level delete private coverages.

Screenshots before changes merged
-----
<img width="734" alt="Screen Shot 2021-09-17 at 10 58 51 AM" src="https://user-images.githubusercontent.com/62904679/134032224-7919edd0-95d5-4b5a-8310-534a79e89c67.png">

PR Checklist
----
- [x] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.
