### PR TITLE
Remove out-of-date documentation re: revocation

### DIFF
--- a/content/authorization.md
+++ b/content/authorization.md
@@ -1099,7 +1099,7 @@ new token via a new authorization grant request.
   
 The location of an RFC 7009 token revocation endpoint is
 advertised at /.well-known/smart-configuration; see
-["CapabilityStatement"](/millennium/r4/foundation/conformance/capability-statement/#well-known-smart-configuration)
+[CapabilityStatement](/millennium/r4/foundation/conformance/capability-statement/#well-known-smart-configuration)
 for further details.
 
 **How can my application participate in log out

--- a/content/authorization.md
+++ b/content/authorization.md
@@ -1094,14 +1094,6 @@ re-approval, then the token refresh will continue to fail.
 As an alternative, the application can request an entirely
 new token via a new authorization grant request.
 
-**How can my application revoke a refresh token on
-  behalf of a user?**
-
-Cerner currently does not have a mechanism that allows
-  client applications to revoke refresh tokens.  If/when
-  such functionality is implemented, it will follow RFC 7009
-  ["OAuth 2.0 Token Revocation"](https://tools.ietf.org/html/rfc7009).
-
 **How can my application participate in log out
   mechanisms provided by the organization's single
   sign-on (SSO) ecosystem?**

--- a/content/authorization.md
+++ b/content/authorization.md
@@ -1094,6 +1094,14 @@ re-approval, then the token refresh will continue to fail.
 As an alternative, the application can request an entirely
 new token via a new authorization grant request.
 
+**How can my application revoke a refresh token on
+  behalf of a user?**
+  
+The location of an RFC 7009 token revocation endpoint is
+advertised at /.well-known/smart-configuration; see
+["CapabilityStatement"](/millennium/r4/foundation/conformance/capability-statement/#well-known-smart-configuration)
+for further details.
+
 **How can my application participate in log out
   mechanisms provided by the organization's single
   sign-on (SSO) ecosystem?**


### PR DESCRIPTION
Description
----
As part of the work for the 21st Century Cures Act, we now _do_ advertise a RFC 7009 endpoint at /.well-known/smart-configuration, making this documentation out-of-date and misleading. See also: http://fhir.cerner.com/millennium/r4/foundation/conformance/capability-statement/#example

PR Checklist
----
- [x] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.

<img width="976" alt="Screen Shot 2022-10-27 at 3 35 20 PM" src="https://user-images.githubusercontent.com/467773/198392691-253f1170-7584-4792-8fb8-023b9f0187c6.png">