### PR TITLE
Added documentation for AllergyIntolerance onset datetime precision extension

### DIFF
--- a/content/millennium/r4/clinical/summary/allergy-intolerance.md
+++ b/content/millennium/r4/clinical/summary/allergy-intolerance.md
@@ -34,7 +34,8 @@ The following fields are returned if valued:
 * [Allergy Code](https://hl7.org/fhir/R4/allergyintolerance-definitions.html#AllergyIntolerance.code){:target="_blank"}
 * [Patient with allergy/intolerance](https://hl7.org/fhir/R4/allergyintolerance-definitions.html#AllergyIntolerance.patient){:target="_blank"}
 * [Encounter](https://hl7.org/fhir/R4/allergyintolerance-definitions.html#AllergyIntolerance.encounter){:target="_blank"}
-* [Date of allergy onset](https://hl7.org/fhir/R4/allergyintolerance-definitions.html#AllergyIntolerance.onset){:target="_blank"}
+* [Date of allergy onset](https://hl7.org/fhir/R4/allergyintolerance-definitions.html#AllergyIntolerance.onset_x_){:target="_blank"}
+  * [Precision Extension](#extensions){:target="_blank"}
 * [Date/Time recorded](https://hl7.org/fhir/R4/allergyintolerance-definitions.html#AllergyIntolerance.recordedDate){:target="_blank"}
 * [Who recorded](https://hl7.org/fhir/R4/allergyintolerance-definitions.html#AllergyIntolerance.recorder){:target="_blank"}
   * [Reference](https://hl7.org/fhir/r4/references.html#Reference){:target="_blank"} ([Practitioner](https://hl7.org/fhir/r4/practitioner.html){:target="_blank"})
@@ -52,6 +53,18 @@ The following fields are returned if valued:
 ## Terminology Bindings
 
 <%= terminology_table(:allergy_intolerance, :r4) %>
+
+## Extensions
+
+### Custom Extensions
+
+* [Precision Extension]
+
+All URLs for custom extensions are defined as `https://fhir-ehr.cerner.com/r4/StructureDefinition/{id}`
+
+ID          | Value\[x] Type                                                              | Description
+------------|-----------------------------------------------------------------------------|-----------------------------------------------
+`precision` | [`CodeableConcept`](https://hl7.org/fhir/r4/datatypes.html#codeableconcept) | Indication of the precision of a given value.
 
 ## Search
 
@@ -292,4 +305,5 @@ The common [errors] and [OperationOutcomes] may be returned.
 [`token`]: https://hl7.org/fhir/R4/search.html#token
 [errors]: ../../../#client-errors
 [OperationOutcomes]: ../../../#operation-outcomes
+[Precision Extension]: https://fhir-ehr.cerner.com/r4/StructureDefinition/precision?_format=json
 [FHIR<sup>®</sup> Update]: https://hl7.org/fhir/R4/http.html#update

--- a/lib/resources/example_json/r4_examples_allergy_intolerance.rb
+++ b/lib/resources/example_json/r4_examples_allergy_intolerance.rb
@@ -60,6 +60,24 @@ module Cerner
         'reference': 'Encounter/97953523'
       },
       'onsetDateTime': '2019-12-15T00:00:00Z',
+      '_onsetDateTime': {
+        'extension': [
+          {
+            'url': 'https://fhir-ehr.cerner.com/StructureDefinition/precision',
+            'valueCodeableConcept': {
+              'coding': [
+                {
+                  'system': 'https://fhir.cerner.com/ec2458f2-1e24-41c8-b71b-0e701af7583d/codeSet/25320',
+                  'code': '639011',
+                  'display': 'After',
+                  'userSelected': true
+                }
+              ],
+              'text': 'After'
+            }
+          }
+        ]
+      },
       'recordedDate': '2020-03-04T20:16:02Z',
       'recorder': {
         'reference': 'Practitioner/12724045',


### PR DESCRIPTION
Description
----
Added general info (similar to how the precision extension was added to Family Member History see http://fhir.cerner.com/millennium/r4/clinical/summary/family-member-history/#extensions-1)
<img width="901" alt="image" src="https://user-images.githubusercontent.com/36455545/215713984-9390f388-f5ac-4d75-a191-5c288239509d.png">

Added the extension content to the "Search" action response body (similar to http://fhir.cerner.com/millennium/r4/clinical/summary/family-member-history/#search)
<img width="1017" alt="image" src="https://user-images.githubusercontent.com/36455545/215714427-4485cc3e-0f3c-417a-805f-53d19248eea4.png">

Addedthe extension content to the "Retrievey by id" action response body (similar to http://fhir.cerner.com/millennium/r4/clinical/summary/family-member-history/#retrieve-by-id)
<img width="903" alt="image" src="https://user-images.githubusercontent.com/36455545/215714631-369ecc96-8543-4afa-8207-0c8a011ec33f.png">


PR Checklist
----
- [x] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.
