### PR TITLE
Updated DSTU2 care-plan

### DIFF
--- a/content/millennium/dstu2/care-provision/care-plan.md
+++ b/content/millennium/dstu2/care-provision/care-plan.md
@@ -29,7 +29,7 @@ The following fields are returned if valued:
 
 ### Care Teams
 
-The CareTeam resource will be available in the STU3 version to represent care team members. Meanwhile, the CarePlan resource will be used to identify the care team members in DSTU2. Care team members or participants include practitioners (physicians, nurses, technicians, etc.), family members, friends, guardians, and the patient. The care team can be specific to an encounter or the patient across all encounters (longitudinal).
+The CareTeam resource will be available in the STU3 and R4 versions to represent care team members. Meanwhile, the CarePlan resource will be used to identify the care team members in DSTU2. Care team members or participants include practitioners (physicians, nurses, technicians, etc.), family members, friends, guardians, and the patient. The care team can be specific to an encounter or the patient across all encounters (longitudinal).
 
 The following fields are returned if valued:
 

--- a/content/millennium/dstu2/care-provision/care-plan.md
+++ b/content/millennium/dstu2/care-provision/care-plan.md
@@ -29,7 +29,9 @@ The following fields are returned if valued:
 
 ### Care Teams
 
-The CareTeam resource will be available in the STU3 and R4 versions to represent care team members. Meanwhile, the CarePlan resource will be used to identify the care team members in DSTU2. Care team members or participants include practitioners (physicians, nurses, technicians, etc.), family members, friends, guardians, and the patient. The care team can be specific to an encounter or the patient across all encounters (longitudinal).
+For DSTU2 Resources, the CarePlan resource is used to represent care team members.  Care team members or participants include practitioners (physicians, nurses, technicians, etc.), family members, friends, guardians, and the patient. The care team can be specific to an encounter or to the patient across all encounters (longitudinal).
+
+If using R4 Resources, the [R4 CareTeam](http://fhir.cerner.com/millennium/r4/clinical/care-provision/care-team/) resource is available.
 
 The following fields are returned if valued:
 


### PR DESCRIPTION
Modify wording for clarity in DSTU2 Care Plan resource

Description
----
Single line change for the DSTU2 CarePlan Resource for wording.
We only have DSTU2 and R4, instead of anything on STU3 over here.
Otherwise, all links verified as good, and the rest of the DSTU2 resource itself looks fine.

PR Checklist
----
Current state - highlighted text being changed, as shown in the commits section.
![image](https://github.com/cerner/fhir.cerner.com/assets/144141792/19794a4d-3b63-407f-a734-700a3683165b)

Future state wording:
![image](https://github.com/cerner/fhir.cerner.com/assets/144141792/ba2936a1-6ead-426b-87fa-ae2af519189b)

