### PR TITLE
Remove stale Q&A from authorization overview

### DIFF
--- a/content/authorization.md
+++ b/content/authorization.md
@@ -1052,10 +1052,7 @@ preceding documentation.
 
 > Cerner currently does not have a mechanism to allow
   such devices to participate in the authorization
-  ecosystem.  Cerner is tracking the progress
-  of the IETF draft RFC
-  ["OAuth 2.0 Device Flow"](https://tools.ietf.org/html/draft-denniss-oauth-device-flow-00)
-  for further evaluation of such capabilities.
+  ecosystem.
 
 - How can my application revoke a refresh token on
   behalf of a user?


### PR DESCRIPTION
Description
----
The referenced standard is no longer in a draft status (and we have no plans on our roadmap to implement it in any case), so simply remove the reference.

PR Checklist
----
- [X] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.

Before:
<img width="608" alt="Screen Shot 2021-11-08 at 9 46 51 AM" src="https://user-images.githubusercontent.com/467773/140773213-9857947f-fcf8-4cdc-b3a6-3060fdabb7d9.png">
