### PR TITLE
R4 Communication add note for supported categories

### DIFF
--- a/lib/resources/r4/communication.yaml
+++ b/lib/resources/r4/communication.yaml
@@ -34,6 +34,10 @@ fields:
   type: CodeableConcept
   description: Codeable definition of the communication type.
   url: https://hl7.org/fhir/r4/communication-definitions.html#Communication.category
+  note: |
+    <ul>
+      <li>Only CommunicationCategory values of <code>notification</code> and <code>reminder</code> and SNOMED CT <code>312853008</code> are supported.</li>
+    </ul>
   example: |
     {
       "category": [


### PR DESCRIPTION
Description
----
R4 Communication only supports HL7 CommunicationCategory values of `notification` and `reminder` as well as SNOMED CT `312853008`. This update is to specify this restriction.

Current:
![Published fhir cerner com - Communication R4 API](https://github.com/cerner/fhir.cerner.com/assets/22381097/a0672fcb-65c5-4728-bed0-528f21f92d82)

With changes:
![local build fhir cerner com -  Communication R4 API](https://github.com/cerner/fhir.cerner.com/assets/22381097/e213b4ba-7d47-4738-8052-6e32cf4cd6b3)

PR Checklist
----
- [x] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.
