### PR TITLE
Updated DM Profile Links for health-cards API

### DIFF
--- a/content/millennium/r4/foundation/other/health-cards.md
+++ b/content/millennium/r4/foundation/other/health-cards.md
@@ -43,11 +43,11 @@ Represents the patient and the clinical data related to a vaccination
 
 Contains the following resources:
 
-* A single Patient resource that follows the [VaccinationCredentialPatientDM](http://build.fhir.org/ig/dvci/vaccine-credential-ig/branches/main/StructureDefinition-vaccination-credential-patient-dm.html#tab-ms) profile with the following fields, if valued:
+* A single Patient resource that follows the [VaccinationCredentialPatientDM](https://build.fhir.org/ig/HL7/fhir-shc-vaccination-ig/StructureDefinition-shc-patient-us-resource-examples.html) profile with the following fields, if valued:
   * [Patient official name](http://build.fhir.org/ig/dvci/vaccine-credential-ig/branches/main/StructureDefinition-vaccination-credential-patient-definitions.html#Patient.name){:target="_blank"}
   * [Date of Birth](http://build.fhir.org/ig/dvci/vaccine-credential-ig/branches/main/StructureDefinition-vaccination-credential-patient-definitions.html#Patient.birthDate){:target="_blank"}
 
-* One or more Immunization resources that follow the [VaccinationCredentialImmunizationDM](http://build.fhir.org/ig/dvci/vaccine-credential-ig/branches/main/StructureDefinition-vaccination-credential-immunization-dm.html) profile with the following fields, if valued:
+* One or more Immunization resources that follow the [VaccinationCredentialImmunizationDM](https://build.fhir.org/ig/HL7/fhir-shc-vaccination-ig/StructureDefinition-shc-vaccination-dm.html) profile with the following fields, if valued:
   * [Status](http://build.fhir.org/ig/dvci/vaccine-credential-ig/branches/main/StructureDefinition-vaccination-credential-immunization-definitions.html#Immunization.status){:target="_blank"}
   * [Vaccine administered](http://build.fhir.org/ig/dvci/vaccine-credential-ig/branches/main/StructureDefinition-vaccination-credential-immunization-definitions.html#Immunization.vaccineCode){:target="_blank"}
   * [Patient](http://build.fhir.org/ig/dvci/vaccine-credential-ig/branches/main/StructureDefinition-vaccination-credential-immunization-definitions.html#Immunization.patient){:target="_blank"}
@@ -70,11 +70,11 @@ Represents the patient and the clinical data related to a laboratory test result
 
 Contains the following resources:
 
-* A single Patient resource that follows the [VaccinationCredentialPatientDM](http://build.fhir.org/ig/dvci/vaccine-credential-ig/branches/main/StructureDefinition-vaccination-credential-patient-dm.html#tab-ms) profile with the following fields, if valued:
+* A single Patient resource that follows the [VaccinationCredentialPatientDM](https://build.fhir.org/ig/HL7/fhir-shc-vaccination-ig/StructureDefinition-shc-patient-us-resource-examples.html) profile with the following fields, if valued:
   * [Patient official name](http://build.fhir.org/ig/dvci/vaccine-credential-ig/branches/main/StructureDefinition-vaccination-credential-patient-definitions.html#Patient.name){:target="_blank"}
   * [Date of Birth](http://build.fhir.org/ig/dvci/vaccine-credential-ig/branches/main/StructureDefinition-vaccination-credential-patient-definitions.html#Patient.birthDate){:target="_blank"}
 
-* One or more Observation resources that follow the [InfectiousDiseaseLaboratoryResultObservationDM](http://build.fhir.org/ig/dvci/vaccine-credential-ig/branches/main/StructureDefinition-infectious-disease-laboratory-result-observation-dm.html) profile with the following fields, if valued:
+* One or more Observation resources that follow the [InfectiousDiseaseLaboratoryResultObservationDM](https://build.fhir.org/ig/HL7/fhir-shc-vaccination-ig/StructureDefinition-shc-infectious-disease-laboratory-result-observation-resource-examples.html) profile with the following fields, if valued:
   * [Status](http://build.fhir.org/ig/dvci/vaccine-credential-ig/branches/main/StructureDefinition-infectious-disease-laboratory-result-observation-definitions.html#Observation.status){:target="_blank"}
   * [Code](http://build.fhir.org/ig/dvci/vaccine-credential-ig/branches/main/StructureDefinition-infectious-disease-laboratory-result-observation-definitions.html#Observation.code){:target="_blank"}
   * [Subject](http://build.fhir.org/ig/dvci/vaccine-credential-ig/branches/main/StructureDefinition-infectious-disease-laboratory-result-observation-definitions.html#Observation.subject){:target="_blank"}

--- a/content/millennium/r4/foundation/other/health-cards.md
+++ b/content/millennium/r4/foundation/other/health-cards.md
@@ -43,11 +43,11 @@ Represents the patient and the clinical data related to a vaccination
 
 Contains the following resources:
 
-* A single Patient resource that follows the [VaccinationCredentialPatientDM](http://hl7.org/fhir/uv/shc-vaccination/2021Sep/) profile with the following fields, if valued:
+* A single Patient resource that follows the [VaccinationCredentialPatientDM](http://hl7.org/fhir/uv/shc-vaccination/2021Sep/StructureDefinition-shc-patient-general-dm.html) profile with the following fields, if valued:
   * [Patient official name](http://build.fhir.org/ig/dvci/vaccine-credential-ig/branches/main/StructureDefinition-vaccination-credential-patient-definitions.html#Patient.name){:target="_blank"}
   * [Date of Birth](http://build.fhir.org/ig/dvci/vaccine-credential-ig/branches/main/StructureDefinition-vaccination-credential-patient-definitions.html#Patient.birthDate){:target="_blank"}
 
-* One or more Immunization resources that follow the [VaccinationCredentialImmunizationDM](http://hl7.org/fhir/uv/shc-vaccination/2021Sep/) profile with the following fields, if valued:
+* One or more Immunization resources that follow the [VaccinationCredentialImmunizationDM](http://hl7.org/fhir/uv/shc-vaccination/2021Sep/StructureDefinition-shc-vaccination-dm.html) profile with the following fields, if valued:
   * [Status](http://build.fhir.org/ig/dvci/vaccine-credential-ig/branches/main/StructureDefinition-vaccination-credential-immunization-definitions.html#Immunization.status){:target="_blank"}
   * [Vaccine administered](http://build.fhir.org/ig/dvci/vaccine-credential-ig/branches/main/StructureDefinition-vaccination-credential-immunization-definitions.html#Immunization.vaccineCode){:target="_blank"}
   * [Patient](http://build.fhir.org/ig/dvci/vaccine-credential-ig/branches/main/StructureDefinition-vaccination-credential-immunization-definitions.html#Immunization.patient){:target="_blank"}
@@ -70,11 +70,11 @@ Represents the patient and the clinical data related to a laboratory test result
 
 Contains the following resources:
 
-* A single Patient resource that follows the [VaccinationCredentialPatientDM](http://hl7.org/fhir/uv/shc-vaccination/2021Sep/) profile with the following fields, if valued:
+* A single Patient resource that follows the [VaccinationCredentialPatientDM](http://hl7.org/fhir/uv/shc-vaccination/2021Sep/StructureDefinition-shc-patient-general-dm.html) profile with the following fields, if valued:
   * [Patient official name](http://build.fhir.org/ig/dvci/vaccine-credential-ig/branches/main/StructureDefinition-vaccination-credential-patient-definitions.html#Patient.name){:target="_blank"}
   * [Date of Birth](http://build.fhir.org/ig/dvci/vaccine-credential-ig/branches/main/StructureDefinition-vaccination-credential-patient-definitions.html#Patient.birthDate){:target="_blank"}
 
-* One or more Observation resources that follow the [InfectiousDiseaseLaboratoryResultObservationDM](http://hl7.org/fhir/uv/shc-vaccination/2021Sep/) profile with the following fields, if valued:
+* One or more Observation resources that follow the [InfectiousDiseaseLaboratoryResultObservationDM](http://hl7.org/fhir/uv/shc-vaccination/2021Sep/StructureDefinition-shc-infectious-disease-laboratory-result-observation-dm.html) profile with the following fields, if valued:
   * [Status](http://build.fhir.org/ig/dvci/vaccine-credential-ig/branches/main/StructureDefinition-infectious-disease-laboratory-result-observation-definitions.html#Observation.status){:target="_blank"}
   * [Code](http://build.fhir.org/ig/dvci/vaccine-credential-ig/branches/main/StructureDefinition-infectious-disease-laboratory-result-observation-definitions.html#Observation.code){:target="_blank"}
   * [Subject](http://build.fhir.org/ig/dvci/vaccine-credential-ig/branches/main/StructureDefinition-infectious-disease-laboratory-result-observation-definitions.html#Observation.subject){:target="_blank"}

--- a/content/millennium/r4/foundation/other/health-cards.md
+++ b/content/millennium/r4/foundation/other/health-cards.md
@@ -43,11 +43,11 @@ Represents the patient and the clinical data related to a vaccination
 
 Contains the following resources:
 
-* A single Patient resource that follows the [VaccinationCredentialPatientDM](https://build.fhir.org/ig/HL7/fhir-shc-vaccination-ig/StructureDefinition-shc-patient-us-resource-examples.html) profile with the following fields, if valued:
+* A single Patient resource that follows the [VaccinationCredentialPatientDM](http://hl7.org/fhir/uv/shc-vaccination/2021Sep/) profile with the following fields, if valued:
   * [Patient official name](http://build.fhir.org/ig/dvci/vaccine-credential-ig/branches/main/StructureDefinition-vaccination-credential-patient-definitions.html#Patient.name){:target="_blank"}
   * [Date of Birth](http://build.fhir.org/ig/dvci/vaccine-credential-ig/branches/main/StructureDefinition-vaccination-credential-patient-definitions.html#Patient.birthDate){:target="_blank"}
 
-* One or more Immunization resources that follow the [VaccinationCredentialImmunizationDM](https://build.fhir.org/ig/HL7/fhir-shc-vaccination-ig/StructureDefinition-shc-vaccination-dm.html) profile with the following fields, if valued:
+* One or more Immunization resources that follow the [VaccinationCredentialImmunizationDM](http://hl7.org/fhir/uv/shc-vaccination/2021Sep/) profile with the following fields, if valued:
   * [Status](http://build.fhir.org/ig/dvci/vaccine-credential-ig/branches/main/StructureDefinition-vaccination-credential-immunization-definitions.html#Immunization.status){:target="_blank"}
   * [Vaccine administered](http://build.fhir.org/ig/dvci/vaccine-credential-ig/branches/main/StructureDefinition-vaccination-credential-immunization-definitions.html#Immunization.vaccineCode){:target="_blank"}
   * [Patient](http://build.fhir.org/ig/dvci/vaccine-credential-ig/branches/main/StructureDefinition-vaccination-credential-immunization-definitions.html#Immunization.patient){:target="_blank"}
@@ -70,11 +70,11 @@ Represents the patient and the clinical data related to a laboratory test result
 
 Contains the following resources:
 
-* A single Patient resource that follows the [VaccinationCredentialPatientDM](https://build.fhir.org/ig/HL7/fhir-shc-vaccination-ig/StructureDefinition-shc-patient-us-resource-examples.html) profile with the following fields, if valued:
+* A single Patient resource that follows the [VaccinationCredentialPatientDM](http://hl7.org/fhir/uv/shc-vaccination/2021Sep/) profile with the following fields, if valued:
   * [Patient official name](http://build.fhir.org/ig/dvci/vaccine-credential-ig/branches/main/StructureDefinition-vaccination-credential-patient-definitions.html#Patient.name){:target="_blank"}
   * [Date of Birth](http://build.fhir.org/ig/dvci/vaccine-credential-ig/branches/main/StructureDefinition-vaccination-credential-patient-definitions.html#Patient.birthDate){:target="_blank"}
 
-* One or more Observation resources that follow the [InfectiousDiseaseLaboratoryResultObservationDM](https://build.fhir.org/ig/HL7/fhir-shc-vaccination-ig/StructureDefinition-shc-infectious-disease-laboratory-result-observation-resource-examples.html) profile with the following fields, if valued:
+* One or more Observation resources that follow the [InfectiousDiseaseLaboratoryResultObservationDM](http://hl7.org/fhir/uv/shc-vaccination/2021Sep/) profile with the following fields, if valued:
   * [Status](http://build.fhir.org/ig/dvci/vaccine-credential-ig/branches/main/StructureDefinition-infectious-disease-laboratory-result-observation-definitions.html#Observation.status){:target="_blank"}
   * [Code](http://build.fhir.org/ig/dvci/vaccine-credential-ig/branches/main/StructureDefinition-infectious-disease-laboratory-result-observation-definitions.html#Observation.code){:target="_blank"}
   * [Subject](http://build.fhir.org/ig/dvci/vaccine-credential-ig/branches/main/StructureDefinition-infectious-disease-laboratory-result-observation-definitions.html#Observation.subject){:target="_blank"}


### PR DESCRIPTION
Description
Update broken links (DM Profiles) on fhir.cerner.com in the health-cards section 

PR Checklist

Health Cards documentation page with links to broken pages (e.g. VaccinationCredentialPatientDM)

<img width="893" alt="Screen Shot 2022-08-16 at 11 03 51" src="https://user-images.githubusercontent.com/36455545/184829546-1a0006c8-ef22-4e2d-a87f-2a0eb2b24a29.png">

The 404 page displayed for VaccinationCredentialPatientDM broken link :

<img width="938" alt="Screen Shot 2022-08-16 at 11 05 41" src="https://user-images.githubusercontent.com/36455545/184829787-6a4e66a7-6ae0-4792-bd46-df54bda22b32.png">

----
- [x] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.
