### PR TITLE
R4 observation count update

### DIFF
--- a/content/millennium/r4/clinical/diagnostics/observation.md
+++ b/content/millennium/r4/clinical/diagnostics/observation.md
@@ -102,7 +102,7 @@ _Implementation Notes_
  | `date`         | N                 | [`date`]      | Date range into which the observation falls. Example: `date=gt2014-09-24` or `date=lt2015-09-24T12:00:00.000Z`                          |
  | `_lastUpdated` | N                 | [`date`]      | Date range in which the observation was last updated. Example: `_lastUpdated=gt2014-09-24` or `_lastUpdated=lt2015-09-24T12:00:00.000Z` |
  | `category`     | N                 | [`token`]     | The category of observations. Example: `category=laboratory`                                                                            |
- | [`_count`]     | N                 | [`number`]    | The maximum number of results to return per page. Defaults to 50.                                                                                      |
+ | [`_count`]     | N                 | [`number`]    | The maximum number of results to return per page. Defaults to 50 and maximum 200 results can return                                         |
  | `_revinclude`  | No                | [`token`]     | Provenance resource entries to be returned as part of the bundle. Example:_revinclude=Provenance:target                                 |
 
 

--- a/content/millennium/r4/clinical/diagnostics/observation.md
+++ b/content/millennium/r4/clinical/diagnostics/observation.md
@@ -102,7 +102,7 @@ _Implementation Notes_
  | `date`         | N                 | [`date`]      | Date range into which the observation falls. Example: `date=gt2014-09-24` or `date=lt2015-09-24T12:00:00.000Z`                          |
  | `_lastUpdated` | N                 | [`date`]      | Date range in which the observation was last updated. Example: `_lastUpdated=gt2014-09-24` or `_lastUpdated=lt2015-09-24T12:00:00.000Z` |
  | `category`     | N                 | [`token`]     | The category of observations. Example: `category=laboratory`                                                                            |
- | [`_count`]     | N                 | [`number`]    | The maximum number of results to return per page. Defaults to 50 and maximum 200 results can return                                         |
+ | [`_count`]     | N                 | [`number`]    | The maximum number of results to return per page. Defaults to 50 and maximum 200 observations can be returned                                        |
  | `_revinclude`  | No                | [`token`]     | Provenance resource entries to be returned as part of the bundle. Example:_revinclude=Provenance:target                                 |
 
 

--- a/content/millennium/r4/clinical/diagnostics/observation.md
+++ b/content/millennium/r4/clinical/diagnostics/observation.md
@@ -102,7 +102,7 @@ _Implementation Notes_
  | `date`         | N                 | [`date`]      | Date range into which the observation falls. Example: `date=gt2014-09-24` or `date=lt2015-09-24T12:00:00.000Z`                          |
  | `_lastUpdated` | N                 | [`date`]      | Date range in which the observation was last updated. Example: `_lastUpdated=gt2014-09-24` or `_lastUpdated=lt2015-09-24T12:00:00.000Z` |
  | `category`     | N                 | [`token`]     | The category of observations. Example: `category=laboratory`                                                                            |
- | [`_count`]     | N                 | [`number`]    | The maximum number of results to return per page.                                                                                       |
+ | [`_count`]     | N                 | [`number`]    | The maximum number of results to return per page. Defaults to 50.                                                                                      |
  | `_revinclude`  | No                | [`token`]     | Provenance resource entries to be returned as part of the bundle. Example:_revinclude=Provenance:target                                 |
 
 
@@ -126,6 +126,7 @@ Notes:
 
 * When `_count` parameter is provided,
   * it won’t affect the first page, because all social history data will appear in the first page regardless of requested count.
+  * Maximal supported count = 200.
   * Second page onward, returned item count may be less than requested.
 
 * The `_revinclude` parameter may be provided once with the value `Provenance:target`. Example: `_revinclude=Provenance:target`

--- a/content/millennium/r4/clinical/diagnostics/observation.md
+++ b/content/millennium/r4/clinical/diagnostics/observation.md
@@ -126,7 +126,7 @@ Notes:
 
 * When `_count` parameter is provided,
   * it won’t affect the first page, because all social history data will appear in the first page regardless of requested count.
-  * Maximal supported count = 200.
+  * Maximum supported count = 200.
   * Second page onward, returned item count may be less than requested.
 
 * The `_revinclude` parameter may be provided once with the value `Provenance:target`. Example: `_revinclude=Provenance:target`


### PR DESCRIPTION
Description
----
Updated constraints of r4_observation _count parameter
<img width="783" alt="Screenshot 2022-12-13 at 13 41 08" src="https://user-images.githubusercontent.com/120368297/207311534-e2b9ce3c-352b-4429-85f0-1d7dc93a3a9c.png">
<img width="754" alt="Screenshot 2022-12-13 at 13 41 35" src="https://user-images.githubusercontent.com/120368297/207311553-ec4ba97b-0709-45cb-bdc7-4a2cb9cad049.png">
<img width="739" alt="Screenshot 2022-12-13 at 13 08 58" src="https://user-images.githubusercontent.com/120368297/207311587-92bb3a32-6ab3-424c-b623-5fc4dacb4e5b.png">


PR Checklist
----
- [x] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.
