### PR TITLE
Updated R4 CareTeam Resource

### DIFF
--- a/content/millennium/r4/clinical/care-provision/care-team.md
+++ b/content/millennium/r4/clinical/care-provision/care-team.md
@@ -64,12 +64,12 @@ Notes:
   - This is required if `patient` or `encounter` are not provided.
 
 - The `patient` parameter
-  - This is required when `_id` or `encounter` is not provided.
+  - This is required when `_id` or `encounter` are not provided.
   - This can be combined with `status` as per US Core guidelines.
   - This can be combined with the `category` parameter.
 
 - The `encounter` parameter
-  - This is required when `_id` or `patient` is not provided.
+  - This is required when `_id` or `patient` are not provided.
   - This cannot be combined with `category` or status.
 
 - The `category` parameter

--- a/content/millennium/r4/clinical/care-provision/care-team.md
+++ b/content/millennium/r4/clinical/care-provision/care-team.md
@@ -56,7 +56,7 @@ _Implementation Notes_
  `encounter`  | Required if `_id` or `patient` is not present       | [`reference`] | Who care team is for. Example: `encounter=98765`
  `category`   | N                                                   | [`token`]     | The scope of care team being searched for. Examples: `category=longitudinal`
  `status`     | N                                                   | [`token`]     | Indicates the status of the care team
-`_revinclude`      | No                                             | [`token`]     | Provenance resource entries to be returned as part of the bundle. Example:_revinclude=Provenance:target
+`_revinclude` | N                                                   | [`token`]     | Provenance resource entries to be returned as part of the bundle. Example:_revinclude=Provenance:target
 
 Notes:
 
@@ -75,11 +75,11 @@ Notes:
 * The `category` parameter
   * Only supports the codes longitudinal and encounter.
   * Can only be used with the `patient` parameter.
-  * The longitudinal and encounter codes are defined by the CareTeam category system
+  * The longitudinal and encounter codes are defined by the CareTeam category system.
 
-* The `_revinclude` parameter may be provided once with the value `Provenance:target`. Example: `_revinclude=Provenance:target`
-
-* The `_revinclude` parameter may be provided with the `_id/patient` parameter. Example: `_id=LIFETIME_PROVIDER-4169494-0-4105597-0-0-0&_revinclude=Provenance:target`
+* The `_revinclude` parameter 
+  * May be provided once with the value `Provenance:target`. Example: `_revinclude=Provenance:target`
+  * May be provided with the `_id/patient` parameter. Example: `_id=LIFETIME_PROVIDER-4169494-0-4105597-0-0-0&_revinclude=Provenance:target`
 
 * When `_revinclude` is provided in a request to the closed endpoint, the OAuth2 token must include the `user/Provenance.read` scope. Currently `patient/Provenance.read` is not supported and hence `_revinclude` cannot be utilised for patient persona.
 

--- a/content/millennium/r4/clinical/care-provision/care-team.md
+++ b/content/millennium/r4/clinical/care-provision/care-team.md
@@ -54,34 +54,34 @@ _Implementation Notes_
  `_id`        | Required if `patient` or `encounter` is not present | [`token`]     | The logical resource id associated with the resource.
  `patient`    | Required if `_id` or `encounter` is not present     | [`reference`] | Who care team is for. Example: `patient=12345`
  `encounter`  | Required if `_id` or `patient` is not present       | [`reference`] | Who care team is for. Example: `encounter=98765`
- `category`   | N                                                   | [`token`]     | The scope of care team being searched for. Examples: `category=longitudinal`
+ `category`   | N                                                   | [`token`]     | The scope of care team being searched for. Example: `category=longitudinal`
  `status`     | N                                                   | [`token`]     | Indicates the status of the care team
-`_revinclude` | N                                                   | [`token`]     | Provenance resource entries to be returned as part of the bundle. Example:_revinclude=Provenance:target
+`_revinclude` | N                                                   | [`token`]     | Provenance resource entries to be returned as part of the bundle. Example: `_revinclude=Provenance:target`
 
 Notes:
 
-* The `_id` parameter
-  * This is required if `patient` or `encounter` are not provided.
+- The `_id` parameter
+  - This is required if `patient` or `encounter` are not provided.
 
-* The `patient` parameter
-  * This is required when `_id` or `encounter` is not provided.
-  * This can be combined with `status` as per US Core guidelines.
-  * This can be combined with the `category` parameter.
+- The `patient` parameter
+  - This is required when `_id` or `encounter` is not provided.
+  - This can be combined with `status` as per US Core guidelines.
+  - This can be combined with the `category` parameter.
 
-* The `encounter` parameter
-  * This is required when `_id` or `patient` is not provided.
-  * This cannot be combined with `category` or status.
+- The `encounter` parameter
+  - This is required when `_id` or `patient` is not provided.
+  - This cannot be combined with `category` or status.
 
-* The `category` parameter
-  * Only supports the codes longitudinal and encounter.
-  * Can only be used with the `patient` parameter.
-  * The longitudinal and encounter codes are defined by the CareTeam category system.
+- The `category` parameter
+  - Only supports the codes `longitudinal` and `encounter`.
+  - Can only be used with the `patient` parameter.
+  - The `longitudinal` and `encounter` codes are defined by the CareTeam category system.
 
-* The `_revinclude` parameter 
-  * May be provided once with the value `Provenance:target`. Example: `_revinclude=Provenance:target`
-  * May be provided with the `_id/patient` parameter. Example: `_id=LIFETIME_PROVIDER-4169494-0-4105597-0-0-0&_revinclude=Provenance:target`
+- The `_revinclude` parameter 
+  - May be provided once with the value `Provenance:target`. Example: `_revinclude=Provenance:target`
+  - May be provided with the `_id` or `patient` parameter. Example: `_id=LIFETIME_PROVIDER-4169494-0-4105597-0-0-0&_revinclude=Provenance:target`
 
-* When `_revinclude` is provided in a request to the closed endpoint, the OAuth2 token must include the `user/Provenance.read` scope. Currently `patient/Provenance.read` is not supported and hence `_revinclude` cannot be utilised for patient persona.
+- When `_revinclude` is provided in a request to the closed endpoint, the OAuth2 token must include the `user/Provenance.read` scope. Currently `patient/Provenance.read` is not supported and hence `_revinclude` cannot be utilized for patient persona.
 
 ### Headers
 


### PR DESCRIPTION
Formatting updates to be consistent across parameter table and notes, including punctuation, and matching _revinclude to other parameters' styling.

Verified good links throughout document and have validated that example API calls behave as noted with examples.

Description
----

- Parameters table - Required flag for _revinclude changed to match others'
- Parameter notes - _revinclude modified structure to largely match other parameters' styling

PR Checklist
----

- Parameters table before _revinclude change:
![image](https://github.com/cerner/fhir.cerner.com/assets/144141792/0d83fc5f-d7cd-432c-8708-58e5445745a1)

- After:
![image](https://github.com/cerner/fhir.cerner.com/assets/144141792/1136e00c-095f-4ab1-927d-40fc012b710a)


*****************************

-  _revinclude section of parameter notes before change:
![image](https://github.com/cerner/fhir.cerner.com/assets/144141792/16bcf093-25a7-4e5a-a87c-a207c14e2673)

- After:
![image](https://github.com/cerner/fhir.cerner.com/assets/144141792/deb9b61c-c9b1-4d39-98d1-8f6adeedf527)
