### PR TITLE
Updated R4 CarePlan Resource

### DIFF
--- a/content/millennium/r4/clinical/care-provision/care-plan.md
+++ b/content/millennium/r4/clinical/care-provision/care-plan.md
@@ -85,7 +85,7 @@ Notes:
 
 - The `_revinclude` parameter 
   - May be provided once with the value `Provenance:target`. Example: `_revinclude=Provenance:target`
-  - May be provided with the `_id/` or `patient` parameter. Example: `_id=178866310&_revinclude=Provenance:target`
+  - May be provided with the `_id` or `patient` parameter. Example: `_id=178866310&_revinclude=Provenance:target`
 
 - When `_revinclude` is provided in a request to the closed endpoint, the OAuth2 token must include the `user/Provenance.read` scope. Currently `patient/Provenance.read` is not supported and hence `_revinclude` cannot be utilised for patient persona.
 

--- a/content/millennium/r4/clinical/care-provision/care-plan.md
+++ b/content/millennium/r4/clinical/care-provision/care-plan.md
@@ -87,7 +87,7 @@ Notes:
   - May be provided once with the value `Provenance:target`. Example: `_revinclude=Provenance:target`
   - May be provided with the `_id` or `patient` parameter. Example: `_id=178866310&_revinclude=Provenance:target`
 
-- When `_revinclude` is provided in a request to the closed endpoint, the OAuth2 token must include the `user/Provenance.read` scope. Currently `patient/Provenance.read` is not supported and hence `_revinclude` cannot be utilised for patient persona.
+- When `_revinclude` is provided in a request to the closed endpoint, the OAuth2 token must include the `user/Provenance.read` scope. Currently `patient/Provenance.read` is not supported and hence `_revinclude` cannot be utilized for patient persona.
 
 ### Headers
 

--- a/content/millennium/r4/clinical/care-provision/care-plan.md
+++ b/content/millennium/r4/clinical/care-provision/care-plan.md
@@ -60,19 +60,19 @@ _Implementation Notes_
  `patient`    | See notes | [`reference`] | Who care plan is for. Example: `patient=12345`
  `category`   | See notes | [`token`]     | The scope of care plan being searched for. Examples: `category=assess-plan`
  [`_count`]   | N         | [`number`]    | Number of results per page.
- `_revinclude`| No        | [`token`]     | Provenance resource entries to be returned as part of the bundle. Example:_revinclude=Provenance:target
+ `_revinclude`| N         | [`token`]     | Provenance resource entries to be returned as part of the bundle. Example:_revinclude=Provenance:target
 
 
 Notes:
 
 - The `_id` parameter
-  - May not be provided with any other parameters.
+  - May not be provided with any other parameters, except for `_revinclude` as indicated below.
   - When provided, `_count` is ignored.
 
 - The `date` parameter
-  - When provided, must use both `ge` and `le` prefixes in the same search
-    - The lower value must have the `ge` prefix and the higher value must have the `le` prefix
-    - If date precision must be consistent
+  - When provided, must use both `ge` and `le` prefixes in the same search.
+    - The lower value must have the `ge` prefix and the higher value must have the `le` prefix.
+    - If date precision must be consistent.
   - May be combined with the patient and category parameters.
 
 - The `patient` parameter
@@ -83,9 +83,9 @@ Notes:
   - Only supports the code `assess-plan`.
   - This can be combined with the patient parameter.
 
-- The `_revinclude` parameter may be provided once with the value `Provenance:target`. Example: `_revinclude=Provenance:target`
-
-- The `_revinclude` parameter may be provided with the `_id/patient` parameter. Example: `_id=178866310&_revinclude=Provenance:target`
+- The `_revinclude` parameter 
+  - May be provided once with the value `Provenance:target`. Example: `_revinclude=Provenance:target`
+  - May be provided with the `_id/patient` parameter. Example: `_id=178866310&_revinclude=Provenance:target`
 
 - When `_revinclude` is provided in a request to the closed endpoint, the OAuth2 token must include the `user/Provenance.read` scope. Currently `patient/Provenance.read` is not supported and hence `_revinclude` cannot be utilised for patient persona.
 

