### PR TITLE
Remove Group from resouces table and fix health cards link

### DIFF
--- a/content/millennium/r4/base/individuals/patient.md
+++ b/content/millennium/r4/base/individuals/patient.md
@@ -323,4 +323,4 @@ See [Health Cards] documentation for more details about this operation.
 [US Core Ethnicity]: https://hl7.org/fhir/us/core/StructureDefinition-us-core-ethnicity.html
 [US Core Birth Sex]: https://hl7.org/fhir/us/core/StructureDefinition-us-core-birthsex.html
 [Communication Preference]: https://fhir-ehr.cerner.com/r4/StructureDefinition/communication-preference?_format=json
-[Health Cards]: /millennium/r4/other/health-cards/
+[Health Cards]: /millennium/r4/foundation/other/health-cards/

--- a/static/js/millennium_diff_table.js
+++ b/static/js/millennium_diff_table.js
@@ -125,7 +125,7 @@ function matchDstu2Resources(dstu2Resources, r4Resources) {
   for (let i = 0; i < dstu2Resources.length; i++) {
     let currentResource = dstu2Resources[i];
 
-    if (currentResource != null) {
+    if (currentResource != null && !config.resourceConfig.ignoredResources.includes(currentResource.type)) {
       let config = getConfiguration(currentResource.type);
       let match = null;
 
@@ -155,7 +155,7 @@ function getUnmatchedResources(r4Resources) {
   for (let i = 0; i < r4Resources.length; i++) {
     let currentResource = r4Resources[i];
 
-    if (currentResource != null) {
+    if (currentResource != null && !config.resourceConfig.ignoredResources.includes(currentResource.type)) {
       let config = getConfiguration(currentResource.type)
 
       if (config != null) {

--- a/static/js/millennium_diff_table.js
+++ b/static/js/millennium_diff_table.js
@@ -28,15 +28,20 @@ function getConfiguration(resourceName) {
 function buildResource(resourceObject) {
   let supportedActions = resourceObject.interaction;
 
-  return {
-    resourceName: resourceObject.type,
-    readSupported: supportedActions.filter(action => action.code == "read").length > 0,
-    searchSupported: supportedActions.filter(action => action.code == "search-type").length > 0,
-    createSupported: supportedActions.filter(action => action.code == "create").length > 0,
-    updateSupported: supportedActions.filter(action => action.code == "update").length > 0,
-    patchSupported: supportedActions.filter(action => action.code == "patch").length > 0,
-    deleteSupported: supportedActions.filter(action => action.code == "delete").length > 0
-  };
+  if (supportedActions != null) {
+    return {
+      resourceName: resourceObject.type,
+      readSupported: supportedActions.filter(action => action.code == "read").length > 0,
+      searchSupported: supportedActions.filter(action => action.code == "search-type").length > 0,
+      createSupported: supportedActions.filter(action => action.code == "create").length > 0,
+      updateSupported: supportedActions.filter(action => action.code == "update").length > 0,
+      patchSupported: supportedActions.filter(action => action.code == "patch").length > 0,
+      deleteSupported: supportedActions.filter(action => action.code == "delete").length > 0
+    }
+  }
+  else {
+    return { resourceName: resourceObject.type }
+  }
 }
 
 /**

--- a/static/js/millennium_diff_table_config.js
+++ b/static/js/millennium_diff_table_config.js
@@ -32,13 +32,14 @@ const config = {
       {
         type: "FinancialTransaction",
         interaction: [
-          {
-            code: "create"
-          }
-      ],
-      notes: "FinancialTransaction is a custom resource implemented via extensions on the Basic resource."
+            {
+              code: "create"
+            }
+        ],
+        notes: "FinancialTransaction is a custom resource implemented via extensions on the Basic resource."
       }
-    ]
+    ],
+    ignoredResources: [ "Group" ]
   },
   dstu2: {
     metadataUrl: "https://fhir-ehr-code.cerner.com/dstu2/ec2458f2-1e24-41c8-b71b-0e701af7583d/metadata",


### PR DESCRIPTION
Description
----
Remove the Group resource from the Millennium Resources Table.
Fix Health Cards link in Patient resource documentation.

Dev Validation
----
<img width="533" alt="Screen Shot 2022-09-21 at 2 52 12 PM" src="https://user-images.githubusercontent.com/18171913/191598112-20a8f1b7-e5f8-4df6-ac3c-87f6ca9b50e5.png">
<img width="379" alt="Screen Shot 2022-09-21 at 2 52 35 PM" src="https://user-images.githubusercontent.com/18171913/191598127-ff3788a5-9413-4896-aeb5-050ca8cbfe96.png">

PR Checklist
----
- [x] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.
