### PR TITLE
Update broken link for Authorization "Wildcard scopes"

### DIFF
--- a/content/authorization.md
+++ b/content/authorization.md
@@ -345,7 +345,7 @@ access tokens in perpetuity on behalf of the user until:
 
 ##### Supported Scopes #####
 
-[Wildcard Scopes](http://hl7.org/fhir/smart-app-launch/scopes-and-launch-context/#wildcard-scopes) are currently **not supported**; refer to the linked document for a more detailed discussion of the challenges they pose. An application is currently required to specifically request each scope that it needs to run.
+[Wildcard Scopes](https://hl7.org/fhir/smart-app-launch/scopes-and-launch-context.html#wildcard-scopes) are currently **not supported**; refer to the linked document for a more detailed discussion of the challenges they pose. An application is currently required to specifically request each scope that it needs to run.
 
 Other combinations of scopes may be limited; please see the [FAQ](#faq) for
 known limitations.


### PR DESCRIPTION
Description
----
The current link (without ".html") shows a 404 page. Adding the extension returns the expected content.

![image](https://user-images.githubusercontent.com/22381097/155021457-012a020a-dcec-4bd1-b511-fe86600b2c9a.png)

PR Checklist
----
- [x] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.
