### PR TITLE
Fix APPLINK example code

### DIFF
--- a/content/millennium/faq/common-issues.md
+++ b/content/millennium/faq/common-issues.md
@@ -268,7 +268,7 @@ The following example illustrates opening a web page through a shell execute.
 When Citrix is configured for server-to-client redirection and the link is
 clicked, your local default web browser opens and is directed to the link provided.  
 
-`<a href='javascript:APPLINK(100," "http://www.cerner.com","">Launch "http://www.cerner.com" in local web browser</a>`
+`<a href='javascript:APPLINK(100,"http://www.cerner.com","")'>Launch "http://www.cerner.com" in local web browser</a>`
 
 
 ### Single Patient and Multi-Patient Views


### PR DESCRIPTION
Description
----
The example HTML for the APPLINK functionality is invalid HTML—and JavaScript. This updates that example to the correct, expected syntax.

![image](https://user-images.githubusercontent.com/22381097/222194796-4c196e6d-2534-4184-829c-364416f4e1d3.png)

PR Checklist
----
- [x] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.
