### PR TITLE
[Condition][Update] Refuted status is not relevant for updating clinicalStatus

### DIFF
--- a/lib/resources/r4/condition.yaml
+++ b/lib/resources/r4/condition.yaml
@@ -70,7 +70,7 @@ fields:
   action: update
   note: |
     <ul>
-      <li> A clinicalStatus must always be provided when updating a Condition, unless verificationStatus is <code>entered-in-error</code> or <code>refuted</code>. </li>
+      <li> A clinicalStatus must always be provided when updating a Condition, unless verificationStatus is <code>entered-in-error</code>. </li>
       <li> Only the <code>active</code> code is supported when the category is <code>encounter-diagnosis</code>. </li>
     </ul>
   example: |


### PR DESCRIPTION
Description
----
In https://fhir.cerner.com/millennium/r4/clinical/summary/condition/#update-clinicalStatus, we mention a clinicalStatus needs to be provided unless verificationStatus is 'entered-in-error' or 'refuted' status. This is related to con-5 in the constraints for fhir, http://hl7.org/fhir/condition.html#invs, which only involves 'entered-in-error' not refuted. So refuted should be removed.

PR Checklist
----
- [ ] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.
