### PR TITLE
Correct diagram rendering

### DIFF
--- a/content/authorization/active-user-presence.md
+++ b/content/authorization/active-user-presence.md
@@ -13,7 +13,7 @@ To address this concern, this extension provides a mechanism by which a SMART on
 
 
 ###  Protocol Flow
-```
+<pre class="terminal">
                                                  +-------------------+
                                                  |   Authz Server    |
        +--------+                                | +---------------+ |
@@ -30,9 +30,9 @@ To address this concern, this extension provides a mechanism by which a SMART on
        |        |<-(D)------ Access Token ---------|               | |
        +--------+          + "active_ttl"        | +---------------+ |
                                                  +-------------------+
+</pre>
+__Figure 1__: Abstract Protocol Flow
 
-                     Figure 1: Abstract Protocol Flow
-```
 This specification adds additional parameters to the SMART on FHIR Access Token Response, Refresh Request, and Refresh Response shown in abstract form in Figure 1.
 
 A. The client performs an Access Token Request using an established authorization code that was established with an ```online_access``` scope.


### PR DESCRIPTION
Description
----
It seems that nanoc's rendering capabilities differ slightly from GitHub's built-in Markdown renderer; applying a correction here that was suggested by @Someshnsn. Fixes https://github.com/cerner/fhir.cerner.com/pull/929, which (as actually published to fhir.cerner.com) doesn't currently look correct.

PR Checklist
----
- [x] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.

<img width="1031" alt="Screenshot 2023-02-08 at 10 06 43 AM" src="https://user-images.githubusercontent.com/467773/217585051-2f032061-fc1b-4f84-9a8a-95e6bf56dc20.png">