### PR TITLE
Update r4 condition documentation by adding meta.security

### DIFF
--- a/content/millennium/r4/clinical/summary/condition.md
+++ b/content/millennium/r4/clinical/summary/condition.md
@@ -98,8 +98,8 @@ Notes:
 
 <%= headers status: 200 %>
 <%= json(:r4_condition_bundle) %>
-
 <%= disclaimer %>
+<%= security_field_disclaimer %>
 
 ### Example with RevInclude
 
@@ -116,6 +116,7 @@ Notes:
 <%= headers status: 200 %>
 <%= json(:r4_condition_revinclude_bundle) %>
 <%= disclaimer %>
+<%= security_field_disclaimer %>
 
 #### Patient Authorization Request
 
@@ -125,8 +126,8 @@ Notes:
 
 <%= headers status: 200 %>
 <%= json(:r4_patient_condition_bundle) %>
-
 <%= disclaimer %>
+<%= security_field_disclaimer %>
 
 ### Errors
 
@@ -156,8 +157,8 @@ List an individual Condition by its id:
 
 <%= headers status: 200 %>
 <%= json(:r4_condition_entry) %>
-
 <%= disclaimer %>
+<%= security_field_disclaimer %>
 
 #### Patient Authorization Request For Resolved Status
 
@@ -167,8 +168,8 @@ List an individual Condition by its id:
 
 <%= headers status: 200 %>
 <%= json(:r4_patient_condition_entry) %>
-
 <%= disclaimer %>
+<%= security_field_disclaimer %>
 
 #### Patient Authorization Request For Active Status
 
@@ -178,8 +179,8 @@ List an individual Condition by its id:
 
 <%= headers status: 200 %>
 <%= json(:r4_patient_active_entry) %>
-
 <%= disclaimer %>
+<%= security_field_disclaimer %>
 
 #### Patient Authorization Request For Entered in Error Status
 
@@ -189,8 +190,8 @@ List an individual Condition by its id:
 
 <%= headers status: 200 %>
 <%= json(:r4_patient_entered_in_error_entry) %>
-
 <%= disclaimer %>
+<%= security_field_disclaimer %>
 
 ### Errors
 

--- a/lib/resources.rb
+++ b/lib/resources.rb
@@ -223,6 +223,10 @@ module Cerner
           end
         end
       end
+
+      def security_field_disclaimer
+        'The `meta.security` field will be present only when a problem or diagnosis is marked as confidential.'
+      end
     end
   end
 end

