### PR TITLE
typo fix for CapabilityStatement

### DIFF
--- a/content/millennium/r4/foundation/conformance/capability-statement.md
+++ b/content/millennium/r4/foundation/conformance/capability-statement.md
@@ -22,7 +22,7 @@ _Implementation Notes_
 
 * Authentication is not required to access the Conformance resource
 * No parameters other than the standard `_format` parameter are supported for reading CapabilityStatement
-* Resource actions that are sill under development will be returned in the CapabilityStatement with documentation on the interaction explaining that the resource action is still under development and should not be used in production. These resource actions are listed as 'beta' on fhir.cerner.com.
+* Resource actions that are still under development will be returned in the CapabilityStatement with documentation on the interaction explaining that the resource action is still under development and should not be used in production. These resource actions are listed as 'beta' on fhir.cerner.com.
 
 ### Authorization Types
 


### PR DESCRIPTION
Description
----
In preparation for migrating to Oracle docs, we are reviewing and correcting any inconsistencies, typos, broken links, etc. This PR aims to correct any of the above that needs to be addressed within CapabilityStatement and any other information directly referenced by it. 

Small typo fix on /metadata implementation notes: 

Before: 
<img width="851" alt="image" src="https://github.com/cerner/fhir.cerner.com/assets/143555600/13b64b26-21d4-4911-8bcd-0d8f620dea0e">

After:
<img width="892" alt="image" src="https://github.com/cerner/fhir.cerner.com/assets/143555600/0e27f1bf-2236-405f-9323-59e3a911e3a8">


PR Checklist
----
- [x] Screenshot(s) of changes attached before changes merged.
- [x] Screenshot(s) of changes attached after changes merged and published.
