### PR TITLE
Add Unit of Measurement Extension Information

### DIFF
--- a/content/millennium/r4/clinical/diagnostics/observation.md
+++ b/content/millennium/r4/clinical/diagnostics/observation.md
@@ -46,9 +46,11 @@ The following fields are returned if valued:
 
 ## Extensions
 
+* [convertedMeasurement]
+  This extension returns a converted measurement of a different measurement system than the original quantity.
+* [performerFunction]
 * valueAttachment: URL for this extension is defined as: `http://hl7.org/fhir/5.0/StructureDefinition/extension-Observation.valueAttachment`
   This extension is defined and referenced from the newer version of FHIR. See [Extensions for converting between versions] and [R5 Snapshot of Observation.value] for more information.
-* [performerFunction]
 
 ## Search
 
@@ -340,5 +342,6 @@ The common [errors] and [OperationOutcomes] may be returned.
 [FHIR<sup>®</sup> Update]: https://hl7.org/fhir/R4/http.html#update
 [Extensions for converting between versions]: https://www.hl7.org/fhir/r4/versions.html#extensions
 [R5 Snapshot of Observation.value]: https://hl7.org/fhir/2020Feb/observation-definitions.html#Observation.value_x_
+[convertedMeasurement]: http://hl7.org/fhir/StructureDefinition/iso21090-PQ-translation
 [performerFunction]: http://hl7.org/fhir/R4/extension-event-performerfunction.html
 [Configure Blood Pressure Event Set Pairing Hierarchy]: https://wiki.cerner.com/display/public/reference/Configure+Blood+Pressure+Event+Set+Hierarchy+Pairing

--- a/content/millennium/r4/foundation/conformance/structure-definition.md
+++ b/content/millennium/r4/foundation/conformance/structure-definition.md
@@ -83,6 +83,7 @@ Authorization is not required.
  [`condition-course`]                                        | Indication of a condition's progress since diagnosis.
  [`condition-lifecycle-status`]                              | Indication of whether a condition is active, inactive, resolved, etc.
  [`condition-result`]                                        | Indication of the presence (positive) or absence (negative) of a given condition.
+ [`converted-measurement`]                                   | Returns a converted measurement of a different measurement system than the original quantity.
  [`coverage-encounter`]                                      | Reference to the Encounter associated to the encounter level Coverage.
  [`communication-preference`]                                | Defines communication methods preferred by a patient.
  [`custom-attribute`]                                        | A client defined custom attribute for the resource.
@@ -145,6 +146,7 @@ Authorization is not required.
 [`condition-course`]: https://fhir-ehr.cerner.com/r4/StructureDefinition/condition-course?_format=json
 [`condition-lifecycle-status`]: https://fhir-ehr.cerner.com/r4/StructureDefinition/condition-lifecycle-status?_format=json
 [`condition-result`]: https://fhir-ehr.cerner.com/r4/StructureDefinition/condition-result?_format=json
+[`converted-measurement`]: https://fhir-ehr.cerner.com/r4/StructureDefinition/converted-measurement?_format=json
 [`coverage-encounter`]: https://fhir-ehr.cerner.com/r4/StructureDefinition/coverage-encounter?_format=json
 [`custom-attribute`]: https://fhir-ehr.cerner.com/r4/StructureDefinition/custom-attribute?_format=json
 [`description`]: https://fhir-ehr.cerner.com/r4/StructureDefinition/description?_format=json


### PR DESCRIPTION
Description
----
Update documentation with the unit of measurement information.  Update on Observation and on Structure Definition pages.

Before Changes:
<details open>
<summary>Structure Definition:</summary>
<br>
<img width="1539" alt="Screen Shot 2022-03-10 at 2 38 20 PM" src="https://user-images.githubusercontent.com/87539708/157750488-ef93952c-cce4-4826-9125-5ccff9bc4cf2.png">
</details>
<details open>
<summary>Observation:</summary>
<br>
<img width="1269" alt="Screen Shot 2022-03-10 at 2 37 50 PM" src="https://user-images.githubusercontent.com/87539708/157750532-b19cc232-98c4-4475-a27d-8f27ed3af96e.png">
</details>

After Changes: 
<details open>
<summary>Structure Definition:</summary>
<br>
<img width="1473" alt="Screen Shot 2022-03-10 at 2 26 20 PM" src="https://user-images.githubusercontent.com/87539708/157750594-c6a2d030-860b-4ca6-987f-a56e09f070cd.png">
</details>
<details open>
<summary>Observation:</summary>
<br>
<img width="1377" alt="Screen Shot 2022-03-10 at 2 28 00 PM" src="https://user-images.githubusercontent.com/87539708/157750628-4ff7668e-7c88-4fb9-ad51-6a8153e87624.png">
</details>

PR Checklist
----
- [x] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.