--- a/lib/resources/example_json/r4_examples_condition.rb
+++ b/lib/resources/example_json/r4_examples_condition.rb
@@ -8,7 +8,21 @@ module Cerner
       'id': 'p73077203',
       'meta': {
         'versionId': '73080185',
-        'lastUpdated': '2020-06-11T04:05:04.000Z'
+        'lastUpdated': '2020-06-11T04:05:04.000Z',
+        'security': [
+          {
+            'system': 'http://terminology.hl7.org/CodeSystem/v3-ActCode',
+            'code': 'PHY',
+            'display': 'physician requested information sensitivity',
+            'userSelected': false
+          },
+          {
+            'system': 'http://terminology.hl7.org/CodeSystem/v3-ActCode',
+            'code': 'PRS',
+            'display': 'patient requested information sensitivity',
+            'userSelected': false
+          }
+        ]
       },
       'text': {
         'status': 'generated',
@@ -92,7 +106,21 @@ module Cerner
       'id': 'p109117485',
       'meta': {
         'versionId': '109117485',
-        'lastUpdated': '2020-06-11T04:05:04.000Z'
+        'lastUpdated': '2020-06-11T04:05:04.000Z',
+        'security': [
+          {
+            'system': 'http://terminology.hl7.org/CodeSystem/v3-ActCode',
+            'code': 'PHY',
+            'display': 'physician requested information sensitivity',
+            'userSelected': false
+          },
+          {
+            'system': 'http://terminology.hl7.org/CodeSystem/v3-ActCode',
+            'code': 'PRS',
+            'display': 'patient requested information sensitivity',
+            'userSelected': false
+          }
+        ]
       },
       'text': {
         'status': 'generated',
@@ -171,7 +199,21 @@ module Cerner
       'resourceType': 'Condition',
       'id': 'd2266495305',
       'meta': {
-        'versionId': '2266495305'
+        'versionId': '2266495305',
+        'security': [
+          {
+            'system': 'http://terminology.hl7.org/CodeSystem/v3-ActCode',
+            'code': 'PHY',
+            'display': 'physician requested information sensitivity',
+            'userSelected': false
+          },
+          {
+            'system': 'http://terminology.hl7.org/CodeSystem/v3-ActCode',
+            'code': 'PRS',
+            'display': 'patient requested information sensitivity',
+            'userSelected': false
+          }
+        ]
       },
       'text': {
         'status': 'generated',
@@ -232,7 +274,21 @@ module Cerner
       'id': 'a077dc30-8eee-4bb7-ae7f-ced1273f5c68',
       'meta': {
         'versionId': 'a077dc30-8eee-4bb7-ae7f-ced1273f5c68',
-        'lastUpdated': '2020-12-03T22:47:30.000Z'
+        'lastUpdated': '2020-12-03T22:47:30.000Z',
+        'security': [
+          {
+            'system': 'http://terminology.hl7.org/CodeSystem/v3-ActCode',
+            'code': 'PHY',
+            'display': 'physician requested information sensitivity',
+            'userSelected': false
+          },
+          {
+            'system': 'http://terminology.hl7.org/CodeSystem/v3-ActCode',
+            'code': 'PRS',
+            'display': 'patient requested information sensitivity',
+            'userSelected': false
+          }
+        ]
       },
       'text': {
         'status': 'generated',
@@ -298,7 +354,21 @@ module Cerner
         'id': 'd2572382197',
         'meta': {
           'versionId': '2572382197',
-          'lastUpdated': '2020-06-11T04:03:21.000Z'
+          'lastUpdated': '2020-06-11T04:03:21.000Z',
+          'security': [
+            {
+              'system': 'http://terminology.hl7.org/CodeSystem/v3-ActCode',
+              'code': 'PHY',
+              'display': 'physician requested information sensitivity',
+              'userSelected': false
+            },
+            {
+              'system': 'http://terminology.hl7.org/CodeSystem/v3-ActCode',
+              'code': 'PRS',
+              'display': 'patient requested information sensitivity',
+              'userSelected': false
+            }
+          ]
         },
         'text': {
           'status': 'generated',
@@ -391,7 +461,21 @@ module Cerner
         'id': 'bed1c2ec-1f33-4097-8296-f6aa01824387',
         'meta': {
           'versionId': 'bed1c2ec-1f33-4097-8296-f6aa01824387',
-          'lastUpdated': '2020-10-20T20:46:41.000Z'
+          'lastUpdated': '2020-10-20T20:46:41.000Z',
+          'security': [
+            {
+              'system': 'http://terminology.hl7.org/CodeSystem/v3-ActCode',
+              'code': 'PHY',
+              'display': 'physician requested information sensitivity',
+              'userSelected': false
+            },
+            {
+              'system': 'http://terminology.hl7.org/CodeSystem/v3-ActCode',
+              'code': 'PRS',
+              'display': 'patient requested information sensitivity',
+              'userSelected': false
+            }
+          ]
         },
         'text': {
           'status': 'generated',
@@ -490,7 +574,21 @@ module Cerner
             'id': '00a5d6eb-c567-42f7-be07-53804cece075',
             'meta': {
               'versionId': '00a5d6eb-c567-42f7-be07-53804cece075',
-              'lastUpdated': '2020-07-06T19:36:23.000Z'
+              'lastUpdated': '2020-07-06T19:36:23.000Z',
+              'security': [
+                {
+                  'system': 'http://terminology.hl7.org/CodeSystem/v3-ActCode',
+                  'code': 'PHY',
+                  'display': 'physician requested information sensitivity',
+                  'userSelected': false
+                },
+                {
+                  'system': 'http://terminology.hl7.org/CodeSystem/v3-ActCode',
+                  'code': 'PRS',
+                  'display': 'patient requested information sensitivity',
+                  'userSelected': false
+                }
+              ]
             },
             'text': {
               'status': 'generated',

--- a/lib/resources/example_json/r4_examples_condition.rb
+++ b/lib/resources/example_json/r4_examples_condition.rb
@@ -200,6 +200,7 @@ module Cerner
       'id': 'd2266495305',
       'meta': {
         'versionId': '2266495305',
+        'lastUpdated': '2020-06-11T04:05:04.000Z',
         'security': [
           {
             'system': 'http://terminology.hl7.org/CodeSystem/v3-ActCode',

--- a/lib/resources/r4/condition.yaml
+++ b/lib/resources/r4/condition.yaml
@@ -256,6 +256,16 @@ fields:
         system: http://hl7.org/fhir/sid/icd-10-cm
         info_link: https://hl7.org/fhir/icd.html
 
+- name: meta.security
+  url: http://www.hl7.org/fhir/resource-definitions.html#Meta.security
+  binding:
+    description: These tags connect specific resources to the overall security policy and infrastructure.
+    terminology:
+      - display: ValueSet
+        system: http://terminology.hl7.org/CodeSystem/v3-ActCode
+        info_link: http://www.hl7.org/fhir/valueset-security-labels.html
+  action: terminology
+
 - name: subject
   required: 'Yes'
   type: Reference


### PR DESCRIPTION
Description
----
Added meta.security to the condition response examples.
Added disclaimer for when meta.security is going to be populated.
Added meta.security to terminology bindings.

Screenshot before changes being merged:
Updated terminology binding:
<img width="1010" alt="r4-updated-terminlogy" src="https://github.com/cerner/fhir.cerner.com/assets/20145349/03e83fe7-2959-4bba-93cd-c1677a5fd5b6">

Updated response and disclaimer
<img width="893" alt="r4-updated-response-and-disclaimer" src="https://github.com/cerner/fhir.cerner.com/assets/20145349/ca06c547-7efb-4bfe-926c-172f9c0f5c07">

PR Checklist
----
- [x] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.
