### PR TITLE
R4 FamilyMemberHistory: Remove if-match and etag header

### DIFF
--- a/content/millennium/r4/clinical/summary/family-member-history.md
+++ b/content/millennium/r4/clinical/summary/family-member-history.md
@@ -204,14 +204,11 @@ Cache-Control: no-cache
 Content-Length: 0
 Content-Type: text/html
 Date: Wed, 14 Aug 2019 17:23:14 GMT
-Etag: W/"1"
 Location: https://fhir-ehr-code.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/FamilyMemberHistory/123-456
 Last-Modified: Wed, 14 Aug 2019 17:23:14 GMT
 Vary: Origin
 X-Request-Id: 1638e30e497b93ff4383b2ff0eaeea91
 </pre>
-
-The `ETag` response header indicates the current `If-Match` version to use on a subsequent update.
 
 <%= disclaimer %>
 
@@ -236,8 +233,7 @@ _Implementation Notes_
 
 ### Headers
 
-<%= headers head: {Authorization: '&lt;OAuth2 Bearer Token>', 'Content-Type': 'application/fhir+json',
-'If-Match': 'W/"&lt;Current version of the FamilyMemberHistory resource>"'} %>
+<%= headers head: {Authorization: '&lt;OAuth2 Bearer Token>', 'Content-Type': 'application/fhir+json'} %>
 
 ### Body fields
 


### PR DESCRIPTION
Description
----
Remove if-match and etag header for FamilyMemberHistory

<img width="1680" alt="Screen Shot 2022-01-12 at 10 31 36 AM" src="https://user-images.githubusercontent.com/56039503/149182013-a320e301-7347-4202-9951-7348cef16dc6.png">
<img width="1680" alt="Screen Shot 2022-01-12 at 10 29 57 AM" src="https://user-images.githubusercontent.com/56039503/149182002-0fc91f7d-ef03-44af-9563-98d1662d45ce.png">

PR Checklist
----
- [x] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.
