### PR TITLE
R4 observation updated constraints of the _count parameter

### DIFF
--- a/content/millennium/r4/clinical/diagnostics/observation.md
+++ b/content/millennium/r4/clinical/diagnostics/observation.md
@@ -102,7 +102,7 @@ _Implementation Notes_
  | `date`         | N                 | [`date`]      | Date range into which the observation falls. Example: `date=gt2014-09-24` or `date=lt2015-09-24T12:00:00.000Z`                          |
  | `_lastUpdated` | N                 | [`date`]      | Date range in which the observation was last updated. Example: `_lastUpdated=gt2014-09-24` or `_lastUpdated=lt2015-09-24T12:00:00.000Z` |
  | `category`     | N                 | [`token`]     | The category of observations. Example: `category=laboratory`                                                                            |
- | [`_count`]     | N                 | [`number`]    | The maximum number of results to return per page. Defaults to 50.                                                                                      |
+ | [`_count`]     | N                 | [`number`]    | The maximum number of results to return per page. Defaults to 50 and maximum 200 results can return                                         |
  | `_revinclude`  | No                | [`token`]     | Provenance resource entries to be returned as part of the bundle. Example:_revinclude=Provenance:target                                 |
 
 

--- a/content/millennium/r4/clinical/diagnostics/observation.md
+++ b/content/millennium/r4/clinical/diagnostics/observation.md
@@ -102,7 +102,7 @@ _Implementation Notes_
  | `date`         | N                 | [`date`]      | Date range into which the observation falls. Example: `date=gt2014-09-24` or `date=lt2015-09-24T12:00:00.000Z`                          |
  | `_lastUpdated` | N                 | [`date`]      | Date range in which the observation was last updated. Example: `_lastUpdated=gt2014-09-24` or `_lastUpdated=lt2015-09-24T12:00:00.000Z` |
  | `category`     | N                 | [`token`]     | The category of observations. Example: `category=laboratory`                                                                            |
- | [`_count`]     | N                 | [`number`]    | The maximum number of results to return per page. Defaults to 50 and maximum 200 results can return                                         |
+ | [`_count`]     | N                 | [`number`]    | The maximum number of results to return per page. Defaults to 50 and maximum 200 observations can be returned                                        |
  | `_revinclude`  | No                | [`token`]     | Provenance resource entries to be returned as part of the bundle. Example:_revinclude=Provenance:target                                 |
 
 

--- a/content/millennium/r4/clinical/diagnostics/observation.md
+++ b/content/millennium/r4/clinical/diagnostics/observation.md
@@ -102,7 +102,7 @@ _Implementation Notes_
  | `date`         | N                 | [`date`]      | Date range into which the observation falls. Example: `date=gt2014-09-24` or `date=lt2015-09-24T12:00:00.000Z`                          |
  | `_lastUpdated` | N                 | [`date`]      | Date range in which the observation was last updated. Example: `_lastUpdated=gt2014-09-24` or `_lastUpdated=lt2015-09-24T12:00:00.000Z` |
  | `category`     | N                 | [`token`]     | The category of observations. Example: `category=laboratory`                                                                            |
- | [`_count`]     | N                 | [`number`]    | The maximum number of results to return per page.                                                                                       |
+ | [`_count`]     | N                 | [`number`]    | The maximum number of results to return per page. Defaults to 50.                                                                                      |
  | `_revinclude`  | No                | [`token`]     | Provenance resource entries to be returned as part of the bundle. Example:_revinclude=Provenance:target                                 |
 
 
@@ -126,6 +126,7 @@ Notes:
 
 * When `_count` parameter is provided,
   * it won’t affect the first page, because all social history data will appear in the first page regardless of requested count.
+  * Maximal supported count = 200.
   * Second page onward, returned item count may be less than requested.
 
 * The `_revinclude` parameter may be provided once with the value `Provenance:target`. Example: `_revinclude=Provenance:target`

--- a/content/millennium/r4/clinical/diagnostics/observation.md
+++ b/content/millennium/r4/clinical/diagnostics/observation.md
@@ -126,7 +126,7 @@ Notes:
 
 * When `_count` parameter is provided,
   * it won’t affect the first page, because all social history data will appear in the first page regardless of requested count.
-  * Maximal supported count = 200.
+  * Maximum supported count = 200.
   * Second page onward, returned item count may be less than requested.
 
 * The `_revinclude` parameter may be provided once with the value `Provenance:target`. Example: `_revinclude=Provenance:target`


### PR DESCRIPTION
Description
----
Updated constraints of r4_observation _count parameter
<img width="783" alt="Screenshot 2022-12-13 at 13 41 08" src="https://user-images.githubusercontent.com/120368297/207308909-3392cbf9-703f-43a2-82ab-3c65c22dcc4f.png">
<img width="754" alt="Screenshot 2022-12-13 at 13 41 35" src="https://user-images.githubusercontent.com/120368297/207308926-3b88e19d-298a-4f83-bba5-93e1dcb8cfbb.png">
<img width="739" alt="Screenshot 2022-12-13 at 13 08 58" src="https://user-images.githubusercontent.com/120368297/207302621-5692dbd9-1325-469c-942e-bae511d5886d.png">

PR Checklist
----
- [x] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.
