### PR TITLE
Review and corrections for ChargeItem

### DIFF
--- a/content/millennium/r4/financial/general/charge-item.md
+++ b/content/millennium/r4/financial/general/charge-item.md
@@ -155,7 +155,7 @@ List an individual ChargeItem by its id:
 
 The common [errors] and [OperationOutcomes] may be returned.
 
-## Operation: charge-item-credit
+## Credit
 
 
 Creates an offsetting ChargeItem for an existing debit ChargeItem.
@@ -209,7 +209,7 @@ The `ETag` response header indicates the current `If-Match` version to use on su
 
 The common [errors] and [OperationOutcomes] may be returned.
 
-## Operation: charge-item-modify
+## Modify
 
 
 Modifies an existing ChargeItem resulting in a newly created ChargeItem.
@@ -263,12 +263,12 @@ The `ETag` response header indicates the current `If-Match` version to use on su
 
 The common [errors] and [OperationOutcomes] may be returned.
 
-## Operation: charge-item-create
+## Create
 
 
 Creates a charge event which can result in the creation of one or more ChargeItems.
 
-    POST /ChargeItem/:id/$create
+    POST /ChargeItem/$create
 
 _Implementation Notes_
 

--- a/content/millennium/r4/proprietary-codes-and-systems.md
+++ b/content/millennium/r4/proprietary-codes-and-systems.md
@@ -869,7 +869,7 @@ This system is the account number of a financial account.
 
 ##### Bill Codes Types
 
