### PR TITLE
Encounter Create custom-attribute type string

### DIFF
--- a/lib/resources/example_json/r4_examples_encounter.rb
+++ b/lib/resources/example_json/r4_examples_encounter.rb
@@ -2006,6 +2006,22 @@ module Cerner
             'reference': 'Practitioner/4122622'
           }
         }
+      ],
+      'extension': [
+        {
+          'extension': [
+            {
+              'id': 'ENCNTR:2822522',
+              'valueString': 'ICD-9 Code',
+              'url': 'custom-attribute-name'
+            },
+            {
+              'valueString': 'test string',
+              'url': 'custom-attribute-value'
+            }
+          ],
+          'url': 'https://fhir-ehr.cerner.com/r4/StructureDefinition/custom-attribute'
+        }
       ]
     }.freeze
 

--- a/lib/resources/r4/encounter.yaml
+++ b/lib/resources/r4/encounter.yaml
@@ -552,7 +552,7 @@ fields:
   note: >
     <ul>
       <li>custom-attribute-name and custom-attribute-value are both required</li>
-      <li>id and valueString for custom-attribute-value are required</li>
+      <li>id and valueString for custom-attribute-name are required</li>
       <li>custom-attribute-value can only be of type string</li>
     </ul>
 

--- a/lib/resources/r4/encounter.yaml
+++ b/lib/resources/r4/encounter.yaml
@@ -528,6 +528,34 @@ fields:
       }
     }
 
+- name: custom-attribute
+  url: https://fhir-ehr.cerner.com/r4/StructureDefinition/custom-attribute?_format=json
+  required: 'No'
+  type: Extension
+  description: A client defined custom attribute for the encounter.
+  action: create
+  example: |
+    {
+      "extension": [
+        {
+          "id": "ENCNTR:2822522",
+          "valueString": "ICD-9 Code",
+          "url": "custom-attribute-name"
+        },
+        {
+          "valueString": "test string",
+          "url": "custom-attribute-value"
+        }
+      ],
+      "url": "https://fhir-ehr.cerner.com/r4/StructureDefinition/custom-attribute"
+    }
+  note: >
+    <ul>
+      <li>custom-attribute-name and custom-attribute-value are both required</li>
+      <li>id and valueString for custom-attribute-value are required</li>
+      <li>custom-attribute-value can only be of type string</li>
+    </ul>
+
 - name: meta.security
   url: https://hl7.org/fhir/r4/resource-definitions.html#Meta.security
   required: 'No'
@@ -555,34 +583,6 @@ fields:
         system: http://terminology.hl7.org/CodeSystem/v3-ObservationValue
         info_link: http://hl7.org/fhir/r4/v3/ObservationValue/cs.html
     note: Encounters created with meta.security set with code 'UNCERTREL' will be returned with an external encounter type.
-
-- name: custom-attribute
-    required: 'No'
-    type: Extension
-    description: A client defined custom attribute for the encounter.
-    action: create
-    example: |
-      {
-        "extension": [
-          {
-            "id": "ENCNTR:2822522",
-            "valueString": "ICD-9 Code",
-            "url": "custom-attribute-name"
-          },
-          {
-            "valueString": "test string",
-            "url": "custom-attribute-value"
-          }
-        ],
-        "url": "https://fhir-ehr.cerner.com/r4/StructureDefinition/custom-attribute"
-      }
-    note: >
-      <ul>
-        <li>custom-attribute-name and custom-attribute-value are both required</li>
-        <li>id and valueString for custom-attribute-value are required</li>
-        <li>custom-attribute-value can only be of type string</li>
-      </ul>
-    url: https://fhir-ehr.cerner.com/r4/StructureDefinition/custom-attribute?_format=json
 
 - name: Custom Attribute Value Extension
   url: https://fhir-ehr.cerner.com/r4/StructureDefinition/custom-attribute?_format=json

--- a/lib/resources/r4/encounter.yaml
+++ b/lib/resources/r4/encounter.yaml
@@ -556,6 +556,34 @@ fields:
         info_link: http://hl7.org/fhir/r4/v3/ObservationValue/cs.html
     note: Encounters created with meta.security set with code 'UNCERTREL' will be returned with an external encounter type.
 
+- name: custom-attribute
+    required: 'No'
+    type: Extension
+    description: A client defined custom attribute for the encounter.
+    action: create
+    example: |
+      {
+        "extension": [
+          {
+            "id": "ENCNTR:2822522",
+            "valueString": "ICD-9 Code",
+            "url": "custom-attribute-name"
+          },
+          {
+            "valueString": "test string",
+            "url": "custom-attribute-value"
+          }
+        ],
+        "url": "https://fhir-ehr.cerner.com/r4/StructureDefinition/custom-attribute"
+      }
+    note: >
+      <ul>
+        <li>custom-attribute-name and custom-attribute-value are both required</li>
+        <li>id and valueString for custom-attribute-value are required</li>
+        <li>custom-attribute-value can only be of type string</li>
+      </ul>
+    url: https://fhir-ehr.cerner.com/r4/StructureDefinition/custom-attribute?_format=json
+
 - name: Custom Attribute Value Extension
   url: https://fhir-ehr.cerner.com/r4/StructureDefinition/custom-attribute?_format=json
   terminology_name: extension[x].extension[x].valueCodeableConcept


### PR DESCRIPTION
Description
----
Documentation for encounter create custom-attribute type string support.

Screenshots before changes merged
----
<img width="685" alt="Screen Shot 2022-02-07 at 9 55 46 AM" src="https://user-images.githubusercontent.com/62904679/152823691-4414fe9a-2fb0-4853-b946-91c66acfc293.png">
<img width="766" alt="Screen Shot 2022-02-07 at 12 08 08 PM" src="https://user-images.githubusercontent.com/62904679/152847004-dd1e7a3b-cc38-4e47-8d1c-b27273c95b18.png">

PR Checklist
----
- [x] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.
