### PR TITLE
Update QuestionnaireResponse search example

### DIFF
--- a/content/millennium/r4/clinical/diagnostics/questionnaire-response.md
+++ b/content/millennium/r4/clinical/diagnostics/questionnaire-response.md
@@ -82,7 +82,7 @@ _Implementation Notes_
 
 #### Request
 
-    GET https://fhir-open.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/QuestionnaireResponses?_id=SH-12508041
+    GET https://fhir-open.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/QuestionnaireResponse?_id=SH-12508041
 
 #### Response
 


### PR DESCRIPTION
the search example has the resource questionnaireresponses instead of questionnaireresponse.  Updated the example.

Description
----
<img width="1680" alt="Screen Shot 2022-02-07 at 4 11 54 PM" src="https://user-images.githubusercontent.com/56039503/152880844-bcda2310-aa7b-41c5-a075-c23c5abc470f.png">

PR Checklist
----
- [x] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.
