### PR TITLE
patient-r4-dstu2-search-notes-update

### DIFF
--- a/content/millennium/dstu2/individuals/patient.md
+++ b/content/millennium/dstu2/individuals/patient.md
@@ -77,6 +77,7 @@ Notes:
 * Either the `_id`, or a combination of `identifier` , `birthdate`, `name`, `given`, `family`, `address-postalcode`, `phone`, or `email` parameters must be provided.
 * The `gender` parameter may only be provided if at least one of `identifier` , `birthdate`, `name`, `given`, `family`, `address-postalcode`, `phone`, or `email` parameters is provided.
 * The `name`, `family`, and `given` parameters support the ':exact' modifier and will search for current names only.
+* It is recommended that when searching for a patient to not combine `family`, or `family` and `given`, with `name` key, and use the ':exact' modifier when possible.
 * The `address-postalcode` parameter supports the `:exact` modifer.
 * The `identifier`, `name`, `family`, `given`, `phone`, `email`, `address-postalcode`, or `gender` parameters may be provided exactly once and may have only a single value.
 * The `birthdate` parameter may be provided twice to indicate a date range, but must contain the inclusive prefixes 'le' and 'ge'

--- a/content/millennium/dstu2/individuals/patient.md
+++ b/content/millennium/dstu2/individuals/patient.md
@@ -77,7 +77,7 @@ Notes:
 * Either the `_id`, or a combination of `identifier` , `birthdate`, `name`, `given`, `family`, `address-postalcode`, `phone`, or `email` parameters must be provided.
 * The `gender` parameter may only be provided if at least one of `identifier` , `birthdate`, `name`, `given`, `family`, `address-postalcode`, `phone`, or `email` parameters is provided.
 * The `name`, `family`, and `given` parameters support the ':exact' modifier and will search for current names only.
-* It is recommended that when searching for a patient to not combine `family`, or `family` and `given`, with `name` key, and use the ':exact' modifier when possible.
+* It is not recommended to combine `family` or `given` parameters with `name` parameter when searching for a patient. Whenever possible use the ':exact' modifier.
 * The `address-postalcode` parameter supports the `:exact` modifer.
 * The `identifier`, `name`, `family`, `given`, `phone`, `email`, `address-postalcode`, or `gender` parameters may be provided exactly once and may have only a single value.
 * The `birthdate` parameter may be provided twice to indicate a date range, but must contain the inclusive prefixes 'le' and 'ge'

--- a/content/millennium/r4/base/individuals/patient.md
+++ b/content/millennium/r4/base/individuals/patient.md
@@ -88,6 +88,7 @@ Notes:
 * Either the `_id`, or a combination of `identifier` , `birthdate`, `name`, `given`, `family`, `address-postalcode`, `phone`, or `email` parameters must be provided.
 * The `gender` parameter may only be provided if at least one of `identifier` , `birthdate`, `name`, `given`, `family`, `address-postalcode`, `phone`, or `email` parameters is provided.
 * The `name`, `family`, and `given` parameters support the ':exact' modifier and will search for current names only.
+* It is recommended that when searching for a patient to not combine `family`, or `family` and `given`, with `name` key, and use the ':exact' modifier when possible.
 * The `identifier`, `name`, `family`, `given`, `phone`, `email`, `address-postalcode`, or `gender` parameters may be provided exactly once and may have only a single value.
 * The `birthdate` parameter
   * May be provided twice using the prefixes `le` and `ge` to indicate a date range

--- a/content/millennium/r4/base/individuals/patient.md
+++ b/content/millennium/r4/base/individuals/patient.md
@@ -88,7 +88,7 @@ Notes:
 * Either the `_id`, or a combination of `identifier` , `birthdate`, `name`, `given`, `family`, `address-postalcode`, `phone`, or `email` parameters must be provided.
 * The `gender` parameter may only be provided if at least one of `identifier` , `birthdate`, `name`, `given`, `family`, `address-postalcode`, `phone`, or `email` parameters is provided.
 * The `name`, `family`, and `given` parameters support the ':exact' modifier and will search for current names only.
-* It is recommended that when searching for a patient to not combine `family`, or `family` and `given`, with `name` key, and use the ':exact' modifier when possible.
+* It is not recommended to combine `family` or `given` parameters with `name` parameter when searching for a patient. Whenever possible use the ':exact' modifier.
 * The `identifier`, `name`, `family`, `given`, `phone`, `email`, `address-postalcode`, or `gender` parameters may be provided exactly once and may have only a single value.
 * The `birthdate` parameter
   * May be provided twice using the prefixes `le` and `ge` to indicate a date range


### PR DESCRIPTION
added a new note to the Notes section in patient search for both R4 and DSTU2 the new line is:
* It is recommended that when searching for a patient to not combine `family`, or `family` and `given`, with `name` key, and use the ':exact' modifier when possible.

Description
----

PR Checklist
----
- [x] Screenshot(s) of changes attached before changes merged.
- [x] Screenshot(s) of changes attached after changes merged and published.
