### PR TITLE
Update proprietary code system page for multi-region support

### DIFF
--- a/content/millennium/r4/proprietary-codes-and-systems.md
+++ b/content/millennium/r4/proprietary-codes-and-systems.md
@@ -13,7 +13,7 @@ title: Proprietary Codes and Systems | R4 API
 
 Cerner's implementation of the HL7<sup>®</sup> R4 FHIR<sup>®</sup> standard allows Millennium proprietary code values to be used in addition to standard value set codes. This allows developers to read and write data with clients' proprietary codes, eliminating the need to map proprietary codes to standard codes. This is particularly beneficial for concepts that are highly customized by clients such as appointment and document types.
 
-Millennium groups repetitive textual information into code sets. The code set stores a numeric code value that represents a textual or character display. Code sets are consistent across all clients. But the values in a code set vary between clients and are only guaranteed unique within a specific EHR system, which is the reason for the region and the EHR source id (or tenant) qualifier in the system URL. See [Multi-Region Support](#multi-region-support) for further details.
+Millennium groups repetitive textual information into code sets. A code set stores numeric code values that represent textual or character displays. Code sets are consistent across all clients, however the values within a code set vary between clients and are only guaranteed unique within a specific EHR system. For this reason the region and the EHR source id (or tenant) are included in the system URL. See [Multi-Region Support](#multi-region-support) for further details.
 
 The following are true for all Millennium proprietary codes:
 
@@ -883,11 +883,11 @@ This system contains all nomenclature values configured in the domain.
 
 ### Overview
 
-Proprietary codes and systems that are dependent on a specific EHR system may include a Cerner cloud region in their `system` value. The default `system` value format is `https://fhir.cerner.com/<EHR source id>/`.
+Proprietary codes and systems that are dependent on a specific EHR system may include a Cerner cloud region in their `system` value. Unless stated otherwise below, the `system` value format is `https://fhir.cerner.com/<EHR source id>/`.
 
-### Regions
+### Region-specific Systems
 
-The `system` value formats for the following regions are:
+The following regions override the format above with a region-specific `system`:
 
 * Canada:  `https://fhir.ca.cerner.com/<EHR source id>/`
 * Asia-Pacific: `https://fhir.au.cerner.com/<EHR source id>/`

--- a/content/millennium/r4/proprietary-codes-and-systems.md
+++ b/content/millennium/r4/proprietary-codes-and-systems.md
@@ -13,11 +13,11 @@ title: Proprietary Codes and Systems | R4 API
 
 Cerner's implementation of the HL7<sup>®</sup> R4 FHIR<sup>®</sup> standard allows Millennium proprietary code values to be used in addition to standard value set codes. This allows developers to read and write data with clients' proprietary codes, eliminating the need to map proprietary codes to standard codes. This is particularly beneficial for concepts that are highly customized by clients such as appointment and document types.
 
-Millennium groups repetitive textual information into code sets. The code set stores a numeric code value that represents a textual or character display. Code sets are consistent across all clients. But the values in a code set vary between clients and are only guaranteed unique within a specific EHR system, which is the reason for the EHR source id (or tenant) qualifier in the system URL.
+Millennium groups repetitive textual information into code sets. The code set stores a numeric code value that represents a textual or character display. Code sets are consistent across all clients. But the values in a code set vary between clients and are only guaranteed unique within a specific EHR system, which is the reason for the region and the EHR source id (or tenant) qualifier in the system URL. See [Multi-Region Support](#multi-region-support) for further details.
 
 The following are true for all Millennium proprietary codes:
 
-* The `system` value uses the following format: `https://fhir.cerner.com/<EHR source id>/codeSet/<code set>`
+* The `system` value uses the following format: `https://fhir.<region>.cerner.com/<EHR source id>/codeSet/<code set>`
 * The `code` value is the numeric code value as a string
 * The `display` value is the code value display
 * The `userSelected` value is set to true
@@ -834,7 +834,7 @@ This system is the account number of a financial account.
 
     {
       "use": "usual",
-      "system": "https://fhir.cerner.com/<EHR source id>/account-number",
+      "system": "https://fhir.<region>.cerner.com/<EHR source id>/account-number",
       "value": "5646"
     }
 
@@ -843,7 +843,7 @@ This system is the account number of a financial account.
 This system is the bill code type for a charge item. `Bill code type` can be either `CDM_SCHED`, `CPT`, `HCPCS`, `ICD`, `MODIFIER`, or `REVENUE`.
 
     {
-      "system": "https://fhir.cerner.com/<Ehr source id>/CodeSystem/BillCodes-<Bill code type>",
+      "system": "https://fhir.<region>.cerner.com/<EHR source id>/CodeSystem/BillCodes-<Bill code type>",
       "code": "0310"
     }
 
@@ -862,7 +862,7 @@ This system is the category and is only for a pharmacy charge-only order. The co
 This system is the synonym id for an order and the ingredients.
 
     {
-      'system': 'https://fhir.cerner.com/<Ehr source id>/synonym',
+      'system': 'https://fhir.<region>.cerner.com/<EHR source id>/synonym',
       'code': '2762111',
       'display': 'lidocaine topical',
       'userSelected': true
@@ -873,8 +873,25 @@ This system is the synonym id for an order and the ingredients.
 This system contains all nomenclature values configured in the domain.
 
     {
-      'system': 'https://fhir.cerner.com/ec2458f2-1e24-41c8-b71b-0e701af7583d/nomenclature',
+      'system': 'https://fhir.<region>.cerner.com/<EHR source id>/nomenclature',
       'code': '13249579',
       'display': 'Tension-type headache',
       'userSelected': false
     }
+
+## Multi-Region Support
+
+### Overview
+
+Proprietary codes and systems that are dependent on a specific EHR system may include a Cerner cloud region in their `system` value. The default `system` value format is `https://fhir.cerner.com/<EHR source id>/`.
+
+### Regions
+
+The `system` value formats for the following regions are:
+
+* Canada:  `https://fhir.ca.cerner.com/<EHR source id>/`
+* Asia-Pacific: `https://fhir.au.cerner.com/<EHR source id>/`
+
+### Exclusions
+
+The proprietary systems that are not dependent on a EHR system will not include region in their `system` value, for example `https://fhir.cerner.com/medicationrequest-category` is applied for all regions.


### PR DESCRIPTION
Description
----
Updated the Millennium R4 Proprietary codes and systems page for multi-region support.

Screen shots of the updates:
![afterchange-1](https://user-images.githubusercontent.com/40371706/154112619-7be94d27-c229-4478-a1b9-78e3eef58492.png)
![afterchange-2](https://user-images.githubusercontent.com/40371706/154112662-7292eb1a-790c-475f-9272-5e4d9a2a2936.png)
![afterchange-3](https://user-images.githubusercontent.com/40371706/154112690-bcee285b-0d7d-426d-a4b7-42a6966e80d7.png)
![afterchange-4](https://user-images.githubusercontent.com/40371706/154112718-b0924bb1-3afa-4ed9-ba19-f080d2f67b7e.png)

PR Checklist
----
- [x] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.
