### PR TITLE
R4 Encounter custom-attribute id documentation

### DIFF
--- a/Rules
+++ b/Rules
@@ -34,6 +34,9 @@ end
 compile '/static/**/*' do
 end
 
+compile '/authorization/cert_example.png' do
+end
+
 compile '/**/faq.*' do
   filter :erb
   filter :kramdown, toc_levels: [2]

--- a/Rules
+++ b/Rules
@@ -34,9 +34,6 @@ end
 compile '/static/**/*' do
 end
 
-compile '/authorization/cert_example.png' do
-end
-
 compile '/**/faq.*' do
   filter :erb
   filter :kramdown, toc_levels: [2]

--- a/lib/resources/example_json/r4_examples_encounter.rb
+++ b/lib/resources/example_json/r4_examples_encounter.rb
@@ -21,6 +21,7 @@ module Cerner
       },
       'extension': [
         {
+          'id': 'CA-0',
           'extension': [
             {
               'id': 'ENCNTR:17368048',
@@ -35,6 +36,7 @@ module Cerner
           'url': 'https://fhir-ehr.cerner.com/r4/StructureDefinition/custom-attribute'
         },
         {
+          'id': 'CA-1',
           'extension': [
             {
               'id': 'ENCNTR:2572582103',
@@ -422,6 +424,7 @@ module Cerner
             },
             "extension": [
               {
+                "id": 'CA-0',
                 "extension": [
                   {
                     "id": 'ENCNTR:3339151',
@@ -446,6 +449,7 @@ module Cerner
                 "url": 'https://fhir-ehr.cerner.com/r4/StructureDefinition/custom-attribute'
               },
               {
+                "id": 'CA-1',
                 "extension": [
                   {
                     "id": 'ENCNTR:17368048',
@@ -460,6 +464,7 @@ module Cerner
                 "url": 'https://fhir-ehr.cerner.com/r4/StructureDefinition/custom-attribute'
               },
               {
+                "id": 'CA-2',
                 "extension": [
                   {
                     "id": 'ENCNTR:4047481',

--- a/lib/resources/r4/encounter.yaml
+++ b/lib/resources/r4/encounter.yaml
@@ -627,6 +627,7 @@ fields:
 
   note: >
     <ul>
+      <li>The custom-attribute id field cannot be set.</li>
       <li>custom-attribute-name and custom-attribute-value are both required.</li>
       <li>id and valueString for custom-attribute-name are required.</li>
       <li>custom-attribute-value can be of type string, integer, dateTime, or CodeableConcept.</li>


### PR DESCRIPTION
Description
----
Updating read/search examples to include the custom-attribute id and add a note about it not being supported to create documentation.

Retrieve update:
<img width="704" alt="Screen Shot 2022-04-26 at 4 40 46 PM" src="https://user-images.githubusercontent.com/17835620/165397273-e204aaa9-4fcc-487c-9128-f81b9fae1d87.png">

Search update:
<img width="563" alt="Screen Shot 2022-04-26 at 4 41 26 PM" src="https://user-images.githubusercontent.com/17835620/165397297-3654f5ac-2017-44e5-b933-9d64131167c3.png">


Create note:
<img width="591" alt="Screen Shot 2022-04-26 at 4 41 38 PM" src="https://user-images.githubusercontent.com/17835620/165397314-f47247e7-de46-4d15-bd04-2f87ca2e28b0.png">


PR Checklist
----
- [x] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.
