### PR TITLE
Added documentation for suspended refresh tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ crash.log
 /bin/
 /.bundle/
 .idea
+*.iml
 output.diff

--- a/content/authorization.md
+++ b/content/authorization.md
@@ -176,7 +176,7 @@ containing this information:
       "security": {
         "extension": [
           {
-            "url": "https://fhir-registry.smarthealthit.org/StructureDefinition/oauth-uris",
+            "url": "http://fhir-registry.smarthealthit.org/StructureDefinition/oauth-uris",
             "extension": [
               {
                 "url": "token",

--- a/content/authorization.md
+++ b/content/authorization.md
@@ -176,7 +176,7 @@ containing this information:
       "security": {
         "extension": [
           {
-            "url": "http://fhir-registry.smarthealthit.org/StructureDefinition/oauth-uris",
+            "url": "https://fhir-registry.smarthealthit.org/StructureDefinition/oauth-uris",
             "extension": [
               {
                 "url": "token",
@@ -257,7 +257,7 @@ The "resource context" represents one of three possible choices:
 - user:  Access to the resource is only constrained by the access of the user.
 - patient:  Access to the resource is constrained within context of a single patient.
 - system:  Used in system-based authorization workflows, as described in
-  ["Requesting Authorization on Behalf of a System"](#system-authorization).
+  ["Requesting Authorization on Behalf of a System"](#requesting-authorization-on-behalf-of-a-system).
 
 In certain cases, the authenticated user will be presented a choice to allow your
 application to utilize the requested scopes on the user's behalf.  As such,
@@ -306,7 +306,7 @@ limited to) the following:
 The scope 'openid' will request that Cerner's authorization server supply
 and [OpenID Connect][OPENID] identity token as part of the authorization
 workflow.  Further details on utilizing the OpenID token can be found in
-the [OpenID Connect Guide](../authorization/openid-connect).
+the [OpenID Connect Guide](/authorization/openid-connect).
 
 The scope 'fhirUser' will additionally request that the OpenID Connect
 token include the claim 'fhirUser', as defined by the
@@ -321,7 +321,7 @@ The default duration of access received through the authorization grant
 workflow is a single token that is valid for 570 seconds (~10 minutes).
 For applications that need access to services for longer durations,
 Cerner's Ignite platform supports the concept of
-["refresh tokens"](#refresh_tokens).
+["refresh tokens"](#utilizing-refresh-tokens).
 
 With 'online_access', your application can continue to obtain access
 tokens on behalf of the user until:
@@ -347,8 +347,8 @@ access tokens in perpetuity on behalf of the user until:
 
 [Wildcard Scopes](https://hl7.org/fhir/smart-app-launch/scopes-and-launch-context.html#wildcard-scopes) are currently **not supported**; refer to the linked document for a more detailed discussion of the challenges they pose. An application is currently required to specifically request each scope that it needs to run.
 
-Other combinations of scopes may be limited; please see the [FAQ](#faq) for
-known limitations.
+Other combinations of scopes may be limited; please see the
+[FAQ](#frequently-asked-questions) for known limitations.
 
 ##### State ####
 
@@ -851,35 +851,6 @@ _NOTE_: The token response from a refresh will not contain a new
 refresh token.  The original refresh token from the initial
 grant response must be retained.
 
-#### Considerations for Handling 'offline_access' ####
-
-Cerner's authorization server can be used as an authentication
-mechanism via the use of the "openid" scope.  In this scenario,
-an offline access refresh token could be stored in your
-application's service tier and associated with the user's
-OpenID Connect principal and issuer.  Upon subsequent
-access, the client application would invoke an authorization
-reuqest containing the "openid" scope to soley perform
-authentication to allow your service tier to identify the user
-and any refresh tokens your application currently possesses
-for the user.
-
-_NOTE_:  Cerner's authorization server currently does not
-support the stand-alone "openid" workflow for patients and/or
-their authorized representatives.
-
-When retrieving an access token utilizing using an
-online_access refresh, the most likely cause of failures
-is that access has been revoked.  The following steps are
-recommended for the user experience:
-
-- Indicate that the application's access may have been
-  revoked.
-- Offer a "more information" link/button, hyperlinked to
-  the value returned in the parameter "error_uri".
-- Offer the ability for the user to re-request
-  authorization for your client application.
-
 #### Considerations for Handling 'online_access' ####
 
 When retrieving an access token utilizing using an
@@ -898,6 +869,63 @@ experience:
   appropriate.
 - Offer a "more information" link/button, hyperlinked to
   the value returned in the parameter "error_uri".
+
+#### Considerations for Handling 'offline_access' ####
+
+Cerner's authorization server can be used as an authentication
+mechanism via the use of the "openid" scope.  In this scenario,
+an offline access refresh token could be stored in your
+application's service tier and associated with the user's
+OpenID Connect principal and issuer.  Upon subsequent
+access, the client application would invoke an authorization
+request containing the "openid" scope to solely perform
+authentication to allow your service tier to identify the user
+and any refresh tokens your application currently possesses
+for the user.
+
+_NOTE_:  Cerner's authorization server currently does not
+support the stand-alone "openid" workflow for patients and/or
+their authorized representatives.
+
+When retrieving an access token utilizing using an
+offline_access refresh, the most likely cause of failures
+is that access has been suspended or completely revoked.
+The following steps are recommended for the user experience:
+
+- Indicate that the application's access may have been
+  suspended or revoked.
+- Offer a "more information" link/button, hyperlinked to
+  the value returned in the parameter "error_uri".
+- Offer the ability for the user to re-request
+  authorization for your client application.
+
+_NOTE_:  The authorization server will not explicitly indicate
+whether a token was revoked or suspended.  As a result, there
+are additional recommendations to improve the overall
+interaction with the end-user.
+
+The error_uri used in the hyperlink/button should be launched
+in a separate browser window/tab.  This is recommended
+because there is no callback/redirect mechanism to get the
+user back into the application once they take an action.
+
+Additionally, the error_uri may not provide an opportunity
+for the user to re-approve the application, such as when
+the token has been fully revoked rather than just suspended.
+
+Ultimately, your application should provide a modal dialog
+to prompt the user for an action that coincides with
+their choice and/or action in the separate window.
+This should include options to retry the token refresh,
+request an entirely new authorization grant, and simply
+stop using the application (and log out if necessary).
+
+Note that the automatic suspension of a token can occur when the
+TLS or DNS information has changed since the original authorization.
+For example, if your application's TLS certificate has expired,
+then your application's refresh token will be suspended.
+See the [Application Registration Prerequisites](application-registration-prerequisites)
+for additional information about TLS and DNS requirements.
 
 ## Utilizing Authorization ##
 
@@ -940,8 +968,7 @@ their current authorizations.  Generally, such links
 are presented in conjunction with menu accessible from
 a status bar.
 
-For information on how to discover the management
-endpoint for a user, see
+For information on how to discover the management endpoint for a user, see
 [Discovery](authorization-specification#discovery) in the
 authorization specification.
 
@@ -1022,18 +1049,18 @@ The next sections discuss questions that application
 developers may pose that are not covered by the
 preceding documentation.
 
-- How can I allow users to utilize devices that do
+**How can I allow users to utilize devices that do
   not provide a browser (user agent) to facilitate
-  the authorization workflow?
+  the authorization workflow?**
 
-> Cerner currently does not have a mechanism to allow
+Cerner currently does not have a mechanism to allow
   such devices to participate in the authorization
   ecosystem.
 
-- What happens when a user revokes my application's
-  access to their data?
+**What happens when a user revokes my application's
+  access to their data?**
 
-> When a user revokes an application's access, its
+When a user revokes an application's access, its
   *refresh* tokens immediately become non-functional.
   *Access* tokens cannot be directly revoked; however,
   they are only valid for a brief period in any case
@@ -1047,60 +1074,72 @@ preceding documentation.
   ["OpenID Connect Core 1.0"](https://openid.net/specs/openid-connect-core-1_0.html)
   specification.
 
-- How can my application revoke a refresh token on
-  behalf of a user?
+**What happens if a refresh token is suspended?**
 
-> Cerner currently does not have a mechanism that allows
+When the authorization server suspends a refresh token,
+the user can re-approve the application so that a
+subsequent token refresh will succeed.  The application
+must present the "error_uri" link to the user so that they
+can launch the management application to re-approve the token.
+However, if the user does not do this, or they deny the 
+re-approval, then the token refresh will continue to fail.
+As an alternative, the application can request an entirely
+new token via a new authorization grant request.
+
+**How can my application revoke a refresh token on
+  behalf of a user?**
+
+Cerner currently does not have a mechanism that allows
   client applications to revoke refresh tokens.  If/when
   such functionality is implemented, it will follow RFC 7009
   ["OAuth 2.0 Token Revocation"](https://tools.ietf.org/html/rfc7009).
 
-- How can my application participate in log out
+**How can my application participate in log out
   mechanisms provided by the organization's single
-  sign-on (SSO) ecosystem?
+  sign-on (SSO) ecosystem?**
 
-> While the Cerner authorization server provides OpenID
+While the Cerner authorization server provides OpenID
   Connect support, it does not currently implement any
   of the draft log-out specifications currently
   proposed by the community.  Cerner continues to track
   on developments in this ecosystem.
 
-> As an alternative, you may offer the user a link to
+As an alternative, you may offer the user a link to
   "Manage Authorized Applications", which allows the user
   to log out via their SSO system.
 
-- A browser window/tab remains after the completion of the
+**A browser window/tab remains after the completion of the
   authorization workflow.  How should my application handle
-  this?
+  this?**
 
-> Depending on how the browser was launched, your application
+Depending on how the browser was launched, your application
   may not have the ability to close the browser window.
   If you launched a fresh browser window directly, you may
   be able to use Windows APIs to find and send a close
   command directly to the window.
 
-- Does the Cerner authorization server offer an
+**Does the Cerner authorization server offer an
   authentication-only workflow (via OpenID Connect) for
-  patients  and/or their authorized representatives?
+  patients  and/or their authorized representatives?**
 
-> Cerner currently does not offer this capability at this
+Cerner currently does not offer this capability at this
   time.
 
-- Can I append additional query parameters for my
+**Can I append additional query parameters for my
   redirection URI when I send my authorization grant
-  request?
+  request?**
 
-> Yes, Cerner's redirection URI validation allows for
+Yes, Cerner's redirection URI validation allows for
   additional query parameters, per the OAuth specification.
 
-> _NOTE_:  Cerner's implementation uses strict path
+_NOTE_:  Cerner's implementation uses strict path
   validation, which includes trailing slashes in your
   redirection URI.
 
-- I'm having trouble registering my redirection URI,
-  what advice can you offer?
+**I'm having trouble registering my redirection URI,
+  what advice can you offer?**
 
-> URIs must conform with RFC 2396 and must be an
+URIs must conform with RFC 2396 and must be an
   absolute URI, per that specification.  Most issues
   we encounter are individuals attempting to register
   URIs with schemes containing a net path ("//"), but
@@ -1108,46 +1147,46 @@ preceding documentation.
   "app://" is an invalid URI, but "app://callback"
   is valid.
 
-- Can I register multiple redirect URIs?
+**Can I register multiple redirect URIs?**
 
-> Cerner's operations team can register multiple
+Cerner's operations team can register multiple
   redirect URIs for your application.  This function
   is not yet exposed in our developer tooling.
 
-- My organization is a Cerner client that offers an
+**My organization is a Cerner client that offers an
   application directly to patients.  Can we skip the
-  authorization interaction with users for our app?
+  authorization interaction with users for our app?**
 
-> Yes, Cerner offers the ability for organizations
+Yes, Cerner offers the ability for organizations
   providing their own app to disable the patient-mediated
   authorization workflow when used in context with their
   organization.
 
-- How can I embed my SMART<sup>®</sup> on FHIR<sup>®</sup>
+**How can I embed my SMART<sup>®</sup> on FHIR<sup>®</sup>
   application in another application, such as inside of a web
   view or iframe and still orchestrate the authorization
-  workflow?
+  workflow?**
 
-> A general-purpose framework for embedding SMART<sup>®</sup>
+A general-purpose framework for embedding SMART<sup>®</sup>
   on FHIR<sup>®</sup> applications does not currently exist.
 
-- One or more offline access tokens stored by my application
+**One or more offline access tokens stored by my application
   may have been compromised.  What action should I take to
-  prevent their usage?
+  prevent their usage?**
 
-> Disable or rotate your system account via Cerner Central as
+Disable or rotate your system account via Cerner Central as
   soon as possible via
   [Cerner Central System Account Management][SYSTEM-ACCOUNTS].  
 
-- Is offline_access supported for healthcare providers?
+**Is offline_access supported for healthcare providers?**
 
-> Cerner does not currently have support for offline_access
+Cerner does not currently have support for offline_access
   for providers.  It is currently under consideration.
 
-- How can I deliver my solution to users utilizing its own
-  Citrix instance with XenApp?
+**How can I deliver my solution to users utilizing its own
+  Citrix instance with XenApp?**
 
-> Cerner currently does not have guidance on how to deliver
+Cerner currently does not have guidance on how to deliver
   native applications running within their own dedicated
   Citrix container.  Such applications would generally
   interact with the authorization server from a browser

--- a/content/authorization.md
+++ b/content/authorization.md
@@ -767,7 +767,7 @@ token request:
 </pre>
 
 In either circumstance, Cerner's authorization server communicates
-the parameter "error_uri", which represents a URI that contains
+the parameter `error_uri`, which represents a URI that contains
 additional information useful for end users, client app developers,
 and support personnel, along with support contact information
 for the associated organization.  It is recommended when such
@@ -868,7 +868,7 @@ experience:
   (initiate the authorization grant workflow again) as
   appropriate.
 - Offer a "more information" link/button, hyperlinked to
-  the value returned in the parameter "error_uri".
+  the value returned in the parameter `error_uri`.
 
 #### Considerations for Handling 'offline_access' ####
 
@@ -895,25 +895,23 @@ The following steps are recommended for the user experience:
 - Indicate that the application's access may have been
   suspended or revoked.
 - Offer a "more information" link/button, hyperlinked to
-  the value returned in the parameter "error_uri".
+  the value returned in the parameter `error_uri`.
 - Offer the ability for the user to re-request
   authorization for your client application.
 
 _NOTE_:  The authorization server will not explicitly indicate
 whether a token was revoked or suspended.  As a result, there
 are additional recommendations to improve the overall
-interaction with the end-user.
+interaction with the end-user as described below.
 
-The error_uri used in the hyperlink/button should be launched
+The `error_uri` used in the hyperlink/button should be launched
 in a separate browser window/tab.  This is recommended
 because there is no callback/redirect mechanism to get the
-user back into the application once they take an action.
+user back into the application once they take an action
+and the `error_uri` will only provide an opportunity for the
+user to re-approve the application if it was temporarily suspended.
 
-Additionally, the error_uri may not provide an opportunity
-for the user to re-approve the application, such as when
-the token has been fully revoked rather than just suspended.
-
-Ultimately, your application should provide a modal dialog
+Additionally, your application should provide a modal dialog
 to prompt the user for an action that coincides with
 their choice and/or action in the separate window.
 This should include options to retry the token refresh,
@@ -1079,7 +1077,7 @@ When a user revokes an application's access, its
 When the authorization server suspends a refresh token,
 the user can re-approve the application so that a
 subsequent token refresh will succeed.  The application
-must present the "error_uri" link to the user so that they
+must present the `error_uri` link to the user so that they
 can launch the management application to re-approve the token.
 However, if the user does not do this, or they deny the 
 re-approval, then the token refresh will continue to fail.


### PR DESCRIPTION
Description
----

With the new auto-suspension capabilities in the authorization server that are based on evaluations of external application DNS TXT records and TLS certificates, the documentation needed to be updated to provide more detailed instructions on how to get refresh tokens re-approved by the end user.

PR Checklist
----
- [x] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.
