### PR TITLE
ChargeItem custom-attribute valueDateTime

### DIFF
--- a/content/millennium/r4/financial/general/charge-item.md
+++ b/content/millennium/r4/financial/general/charge-item.md
@@ -60,7 +60,7 @@ All URLs for custom extensions are defined as `https://fhir-ehr.cerner.com/r4/St
  ID                           | Value\[x] Type                                                    | Description
 ------------------------------|-------------------------------------------------------------------|--------------------------------------------------------------------------
  `bill-code-schedule`         | [`coding`]                                                        | A defined group of bill codes that drives billing behavior.
- `custom-attribute`           | None (contains nested extensions)                                 | A client defined custom attribute for the resource. Attribute values can be of type [`integer`], [`string`], [`decimal`], or [`date`].
+ `custom-attribute`           | None (contains nested extensions)                                 | A client defined custom attribute for the resource. Attribute values can be of type [`integer`], [`string`], [`decimal`], or [`dateTime`].
  `description`                | [`string`]                                                        | A description providing additional details of the resource.
  `modifier-code`              | None (contains nested extensions)                                 | A code providing additional detail about a product or service.
  `national-drug-product`      | None (contains nested extensions)                                 | The national drug product used in care.
@@ -323,7 +323,7 @@ The `ETag` response header indicates the current `If-Match` version to use on su
 
 The common [errors] and [OperationOutcomes] may be returned.
 
-[`date`]: https://hl7.org/fhir/r4/datatypes.html#date
+[`dateTime`]: https://hl7.org/fhir/r4/datatypes.html#datetime
 [`decimal`]: https://hl7.org/fhir/r4/datatypes.html#decimal
 [`integer`]: https://hl7.org/fhir/r4/datatypes.html#integer
 [`Money`]: https://hl7.org/fhir/r4/datatypes.html#Money

--- a/lib/resources/r4/charge_item_create.yaml
+++ b/lib/resources/r4/charge_item_create.yaml
@@ -291,7 +291,7 @@ fields:
       <ul>
         <li>Custom-attribute-name and Custom-attribute-value are both required</li>
         <li>id and valueString for custom-attribute-value are required</li>
-        <li>Custom-attribute-value can be of type integer, string, or decimal</li>
+        <li>Custom-attribute-value can be of type integer, string, decimal, or dateTime</li>
       </ul>
     url: https://fhir-ehr.cerner.com/r4/StructureDefinition/custom-attribute?_format=json
 

--- a/lib/resources/r4/charge_item_create.yaml
+++ b/lib/resources/r4/charge_item_create.yaml
@@ -289,9 +289,9 @@ fields:
       }
     note: >
       <ul>
-        <li>Custom-attribute-name and Custom-attribute-value are both required</li>
+        <li>custom-attribute-name and custom-attribute-value are both required</li>
         <li>id and valueString for custom-attribute-value are required</li>
-        <li>Custom-attribute-value can be of type integer, string, decimal, or dateTime</li>
+        <li>custom-attribute-value can be of type integer, string, decimal, or dateTime</li>
       </ul>
     url: https://fhir-ehr.cerner.com/r4/StructureDefinition/custom-attribute?_format=json
 

--- a/lib/resources/r4/charge_item_create.yaml
+++ b/lib/resources/r4/charge_item_create.yaml
@@ -290,7 +290,7 @@ fields:
     note: >
       <ul>
         <li>custom-attribute-name and custom-attribute-value are both required</li>
-        <li>id and valueString for custom-attribute-value are required</li>
+        <li>id and valueString for custom-attribute-name are required</li>
         <li>custom-attribute-value can be of type integer, string, decimal, or dateTime</li>
       </ul>
     url: https://fhir-ehr.cerner.com/r4/StructureDefinition/custom-attribute?_format=json

--- a/lib/resources/r4/charge_item_create.yaml
+++ b/lib/resources/r4/charge_item_create.yaml
@@ -291,7 +291,7 @@ fields:
       <ul>
         <li>Custom-attribute-name and Custom-attribute-value are both required</li>
         <li>id and valueString for custom-attribute-value are required</li>
-        <li>Custom-attribute-value can be of type integer, string, decimal, or dateTime</li>
+        <li>Custom-attribute-value can be of type integer, string, or decimal</li>
       </ul>
     url: https://fhir-ehr.cerner.com/r4/StructureDefinition/custom-attribute?_format=json
 

--- a/lib/resources/r4/charge_item_create.yaml
+++ b/lib/resources/r4/charge_item_create.yaml
@@ -291,7 +291,7 @@ fields:
       <ul>
         <li>Custom-attribute-name and Custom-attribute-value are both required</li>
         <li>id and valueString for custom-attribute-value are required</li>
-        <li>Custom-attribute-value can be of type integer, string or decimal</li>
+        <li>Custom-attribute-value can be of type integer, string, decimal, or dateTime</li>
       </ul>
     url: https://fhir-ehr.cerner.com/r4/StructureDefinition/custom-attribute?_format=json
 

--- a/lib/resources/r4/charge_item_modify.yaml
+++ b/lib/resources/r4/charge_item_modify.yaml
@@ -327,7 +327,7 @@ fields:
     note: >
       <ul>
         <li>custom-attribute-name and custom-attribute-value are both required</li>
-        <li>id and valueString for custom-attribute-value are required</li>
+        <li>id and valueString for custom-attribute-name are required</li>
         <li>custom-attribute-value can be of type integer, string, decimal, or dateTime</li>
       </ul>
     url: https://fhir-ehr.cerner.com/r4/StructureDefinition/custom-attribute?_format=json

--- a/lib/resources/r4/charge_item_modify.yaml
+++ b/lib/resources/r4/charge_item_modify.yaml
@@ -328,7 +328,7 @@ fields:
       <ul>
         <li>custom-attribute-name and custom-attribute-value are both required</li>
         <li>id and valueString for custom-attribute-value are required</li>
-        <li>custom-attribute-value can be of type integer, string, or decimal</li>
+        <li>custom-attribute-value can be of type integer, string, decimal, or dateTime</li>
       </ul>
     url: https://fhir-ehr.cerner.com/r4/StructureDefinition/custom-attribute?_format=json
 


### PR DESCRIPTION
Description
----
Update documentation to support a valueDateTime for custom-attribute from a valueDate

Screenshots Before Changes Merged
----
<img width="737" alt="Screen Shot 2022-02-04 at 10 50 07 AM" src="https://user-images.githubusercontent.com/62904679/152569792-05eb2a8a-ae4c-4eea-a760-163f7f53d2c9.png">

Documentation update to charge-item-modify:
<img width="752" alt="Screen Shot 2022-02-07 at 11 38 02 AM" src="https://user-images.githubusercontent.com/62904679/152842183-fd6f7eef-0e55-4232-9290-8af51fcda279.png">

Documentation update to charge-item-create:
<img width="746" alt="Screen Shot 2022-02-07 at 11 38 39 AM" src="https://user-images.githubusercontent.com/62904679/152842203-f81284dc-638b-4008-bc68-96f138c592e2.png">

PR Checklist
----
- [x] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.
