### PR TITLE
R4 Observation,DocumentReference Documentation Updates

### DIFF
--- a/lib/resources/example_json/r4_examples_document_reference.rb
+++ b/lib/resources/example_json/r4_examples_document_reference.rb
@@ -388,6 +388,124 @@ module Cerner
               }
             }
           }
+        },
+        {
+          'resourceType': 'DocumentReference',
+          'id': '201318478',
+          'meta': {
+            'versionId': '1',
+            'lastUpdated': '2022-12-08T08: 26: 36.000Z'
+          },
+          'text': {
+            'status': 'generated',
+            'div': '<div xmlns=\'http: //www.w3.org/1999/xhtml\'><p><b>Document Reference</b></p>'\
+            '<p><b>Patient Name</b>: GETEST, PatientOneHundredSixtySix</p>'\
+            '<p><b>Document Type</b>: Admission Note Physician</p>'\
+            '<p><b>Service Start Date</b>: Dec  7, 2022  6:51 A.M. UTC</p>'\
+            '<p><b>Service End Date</b>: Dec  7, 2022  6:51 A.M. UTC</p>'\
+            '<p><b>Document Status</b>: Final</p><p><b>Verifying Provider</b>: SYSTEM, SYSTEM Cerner</p></div>'
+          },
+          'identifier': [
+            {
+              'system': 'https: //fhir.cerner.com/ceuuid',
+              'value': 'CE87caf4b7-9397-4667-9897-702218017c9e-201318478-2022120808263700'
+            }
+          ],
+          'status': 'current',
+          'docStatus': 'final',
+          'type': {
+            'coding': [
+              {
+                'system': 'https: //fhir.cerner.com/ec2458f2-1e24-41c8-b71b-0e701af7583d/codeSet/72',
+                'code': '2820507',
+                'display': 'Admission Note Physician',
+                'userSelected': true
+              },
+              {
+                'system': 'http: //loinc.org',
+                'code': '83805-2',
+                'display': 'Physician Admission evaluation note',
+                'userSelected': false
+              }
+            ],
+            'text': 'Admission Note Physician'
+          },
+          'category': [
+            {
+              'coding': [
+                {
+                  'system': 'http://loinc.org',
+                  'code': 'LP29684-5',
+                  'display': 'Radiology',
+                  'userSelected': false
+                }
+              ],
+              'text': 'Radiology'
+            },
+            {
+              'coding': [
+                {
+                  'system': 'http://hl7.org/fhir/us/core/CodeSystem/us-core-documentreference-category',
+                  'code': 'clinical-note',
+                  'display': 'Clinical Note',
+                  'userSelected': false
+                }
+              ],
+              'text': 'Clinical Note'
+            }
+          ],
+          'subject': {
+            'reference': 'Patient/12769853',
+            'display': 'GETEST, PatientOneHundredSixtySix'
+          },
+          'date': '2022-12-08T08: 26: 36Z',
+          'author': [
+            {
+              'reference': 'Practitioner/1',
+              'display': 'SYSTEM, SYSTEM Cerner'
+            }
+          ],
+          'authenticator': {
+            'reference': 'Practitioner/1',
+            'display': 'SYSTEM, SYSTEM Cerner'
+          },
+          'content': [
+            {
+              'attachment': {
+                'contentType': 'application/xhtml+xml',
+                'url': 'https: //fhir-open.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/Binary/R-201318478',
+                'creation': '2022-12-07T06: 51: 22.000Z'
+              },
+              'format': {
+                'system': 'http: //ihe.net/fhir/ValueSet/IHE.FormatCode.codesystem',
+                'code': 'urn:ihe:iti:xds: 2017:mimeTypeSufficient',
+                'display': 'mimeType Sufficient'
+              }
+            },
+            {
+              'attachment': {
+                'contentType': 'application/xml',
+                'url': 'https: //fhir-open.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/Binary/XML-201318478',
+                'creation': '2022-12-07T06: 51: 22.000Z'
+              },
+              'format': {
+                'system': 'http: //ihe.net/fhir/ValueSet/IHE.FormatCode.codesystem',
+                'code': 'urn:ihe:iti:xds: 2017:mimeTypeSufficient',
+                'display': 'mimeType Sufficient'
+              }
+            }
+          ],
+          'context': {
+            'period': {
+              'start': '2022-12-07T06: 51: 22Z',
+              'end': '2022-12-07T06: 51: 22Z'
+            },
+            'related': [
+              {
+                'reference': 'DiagnosticReport/201318478'
+              }
+            ]
+          }
         }
       ]
     }.freeze

--- a/lib/resources/example_json/r4_examples_observation.rb
+++ b/lib/resources/example_json/r4_examples_observation.rb
@@ -494,6 +494,151 @@ module Cerner
             ]
           }
         },
