### PR TITLE
Loading indicator suggestion

### DIFF
--- a/content/smart.md
+++ b/content/smart.md
@@ -74,7 +74,7 @@ The recommended screen resolution varies based on the available screen's real es
 ### Loading indicator ###
 For a better user experience we encourage the use of a loading overlay or a status indicator of progress inside your SMART apps.
 
-The loading overlay we use inside **Powerchart** for SMART apps is the one found amongst the [Terra UI components](https://engineering.cerner.com/terra-ui/application/terra-application/how-to/show-loading-overlays). You might want to use this one if you're building
+The loading overlay we recommend for SMART apps is the one found among the [Terra UI components](https://engineering.cerner.com/terra-ui/components/cerner-terra-core-docs/overlay/about). You might want to use this one if you're building
 your SMART app with React and have not yet decided on a loading indicator style.
 
 ### Browser Requirement ###

--- a/content/smart.md
+++ b/content/smart.md
@@ -71,6 +71,12 @@ If you are building your SMART app using the [React](https://reactjs.org/) JavaS
 
 The recommended screen resolution varies based on the available screen's real estate. Instead of targeting a specific resolution, the app should be designed to be responsive, and the app should adjust according to the available screen sizes.
 
+### Loading indicator ###
+For a better user experience we encourage the use of a loading overlay or a status indicator of progress inside your SMART apps.
+
+The loading overlay we use inside **Powerchart** for SMART apps is the one found amongst the [Terra UI components](https://engineering.cerner.com/terra-ui/application/terra-application/how-to/show-loading-overlays). You might want to use this one if you're building
+your SMART app with React and have not yet decided on a loading indicator style.
+
 ### Browser Requirement ###
 
 For provider-facing apps running from within the Cerner Millennium EHR, the only embedded browser we currently support is Internet Explorer (IE). The embedded browser control we use is [IWebBrowser2 C++ interface](https://msdn.microsoft.com/en-us/library/aa752127(v=vs.85).aspx) by Microsoft. The minimum version of IE we support is IE10. The latest supported browser varies based on the version of the browser that is currently installed at each Cerner client site. Although it is no longer supported by Microsoft, many of our clients still use IE10, especially clients who host their own system. We highly suggest that you code your app for IE10 for validation. If you must use IE11 for your app, please note that you may struggle if you plan on deploying across our entire client base.


### PR DESCRIPTION
As an engineer: I want to include a section on UI/UX recommendation relating to having a loading indicator / spinner in the current documentation @ https://fhir.cerner.com/smart
So that: the developers would consider the suggestion and build their app to include a loading indicator/spinner when the app loads and fetch any data from FHIR to give the users a better user's experience and indication of progress