-This system is the bill code type for a charge item. `Bill code type` can be either `CDM_SCHED`, `CPT`, `HCPCS`, `ICD`, `MODIFIER`, or `REVENUE`.
+This system is the bill code type for a charge item. `Bill code type` can be either `CDM_SCHED`, `CPT`, `HCPCS`, `ICD`, `PROCCODE` , `MODIFIER`, or `REVENUE`.
 
     {
       "system": "https://fhir.<region>.cerner.com/<EHR source id>/CodeSystem/BillCodes-<Bill code type>",

--- a/content/millennium/r4/proprietary-codes-and-systems.md
+++ b/content/millennium/r4/proprietary-codes-and-systems.md
@@ -869,7 +869,7 @@ This system is the account number of a financial account.
 
 ##### Bill Codes Types
 
-This system is the bill code type for a charge item. `Bill code type` can be either `CDM_SCHED`, `CPT`, `HCPCS`, `ICD`, `PROCCODE` , `MODIFIER`, or `REVENUE`.
+This system is the bill code type for a charge item. `Bill code type` can be either `CDM_SCHED`, `CPT`, `HCPCS`, `ICD`, `PROCCODE`, `MODIFIER`, or `REVENUE`.
 
     {
       "system": "https://fhir.<region>.cerner.com/<EHR source id>/CodeSystem/BillCodes-<Bill code type>",

--- a/lib/resources/r4/charge_item.yaml
+++ b/lib/resources/r4/charge_item.yaml
@@ -46,7 +46,7 @@ fields:
     required: 'No'
     type: Extension
     description: A code providing information about the procedure performed on the patient associated to the resource.
-    url: https://fhir.cerner.com/millennium/r4/financial/charge-item/#extensions
+    url: https://fhir.cerner.com/millennium/r4/financial/general/charge-item/#extensions
     binding:
       description: A code providing information about the procedure performed on the patient associated to the resource. This binding is used in <code>procedure-code</code> extensions. <code>Bill code type</code> can be either <code>CPT</code>, <code>HCPCS</code>, or <code>PROCCODE</code>.
       terminology:
@@ -55,7 +55,7 @@ fields:
         info_link: https://fhir.cerner.com/millennium/r4/proprietary-codes-and-systems/#bill-codes-types
 
   - name: Revenue Code Extension
-    terminology_name: extension[x].valueCodeableConcept
+    terminology_name: extension[x].extension[x].valueCodeableConcept
     required: 'No'
     type: Extension
     description: The type of revenue or cost center providing the product and/or service.
@@ -129,8 +129,8 @@ fields:
       description: The national drug code for pharmacy charges. This binding is used in <code>national-drug-product</code> extensions.
       terminology:
         - display: National Drug Product
-          system: https://hl7.org/fhir/sid/ndc
-          info_link: https://hl7.org/fhir/sid/ndc
+          system: https://terminology.hl7.org/5.1.0/CodeSystem-v3-ndc.html
+          info_link: https://terminology.hl7.org/5.1.0/CodeSystem-v3-ndc.html
 
   - name: National Drug Product Quantity
     terminology_name: extension[x].extension[x].valueQuantity

--- a/lib/resources/r4/charge_item.yaml
+++ b/lib/resources/r4/charge_item.yaml
@@ -129,7 +129,7 @@ fields:
       description: The national drug code for pharmacy charges. This binding is used in <code>national-drug-product</code> extensions.
       terminology:
         - display: National Drug Product
-          system: https://terminology.hl7.org/5.1.0/CodeSystem-v3-ndc.html
+          system: https://hl7.org/fhir/sid/ndc
           info_link: https://terminology.hl7.org/5.1.0/CodeSystem-v3-ndc.html
 
   - name: National Drug Product Quantity


### PR DESCRIPTION
Description
----
In preparation for migrating to Oracle docs, we are reviewing and correcting any inconsistencies, typos, broken links, etc. This PR aims to correct any of the above that needs to be addressed within ChargeItem and any other information directly referenced by it.

Within Chargeitem.extension[x].extension[x].valueCodeableConcept for procedure-codes anchor link is broken, it should be https://fhir.cerner.com/millennium/r4/financial/general/charge-item/#extension

**Before**:
<img width="935" alt="image" src="https://github.com/cerner/fhir.cerner.com/assets/143555600/d6cd35f5-2f9e-47ed-8951-82666493d61e">
**After**: 
<img width="911" alt="image" src="https://github.com/cerner/fhir.cerner.com/assets/143555600/76ca75d8-f6fe-409f-a08d-5612f6900ad1">

When clicking Bill Code types for Chargeitem.extension[x].extension[x].valueCodeableConcept for procedure-codes, its corresponding bill type code PROCCODE is missing from the list of possible bill type codes. 

**Before**: 
<img width="809" alt="image" src="https://github.com/cerner/fhir.cerner.com/assets/143555600/96c74d5a-b9b0-4165-9887-97a7fb3dde36">
**After**:
<img width="743" alt="image" src="https://github.com/cerner/fhir.cerner.com/assets/143555600/836796db-ad61-4dd2-80e1-e2c29653c8a0">

Chargeitem.extension[x].valueCodeableConcept for revenue-code should have the same depth as modifier code and procedure code extensions: extension[x].extension[x].valueCodeableConcept, as that is how it appears on live json responses.

**Before**:
<img width="794" alt="image" src="https://github.com/cerner/fhir.cerner.com/assets/143555600/eba21559-0a19-4445-acd6-2ac0f957c3fd">
**After**: 
<img width="694" alt="image" src="https://github.com/cerner/fhir.cerner.com/assets/143555600/3e27811b-9c79-4200-8c7c-0d39082f1b92">

Chargeitem.extension[x].extension[x].valueCodeableConcept for national-drug-product has a Broken url in Details for National Drug Product: https://hl7.org/fhir/sid/ndc will redirect to https://hl7.org/fhir/http://terminology.hl7.org/5.1.0/CodeSystem-v3-ndc.html which returns a Server Error, should be https://terminology.hl7.org/5.1.0/CodeSystem-v3-ndc.html

**Before**: 
<img width="791" alt="image" src="https://github.com/cerner/fhir.cerner.com/assets/143555600/64460625-f87d-4f75-8e63-0f05c685f0a1">
![image](https://github.com/cerner/fhir.cerner.com/assets/143555600/a2c665be-66ba-4133-9f4a-d418e9939174)

**After**:
<img width="692" alt="image" src="https://github.com/cerner/fhir.cerner.com/assets/143555600/8454b6b9-669e-45fe-8cb5-ad29465204bb">
<img width="1114" alt="image" src="https://github.com/cerner/fhir.cerner.com/assets/143555600/e095015b-654b-4e29-93d2-a04b079086f2">

For Operations charge-item-credit, charge-item-modify, charge-item-create, their top of section anchor links don’t work properly, this is because in the table they are defined with the prefix operation-charge-item but the metadata endpoint (https://fhir-ehr-code.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/metadata) has them defined as #credit, #modify and #create respectively, and the anchor url is automatically defined from that. This change aims to make them match with the response from metadata so that the proper anchor url is generated.

**Before**
<img width="409" alt="image" src="https://github.com/cerner/fhir.cerner.com/assets/143555600/72127ac8-4ec8-42bb-8b30-6423dca36d7b">

**After**
<img width="296" alt="image" src="https://github.com/cerner/fhir.cerner.com/assets/143555600/624a5834-0a0f-4e73-84f0-17548a1c4590">

Create URL includes an :id, but this endpoint shouldn't have an id parameter, the example correctly omits it 

**Before**
<img width="851" alt="image" src="https://github.com/cerner/fhir.cerner.com/assets/143555600/01d78b1a-1ed8-415e-9901-f0034c53249e">

**After**
<img width="712" alt="image" src="https://github.com/cerner/fhir.cerner.com/assets/143555600/5501995f-787e-40ee-80fc-34e196959c7a">


PR Checklist
----
- [x] Screenshot(s) of changes attached before changes merged.
- [x] Screenshot(s) of changes attached after changes merged and published.