--- a/content/millennium/r4/clinical/care-provision/care-plan.md
+++ b/content/millennium/r4/clinical/care-provision/care-plan.md
@@ -58,9 +58,9 @@ _Implementation Notes_
  `_id`        | See notes | [`token`]     | The logical resource id associated with the resource.
  `date`       | N         | [`date`]      | Time period plan covers. Example: `date=ge2016&date=le2017 (Jan 1, 2016 - Dec 31, 2017)` or `date=ge2016-08-24T12:00:00.000Z&date=le2017-01-24T12:00:00.000Z`
  `patient`    | See notes | [`reference`] | Who care plan is for. Example: `patient=12345`
- `category`   | See notes | [`token`]     | The scope of care plan being searched for. Examples: `category=assess-plan`
+ `category`   | See notes | [`token`]     | The scope of care plan being searched for. Example: `category=assess-plan`
  [`_count`]   | N         | [`number`]    | Number of results per page.
- `_revinclude`| N         | [`token`]     | Provenance resource entries to be returned as part of the bundle. Example:_revinclude=Provenance:target
+ `_revinclude`| N         | [`token`]     | Provenance resource entries to be returned as part of the bundle. Example: `_revinclude=Provenance:target`
 
 
 Notes:
@@ -72,7 +72,7 @@ Notes:
 - The `date` parameter
   - When provided, must use both `ge` and `le` prefixes in the same search.
     - The lower value must have the `ge` prefix and the higher value must have the `le` prefix.
-    - If date precision must be consistent.
+    - Date precision must be consistent.
   - May be combined with the patient and category parameters.
 
 - The `patient` parameter
@@ -85,7 +85,7 @@ Notes:
 
 - The `_revinclude` parameter 
   - May be provided once with the value `Provenance:target`. Example: `_revinclude=Provenance:target`
-  - May be provided with the `_id/patient` parameter. Example: `_id=178866310&_revinclude=Provenance:target`
+  - May be provided with the `_id/` or `patient` parameter. Example: `_id=178866310&_revinclude=Provenance:target`
 
 - When `_revinclude` is provided in a request to the closed endpoint, the OAuth2 token must include the `user/Provenance.read` scope. Currently `patient/Provenance.read` is not supported and hence `_revinclude` cannot be utilised for patient persona.
 


### PR DESCRIPTION
Formatting updates to be consistent across parameter notes, including punctuation, and matching _revinclude to other parameters' styling.
Verified good links throughout document and have validated that example API calls behave as noted with examples.

Description
----

- Miscellaneous formatting changes (e.g. adding periods/punctuation) for consistency across parameters
- Parameters table - Required flag for _revinclude changed to match others'
- Parameter notes - _id changed wording to note interaction with _revinclude
- Parameter notes - _revinclude modified structure to largely match other parameters' styling

PR Checklist
----

- Parameters table before _revinclude change:

![image](https://github.com/cerner/fhir.cerner.com/assets/144141792/d76895d5-94a3-4728-aa60-a3e15e1e8872)

After:
![image](https://github.com/cerner/fhir.cerner.com/assets/144141792/ea0d315a-2cc3-471d-96f2-ddff3edf8e34)

*****************************

- _id parameter details before change:
![image](https://github.com/cerner/fhir.cerner.com/assets/144141792/98845199-5ecd-4d82-8049-ba6e2302f6db)

After:
![image](https://github.com/cerner/fhir.cerner.com/assets/144141792/fc100cb7-ca80-46f1-89df-2daa6a95219d)

*****************************

-  _revinclude section of parameter notes before change:
![image](https://github.com/cerner/fhir.cerner.com/assets/144141792/48eb0e18-794c-477c-829c-f9113e8873a5)

After:
![image](https://github.com/cerner/fhir.cerner.com/assets/144141792/0aec9314-3421-47b5-b58f-a16896fdcc39)


