### PR TITLE
Clarify token revocation behavior

### DIFF
--- a/content/authorization.md
+++ b/content/authorization.md
@@ -1058,11 +1058,9 @@ preceding documentation.
   behalf of a user?
 
 > Cerner currently does not have a mechanism that allows
-  client applications to revoke refresh tokens.  Cerner is
-  currently tracking the progress of the IETF Proposed
-  Standard RFC
-  ["OAuth 2.0 Token Revocation"](https://tools.ietf.org/html/rfc7009)
-  for further evaluation of such capabilities.
+  client applications to revoke refresh tokens.  If/when
+  such functionality is implemented, it will follow RFC 7009
+  ["OAuth 2.0 Token Revocation"](https://tools.ietf.org/html/rfc7009).
 
 - How can my application participate in log out
   mechanisms provided by the organization's single

--- a/content/authorization.md
+++ b/content/authorization.md
@@ -1054,6 +1054,18 @@ preceding documentation.
   such devices to participate in the authorization
   ecosystem.
 
+- What happens when a user revokes my application's
+  access to their data?
+
+> When a user revokes an application's access, its
+  *refresh* tokens immediately become non-functional.
+  *Access* tokens cannot be directly revoked; however,
+  they are only valid a brief period in any case
+  (on the order of a few minutes). As a result, it is
+  generally unnecessary (and inefficient) for applications
+  check for access token validity using an introspection
+  endpoint.
+
 - How can my application revoke a refresh token on
   behalf of a user?
 

--- a/content/authorization.md
+++ b/content/authorization.md
@@ -1064,7 +1064,11 @@ preceding documentation.
   (on the order of a few minutes). As a result, it is
   generally unnecessary (and inefficient) for applications
   check for access token validity using an introspection
-  endpoint.
+  endpoint. This behavior is discussed in more detail in
+  Section 3 of
+  RFC 7009 ["OAuth 2.0 Token Revocation"](https://tools.ietf.org/html/rfc7009),
+  as well as Section 16.18 of
+  ["OpenID Connect Core 1.0"](https://openid.net/specs/openid-connect-core-1_0.html).
 
 - How can my application revoke a refresh token on
   behalf of a user?

--- a/content/authorization.md
+++ b/content/authorization.md
@@ -1060,7 +1060,7 @@ preceding documentation.
 > When a user revokes an application's access, its
   *refresh* tokens immediately become non-functional.
   *Access* tokens cannot be directly revoked; however,
-  they are only valid a brief period in any case
+  they are only valid for a brief period in any case
   (on the order of a few minutes). As a result, it is
   generally unnecessary (and inefficient) for applications
   to check for access token validity using an introspection

--- a/content/authorization.md
+++ b/content/authorization.md
@@ -1065,10 +1065,11 @@ preceding documentation.
   generally unnecessary (and inefficient) for applications
   to check for access token validity using an introspection
   endpoint. This behavior is discussed in more detail in
-  Section 3 of
-  RFC 7009 ["OAuth 2.0 Token Revocation"](https://tools.ietf.org/html/rfc7009),
-  as well as Section 16.18 of
-  ["OpenID Connect Core 1.0"](https://openid.net/specs/openid-connect-core-1_0.html).
+  Section 3 of RFC 7009
+  ["OAuth 2.0 Token Revocation"](https://tools.ietf.org/html/rfc7009),
+  as well as Section 16.18 of the
+  ["OpenID Connect Core 1.0"](https://openid.net/specs/openid-connect-core-1_0.html)
+  specification.
 
 - How can my application revoke a refresh token on
   behalf of a user?

--- a/content/authorization.md
+++ b/content/authorization.md
@@ -1063,7 +1063,7 @@ preceding documentation.
   they are only valid a brief period in any case
   (on the order of a few minutes). As a result, it is
   generally unnecessary (and inefficient) for applications
-  check for access token validity using an introspection
+  to check for access token validity using an introspection
   endpoint. This behavior is discussed in more detail in
   Section 3 of
   RFC 7009 ["OAuth 2.0 Token Revocation"](https://tools.ietf.org/html/rfc7009),


### PR DESCRIPTION
Description
----
In the course of testing related to the 21st Century Cures Act (using the ONC's "Inferno" test suite), some questions arose related to the Authorization Server's handling of token revocation; these changes attempt to clarify those behaviors.

PR Checklist
----
- [X] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.

<img width="1008" alt="Screen Shot 2021-11-29 at 5 00 50 PM" src="https://user-images.githubusercontent.com/467773/143956338-0ba04dfc-d063-4c69-be18-d68f6f1bcd25.png">