### PR TITLE
Update dstu2 condition documentation by adding meta.security

### DIFF
--- a/content/millennium/dstu2/general-clinical/condition.md
+++ b/content/millennium/dstu2/general-clinical/condition.md
@@ -71,6 +71,7 @@ Notes:
 <%= headers status: 200 %>
 <%= json(:dstu2_condition_bundle) %>
 <%= disclaimer %>
+<%= security_field_disclaimer %>
 
 ### Example Read by Ids
 
@@ -83,6 +84,7 @@ Notes:
 <%= headers status: 200 %>
 <%= json(:dstu2_condition_bundle_by_id) %>
 <%= disclaimer %>
+<%= security_field_disclaimer %>
 
 ### Errors
 
@@ -113,6 +115,7 @@ List an individual Condition by its id:
 <%= headers status: 200 %>
 <%= json(:dstu2_condition_health_concern_resource) %>
 <%= disclaimer %>
+<%= security_field_disclaimer %>
 
 ### Errors
 

--- a/lib/resources.rb
+++ b/lib/resources.rb
@@ -223,6 +223,10 @@ module Cerner
           end
         end
       end
+
+      def security_field_disclaimer
+        'The `meta.security` field will be present only when a problem or diagnosis is marked as confidential.'
+      end
     end
   end
 end

--- a/lib/resources/dstu2/condition.yaml
+++ b/lib/resources/dstu2/condition.yaml
@@ -195,6 +195,16 @@ fields:
       system: http://snomed.info/sct
       info_link: http://hl7.org/fhir/dstu2/snomedct.html
 
+- name: meta.security
+  url: http://www.hl7.org/fhir/resource-definitions.html#Meta.security
+  binding:
+    description: These tags connect specific resources to the overall security policy and infrastructure.
+    terminology:
+      - display: ValueSet
+        system: http://terminology.hl7.org/CodeSystem/v3-ActCode
+        info_link: http://www.hl7.org/fhir/valueset-security-labels.html
+  action: terminology
+
 - name: onsetDateTime
   required: 'No'
   type: dateTime

--- a/lib/resources/example_json/dstu2_examples_condition.rb
+++ b/lib/resources/example_json/dstu2_examples_condition.rb
@@ -8,7 +8,21 @@ module Cerner
       'id': 'p73077203',
       'meta': {
         'versionId': '73079095',
-        'lastUpdated': '2020-04-05T04:00:46.000Z'
+        'lastUpdated': '2020-04-05T04:00:46.000Z',
+        'security': [
+          {
+            'system': 'http://terminology.hl7.org/CodeSystem/v3-ActCode',
+            'code': 'PHY',
+            'display': 'physician requested information sensitivity',
+            'userSelected': false
+          },
+          {
+            'system': 'http://terminology.hl7.org/CodeSystem/v3-ActCode',
+            'code': 'PRS',
+            'display': 'patient requested information sensitivity',
+            'userSelected': false
+          }
+        ]
       },
       'text': {
         'status': 'generated',
@@ -56,7 +70,21 @@ module Cerner
         'id': 'd2572382197',
         'meta': {
           'versionId': '2572382197',
-          'lastUpdated': '2020-06-11T04:03:21.000Z'
+          'lastUpdated': '2020-06-11T04:03:21.000Z',
+          'security': [
+            {
+              'system': 'http://terminology.hl7.org/CodeSystem/v3-ActCode',
+              'code': 'PHY',
+              'display': 'physician requested information sensitivity',
+              'userSelected': false
+            },
+            {
+              'system': 'http://terminology.hl7.org/CodeSystem/v3-ActCode',
+              'code': 'PRS',
+              'display': 'patient requested information sensitivity',
+              'userSelected': false
+            }
+          ]
         },
         'text': {
           'status': 'generated',
@@ -113,7 +141,21 @@ module Cerner
         'id': '00a5d6eb-c567-42f7-be07-53804cece075',
         'meta': {
           'versionId': '00a5d6eb-c567-42f7-be07-53804cece075',
-          'lastUpdated': '2020-07-06T19:36:23.000Z'
+          'lastUpdated': '2020-07-06T19:36:23.000Z',
+          'security': [
+            {
+              'system': 'http://terminology.hl7.org/CodeSystem/v3-ActCode',
+              'code': 'PHY',
+              'display': 'physician requested information sensitivity',
+              'userSelected': false
+            },
+            {
+              'system': 'http://terminology.hl7.org/CodeSystem/v3-ActCode',
+              'code': 'PRS',
+              'display': 'patient requested information sensitivity',
+              'userSelected': false
+            }
+          ]
         },
         'text': {
           'status': 'generated',


### PR DESCRIPTION
Description
----
Added meta.security to the condition response examples.
Added disclaimer for when meta.security is going to be populated.
Added meta.security to terminology bindings.

Screenshot before changes being merged:
Updated response and disclaimer:
<img width="822" alt="dstu2-updated-response-and-disclaimer" src="https://github.com/cerner/fhir.cerner.com/assets/20145349/a06e8ebd-1a1e-4998-92d0-73a4bc8eb0d2">

Updated terminology binding:
<img width="822" alt="dstu2-updated-terminology" src="https://github.com/cerner/fhir.cerner.com/assets/20145349/23b9aac1-26d6-457d-a0ce-133b76d63d1e">

PR Checklist
----
- [x] Screenshot(s) of changes attached before changes merged.
- [ ] Screenshot(s) of changes attached after changes merged and published.
