### PR TITLE
Clarify handling of refresh tokens for native applications

### DIFF
--- a/content/authorization.md
+++ b/content/authorization.md
@@ -582,7 +582,7 @@ to the callback URI.
   window will allow the user to proceed with their
   original workflow.
 
-#### Native Client Applications on Mobile Platforms ####
+#### Native Client Applications ####
 
 In recent years, OS platforms have been forced to lock
 down certain behaviors within their browsers that were
@@ -602,6 +602,10 @@ For more information on best practices for OAuth2-based
 workflows for native applications, please refer to the
 IETF Best Current Practices (BCP)
 ["OAuth 2.0 for Native Apps"][OAUTH-NATIVE].
+
+Refresh tokens for native applications are handled in the
+same fashion as for web-based applications; see further
+below for a detailed discussion of this topic.
 
 _NOTE_: Cerner's Authorization Server does not currently
 implement PKCE as noted in section 8.2 of the native

--- a/content/authorization.md
+++ b/content/authorization.md
@@ -598,14 +598,14 @@ preventing remnant browser tabs and smoothing the
 transition between browser and app (no OS app switching
 occurs.)
 
+Refresh tokens for native applications are handled in the
+same fashion as for web-based applications; see further
+below for a detailed discussion of this topic.
+
 For more information on best practices for OAuth2-based
 workflows for native applications, please refer to the
 IETF Best Current Practices (BCP)
 ["OAuth 2.0 for Native Apps"][OAUTH-NATIVE].
-
-Refresh tokens for native applications are handled in the
-same fashion as for web-based applications; see further
-below for a detailed discussion of this topic.
 
 _NOTE_: Cerner's Authorization Server does not currently
 implement PKCE as noted in section 8.2 of the native


### PR DESCRIPTION
Satisfies one of the requirements of the 21st Century Cures Act, specifically: 170.315(g)(10)(v)(A)(1)(iii)

https://www.healthit.gov/sites/default/files/page/2021-07/Clarifications_For_Native_Apps_v5.pdf

> In the Interim Final Rule, ONC clarified that health IT developers must publish the method(s) by which their Health IT Modules support the secure issuance of an initial refresh token to native applications.

Description
----

PR Checklist
----
- [ ] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.