+        {
+          'fullUrl': 'https://fhir-open.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/Observation/L-206310347',
+          'resource': {
+            'resourceType': 'Observation',
+            'id': 'L-206310347',
+            'meta': {
+              'versionId': '1',
+              'lastUpdated': '2023-10-30T17:04:50.000Z'
+            },
+            'text': {
+              'status': 'generated',
+              'div': '<div xmlns=\'http://www.w3.org/1999/xhtml\'><p><b>Observation</b></p>'\
+              '<p><b>Patient Id</b>: 12724066</p><p><b>Status</b>: Final</p>'\
+              '<p><b>Code</b>: Glucose Level POC</p><p><b>Result</b>: 181 mg/dL</p>'\
+              '<p><b>Effective Date</b>: Oct 30, 2023  5:04 P.M. UTC</p></div>'
+            },
+            'identifier': [
+              {
+                'system': 'https://fhir.cerner.com/ceuuid',
+                'value': 'CE87caf4b7-9397-4667-9897-702218017c9e-206310347-2023103017044900'
+              }
+            ],
+            'status': 'final',
+            'category': [
+              {
+                'extension': [
+                  {
+                    'valueCode': 'unknown',
+                    'url': 'http://hl7.org/fhir/StructureDefinition/data-absent-reason'
+                  }
+                ]
+              }
+            ],
+            'code': {
+              'coding': [
+                {
+                  'system': 'https://fhir.cerner.com/ec2458f2-1e24-41c8-b71b-0e701af7583d/codeSet/72',
+                  'code': '2552299163',
+                  'display': 'Glucose Level POC',
+                  'userSelected': true
+                },
+                {
+                  'system': 'http://loinc.org',
+                  'code': '2339-0',
+                  'display': 'Glucose [Mass/volume] in Blood',
+                  'userSelected': false
+                }
+              ],
+              'text': 'Glucose Level POC'
+            },
+            'subject': {
+              'reference': 'Patient/12724066'
+            },
+            'effectiveDateTime': '2023-10-30T17:04:46.000Z',
+            'valueQuantity': {
+              'value': 181,
+              'unit': 'mg/dL'
+            },
+            'note': [
+              {
+                'authorReference': {
+                  'reference': 'Practitioner/1'
+                },
+                'time': '2023-10-30T17:04:49Z',
+                'text': 'Time : 2023-10-30T17:04:49.464400Z\n'\
+                'Author : SYSTEM, SYSTEM Cerner\nComment : Filed via Accuhealth'
+              }
+            ]
+          },
+          'search': {
+            'mode': 'match'
+          }
+        },
+        {
+          'fullUrl': 'https://fhir-open.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/Observation/L-206310341',
+          'resource': {
+            'resourceType': 'Observation',
+            'id': 'L-206310341',
+            'meta': {
+              'versionId': '1',
+              'lastUpdated': '2023-10-30T17:04:45.000Z'
+            },
+            'text': {
+              'status': 'generated',
+              'div': '<div xmlns=\'http://www.w3.org/1999/xhtml\'><p><b>Observation</b></p>'\
+              '<p><b>Patient Id</b>: 12724066</p><p><b>Status</b>: Final</p>'\
+              '<p><b>Code</b>: Glucose Level POC</p><p><b>Result</b>: 189 mg/dL</p>'\
+              '<p><b>Effective Date</b>: Oct 30, 2023  5:04 P.M. UTC</p></div>'
+            },
+            'identifier': [
+              {
+                'system': 'https://fhir.cerner.com/ceuuid',
+                'value': 'CE87caf4b7-9397-4667-9897-702218017c9e-206310341-2023103017044500'
+              }
+            ],
+            'status': 'final',
+            'category': [
+              {
+                'extension': [
+                  {
+                    'valueCode': 'unknown',
+                    'url': 'http://hl7.org/fhir/StructureDefinition/data-absent-reason'
+                  }
+                ]
+              }
+            ],
+            'code': {
+              'coding': [
+                {
+                  'system': 'https://fhir.cerner.com/ec2458f2-1e24-41c8-b71b-0e701af7583d/codeSet/72',
+                  'code': '2552299163',
+                  'display': 'Glucose Level POC',
+                  'userSelected': true
+                },
+                {
+                  'system': 'http://loinc.org',
+                  'code': '2339-0',
+                  'display': 'Glucose [Mass/volume] in Blood',
+                  'userSelected': false
+                }
+              ],
+              'text': 'Glucose Level POC'
+            },
+            'subject': {
+              'reference': 'Patient/12724066'
+            },
+            'effectiveDateTime': '2023-10-30T17:04:42.000Z',
+            'valueQuantity': {
+              'value': 189
+            },
+            'note': [
+              {
+                'authorReference': {
+                  'reference': 'Practitioner/1'
+                },
+                'time': '2023-10-30T17:04:45Z',
+                'text': 'Time : 2023-10-30T17:04:45.459189Z\n'\
+                'Author : SYSTEM, SYSTEM Cerner\nComment : Filed via Accuhealth'
+              }
+            ]
+          },
+          'search': {
+            'mode': 'match'
+          }
+        },
         R4_OBSERVATION_ENTRY
       ]
     }.freeze


### PR DESCRIPTION
Description
----
Updated responses for R4 Observation and DocumentReference

PR Checklist
----
- [x] Screenshot(s) of changes attached before changes merged.
<img width="1792" alt="Screenshot 2024-01-09 at 4 06 32 PM" src="https://github.com/cerner/fhir.cerner.com/assets/62686590/4cd3d3cb-7418-4d4b-99ed-82fce4c38283">
<img width="1786" alt="Screenshot 2024-01-09 at 4 06 48 PM" src="https://github.com/cerner/fhir.cerner.com/assets/62686590/6146df59-7393-4432-9870-f3922062a94c">
<img width="1641" alt="Screenshot 2024-01-09 at 4 08 39 PM" src="https://github.com/cerner/fhir.cerner.com/assets/62686590/6c2b408e-bc2f-4e94-a5b5-65a38ede4875">


- [ ] Screenshot(s) of changes attached after changes merged and published.
