### PR TITLE
Remove Google Analytics tag

### DIFF
--- a/layouts/head.html
+++ b/layouts/head.html
@@ -14,14 +14,4 @@
   <script src="/js/millennium_diff_table.js" type="text/javascript"></script>
   <script src="/js/documentation.js" type="text/javascript"></script>
   <script src="/js/request_button.js" type="text/javascript"></script>
-  <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-    ga('create', 'UA-62403415-1', 'auto');
-    ga('send', 'pageview');
-  </script>
-
 </head>


### PR DESCRIPTION
Description
----
~~Current Analytics tags are expiring 1 July and need to be updated for continued use.~~

Due to Oracle's technology ban on GA, it is being removed for the site.
