### PR TITLE
Remove R4 DocumentReference.period search param note about requiring time

### DIFF
--- a/content/millennium/r4/foundation/documents/document-reference.md
+++ b/content/millennium/r4/foundation/documents/document-reference.md
@@ -74,7 +74,6 @@ _Implementation Notes_
 
 * When searching with the `period` parameter:
   * It must be provided twice, once with the `ge` prefix, and once with the `lt` prefix.
-  * `Period` parameter  must include a time.
 
 * When searching with the `encounter` parameter:
   * Patient level documents are filtered out from responses when the encounter id is zero/blank.


### PR DESCRIPTION
Description
----
Based on testing, it seems that the R4 DocumentReference search parameter `period` does not require a time—contrary to the current documentation.

https://github.com/cerner/fhir.cerner.com/blob/9e8f422892d536ccc75700ea834abd2b031f72c2/content/millennium/r4/foundation/documents/document-reference.md#L77

Example:
https://fhir-open.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/DocumentReference/?patient=12833427&period=ge2023-01-01&period=lt2023-05-31

PR Checklist
----
- [ ] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.
