### PR TITLE
Clarify date parameter's meaning

### DIFF
--- a/content/millennium/r4/clinical/summary/procedure.md
+++ b/content/millennium/r4/clinical/summary/procedure.md
@@ -57,7 +57,7 @@ Search for Procedures that meet supplied query parameters:
  `_id`             | This or `patient` or `subject` | [`token`]     | The logical resource id associated with the resource.
  `patient`         | This or `_id` or `subject`     | [`reference`] | Who the procedure is for. Example: `12345`
  `subject`         | This or `_id` or `patient`     | [`reference`] | Who the procedure is for. Example: `Patient/12345`
- `date`            | No                              | [`dateTime`]  | Date range into which the procedure falls. Example: `date=gt2015-09-24T12:00:00.000Z&date=le2020-07-15T16:00:00.000Z`
+ `date`            | No                             | [`dateTime`]  | Date range in which the procedure was performed. Example: `date=gt2015-09-24T12:00:00.000Z&date=le2020-07-15T16:00:00.000Z`
  `_revinclude`     | No                             | [`token`]     | Provenance resource entries to be returned as part of the bundle. Example:_revinclude=Provenance:target 
 
 Notes:


### PR DESCRIPTION
Description
----
Add some text to clarify that specifying a `date` parameter for a `Procedure.search` call filters based on the procedure's `performed` time, not its `lastUpdated` time.

Fixes #1005 

PR Checklist
----
- [X] Screenshot(s) of changes attached before changes merged.
<img width="817" alt="image" src="https://github.com/cerner/fhir.cerner.com/assets/1088051/39f0efe3-72d8-43bf-9e0d-6e4c36929eff">

- [ ] Screenshot(s) of changes attached after changes merged and published.

Not sure how to generate this screenshot. Happy to provide one if doing so is a hard requirement!